### PR TITLE
Fixing the application of a filter transmission curve in filter.apply…

### DIFF
--- a/synthesizer/imaging/images.py
+++ b/synthesizer/imaging/images.py
@@ -872,9 +872,14 @@ class ParticleImage(ParticleScene, Image):
         for f in self.filters:
 
             # Apply this filter to the IFU
-            self.imgs[f.filter_code] = f.apply_filter(
-                self.ifu, self.ifu_obj.sed.nu
-            )
+            if self.rest_frame:
+                self.imgs[f.filter_code] = f.apply_filter(
+                    self.ifu, self.ifu_obj.sed.nu
+                )
+            else:
+                self.imgs[f.filter_code] = f.apply_filter(
+                    self.ifu, self.ifu_obj.sed.nuz
+                )
 
         return self.imgs
 
@@ -916,9 +921,14 @@ class ParticleImage(ParticleScene, Image):
         for f in self.filters:
 
             # Apply this filter to the IFU
-            self.imgs[f.filter_code] = f.apply_filter(
-                self.ifu, self.ifu_obj.sed.nu
-            )
+            if self.rest_frame:
+                self.imgs[f.filter_code] = f.apply_filter(
+                    self.ifu, self.ifu_obj.sed.nu
+                )
+            else:
+                self.imgs[f.filter_code] = f.apply_filter(
+                    self.ifu, self.ifu_obj.sed.nuz
+                )
 
         return self.imgs
 


### PR DESCRIPTION
…_filter

Fixed the apply_filter method and simplified its use to general axis integration for both rest and observer frame bands. 

## Issue Type
<!-- ignore-task-list-start -->
- [x] Bug
- [N.A] Document
- [N.A] Enhancement
<!-- ignore-task-list-end -->

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
