### PR TITLE
Fix intrinsic save

### DIFF
--- a/synthesizer/galaxy/particle.py
+++ b/synthesizer/galaxy/particle.py
@@ -469,7 +469,15 @@ class ParticleGalaxy(BaseGalaxy):
         alpha_BC: float
             slope of the BC dust curve, -1.3 in MAGPHYS
         save_young_and_old: boolean
-            flag specifying whether to save young and old
+            flag specifying whether to save young and old spectra individually
+        sed_object: bool
+            flag whether to return an SED object
+        update: bool
+            flag for whether to update the `intrinsic` and `attenuated` spectra
+            inside the galaxy object `spectra` dictionary. These are the combined values
+            of young and old.
+        return_wavelength: bool
+            return wavelenght numpy array
 
         Returns
         -------
@@ -492,7 +500,8 @@ class ParticleGalaxy(BaseGalaxy):
             grid, update=False, old=1e7)
 
         # save combined intrinsic spectra 
-        self.spectra['intrinsic'] = intrinsic_sed_young + intrinsic_sed_old
+        if update:
+            self.spectra['intrinsic'] = intrinsic_sed_young + intrinsic_sed_old
 
         if save_young_and_old:
 

--- a/synthesizer/galaxy/particle.py
+++ b/synthesizer/galaxy/particle.py
@@ -491,6 +491,9 @@ class ParticleGalaxy(BaseGalaxy):
         intrinsic_sed_old = self.get_intrinsic_spectra(
             grid, update=False, old=1e7)
 
+        # save combined intrinsic spectra 
+        self.spectra['intrinsic'] = intrinsic_sed_young + intrinsic_sed_old
+
         if save_young_and_old:
 
             # if integrated:


### PR DESCRIPTION
Small fix to save intrinsic spectra when calculating dust attenuated

## Issue Type
<!-- ignore-task-list-start -->
- [ x ] Bug
<!-- ignore-task-list-end -->

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
