### PR TITLE
generate_intrinsic_spectra speed up

### DIFF
--- a/synthesizer/galaxy/particle.py
+++ b/synthesizer/galaxy/particle.py
@@ -41,22 +41,58 @@ class ParticleGalaxy(BaseGalaxy):
 
         # by default should update self.stars
 
-    def generate_intrinsic_spectra(self, grid, fesc=0.0, update=True, young=False, old=False, integrated=True):
+    def generate_intrinsic_spectra(self, grid, fesc=0.0, update=True,
+                                   young=False, old=False, integrated=True):
         """
-        Calculate spectra for all individual stellar particles
+        Calculate intrinsic spectra from stellar particles. The stellar SED
+        component is always created, the intrinsic SED component is only
+        computed if the "total" grid is available form the passed grid.
 
-        Warning: *much* slower than calculating integrated spectra,
-        as it does not use vectorisation.
+        Either an integrated spectra or per-stellar particle SED can be
+        requested. If an SED is requested then the integrated spectra is
+        automatically calculated anyway. 
+
+
+        Parameters
+        ----------
+        grid : obj (Grid)
+            The SPS grid object sampled by stellar particle to make the SED.
+        fesc : float
+            The Lyc escape fraction.
+        update : bool
+            Should we update the Galaxy's attributes?
+        young : bool
+            Are we masking for only young stars?
+        old : bool
+            Are we masking for only old stars?
+        integrated : bool
+            Are we only calculating the integrated spectrum?
 
         Returns
-        lum_array (array) spectrum for each particle, (N_part, wl)
-        fesc (array or float) LyC escape fraction
+        -------
+        grid.lam: array-like (float)
+            The wavelength array associated to grid (N_wavelength).
+        stellar_lum/stellar_lum_array : float/array-like (float)
+            If integrated == True: Integrated stellar spectrum.
+            If integrated == False: Stellar spectrum of each particle
+                                    (N_part, N_wavelength).
+        intrinsic_lum/intrinsic_lum_array :
+            If integrated == True: Integrated intrinsic spectrum.
+            If integrated == False: Intrinsic spectrum of each particle
+                                    (N_part, N_wavelength).
+        
+        Raises
+        ------
+        InconsistentArguments
+            Errors if both a young and old component is requested because these
+            directly contradict each other resulting in 0 particles in the mask.
         """
 
-        if young:
-            if old:
-                raise exceptions.InconsistentParameter(
-                    'Galaxy sub-component can not be simultaneously young and old')
+        # Get masks for which components we are handling, if a sub-component
+        # has not been requested it's necessarily all particles.
+        if young and old:
+            raise exceptions.InconsistentParameter(
+                'Galaxy sub-component can not be simultaneously young and old')
         if young:
             s = self.stars.log10ages <= np.log10(young)
         elif old:
@@ -64,27 +100,41 @@ class ParticleGalaxy(BaseGalaxy):
         else:
             s = np.ones(self.nparticles, dtype=bool)
 
-        # just calculate integrared spectra
+        # JCalculate integrared spectra
         if integrated:
 
-            weights_temp = self._calculate_weights(grid,
-                                                   self.stars.log10metallicities[s],
-                                                   self.stars.log10ages[s],
-                                                   self.stars.initial_masses[s])
+            # Calculate the grid weights for all stellar particles
+            weights_temp = self._calculate_weights(
+                grid, self.stars.log10metallicities[s],
+                self.stars.log10ages[s], self.stars.initial_masses[s]
+            )
 
-            stellar_lum = np.sum(grid.spectra['stellar'] * weights_temp[:, :, None],
-                                 axis=(0, 1))
+            # Get the mask for grid cells we need to sum
+            non0_inds = np.where(weights_temp > 0)
 
-            if 'total' in list(grid.spectra.keys()):  # perhaps should also check that fesc is not false
+            # Compute integrated stellar sed
+            stellar_lum = np.sum(
+                grid.spectra['stellar'][non0_inds[0], non0_inds[1], :]
+                * weights_temp[non0_inds[0], non0_inds[1], None], axis=0
+            )
 
-                intrinsic_lum = np.sum((1.-fesc) * grid.spectra['total'] * weights_temp[:, :, None],
-                                       axis=(0, 1))
+            # TODO: perhaps should also check that fesc is not false
+            if 'total' in list(grid.spectra.keys()):
+
+                # Compute the integrated intrinsic sed
+                intrinsic_lum = np.sum(
+                    (1.-fesc)
+                    * grid.spectra['total'][non0_inds[0], non0_inds[1], :]
+                    * weights_temp[non0_inds[0], non0_inds[1], None], axis=0
+                )
 
             else:
 
-                # --- if no nebular emission the intrinsic emission is simply the stellar emission
+                # If no nebular emission the intrinsic emission is simply
+                # the stellar emission
                 intrinsic_lum = stellar_lum
 
+            # Update the SED's attributes
             if update:
                 self.stellar_lum = stellar_lum
                 self.intrinsic_lum = intrinsic_lum
@@ -94,52 +144,78 @@ class ParticleGalaxy(BaseGalaxy):
 
             return grid.lam, stellar_lum, intrinsic_lum
 
-        # else calculate spectra for every particle individually. This is necessary for los calculation anyway.
+        # Else, calculate spectra for every particle individually. This is
+        # necessary for los calculation anyway.
         else:
 
+            # Initialise arrays to store SEDs
             stellar_lum_array = np.zeros((self.nparticles,
                                           grid.spectra['stellar'].shape[-1]))
 
             intrinsic_lum_array = np.zeros((self.nparticles,
                                             grid.spectra['stellar'].shape[-1]))
 
+            # Loop over all stellar particles
             for i, (mass, age, metal) in enumerate(zip(
                     self.stars.initial_masses[s],
                     self.stars.log10ages[s],
                     self.stars.log10metallicities[s])):
 
+                # Calculate the grid weights for this particle
                 weights_temp = self._calculate_weights(grid, metal, age, mass)
 
-                stellar_lum_array[i] = np.sum(grid.spectra['stellar'] * weights_temp[:, :, None],
-                                              axis=(0, 1))
+                 # Get the mask for grid cells we need to sum
+                non0_inds = np.where(weights_temp > 0)
 
-                if 'total' in list(grid.spectra.keys()):  # perhaps should also check that fesc is not false
+                # Compute the stellar sed for this particle
+                stellar_lum_array[i] = np.sum(
+                    grid.spectra['stellar'][non0_inds[0], non0_inds[1], :]
+                    * weights_temp[non0_inds[0], non0_inds[1], None], axis=0
+                )
 
-                    # --- I'm not sure this will actually work if fesc is an array
-                    intrinsic_lum_array[i] = np.sum((1.-fesc) * grid.spectra['total'] * weights_temp[:, :, None],
-                                                    axis=(0, 1))
+                # TODO: perhaps should also check that fesc is not false
+                if 'total' in list(grid.spectra.keys()):
+
+                    # Calculate the intrinsic sed for this particle
+                    # TODO: I'm not sure this will actually work if fesc is an array
+                    intrinsic_lum_array[i] = np.sum(
+                        (1.-fesc)
+                        * grid.spectra['total'][non0_inds[0], non0_inds[1], :]
+                        * weights_temp[non0_inds[0], non0_inds[1], None],
+                        axis=0
+                    )
 
                 else:
 
-                    # --- if no nebular emission the intrinsic emission is simply the stellar emission
+                    # If no nebular emission the intrinsic emission is simply
+                    # the stellar emission
                     intrinsic_lum_array[i] = stellar_lum_array[i]
 
+            # Update the SED's attributes
             if update:
 
-                # --- these quantities are actually repeated, in the context of an SED object below.
+                # Store the values of the SED in arrays local to Galaxy.
+                # (These quantities are actually repeated, in the context
+                # of an SED object below.)
                 self.stellar_lum_array = stellar_lum_array
                 self.intrinsic_lum_array = intrinsic_lum_array
-                # --- create integrated stellar SED
+                
+                # Compute the integrated SEDs
                 self.stellar_lum = np.sum(stellar_lum_array, axis=0)
-                # --- create integrated intrinsic SED
                 self.intrinsic_lum = np.sum(intrinsic_lum_array, axis=0)
 
-                # --- repititon of above, may want to consolidate
+                # Create the SED objects and store them in the dictionaries
+                # TODO: Repititon of above, may want to consolidate
                 self.spectra['stellar'] = Sed(grid.lam, self.stellar_lum)
-                self.spectra_array['stellar'] = Sed(grid.lam, self.stellar_lum_array)
+                self.spectra_array['stellar'] = Sed(
+                    grid.lam, self.stellar_lum_array
+                )
                 self.spectra['intrinsic'] = Sed(grid.lam, self.intrinsic_lum)
-                self.spectra_array['intrinsic'] = Sed(grid.lam, self.intrinsic_lum_array)
+                self.spectra_array['intrinsic'] = Sed(
+                    grid.lam, self.intrinsic_lum_array
+                )
 
+                # Store the wavelength array
                 self.lam = grid.lam
 
             return grid.lam, stellar_lum_array, intrinsic_lum_array


### PR DESCRIPTION
Implemented spectra creation speed up in Galaxy.generate_intrinsic_spectra where a mask is applied to the weights array to avoid spending time calculating 0xvalue which hogs time but contributes nothing to the sum. 

Also added Numpydoc doc strings and had a general clean up and comment of the function.