### PR TITLE
Cloudy improvements

### DIFF
--- a/examples/cloudy/run_cloudy.py
+++ b/examples/cloudy/run_cloudy.py
@@ -11,11 +11,11 @@ import numpy as np
 
 from synthesizer.abundances import Abundances
 from synthesizer.grid import Grid
-from synthesizer.cloudy import create_cloudy_input
+from synthesizer.cloudy import create_cloudy_input, ShapeCommands
 
 
 grid_dir = '/Users/sw376/Dropbox/Research/data/synthesizer/grids/'
-grid_dir = '/its/home/sw376/astrodata/synthesizer/grids/'
+# grid_dir = '/its/home/sw376/astrodata/synthesizer/grids/'
 
 
 default_params = {
@@ -25,33 +25,42 @@ default_params = {
     'ia' : 0, # 1 Myr
     'iZ' : 8, # Z = 0.01
 
-    # --- cloudy model
-    'cloudy_version' : 'c17.03',
-    'log10U' : -2,
-
     # --- abundance parameters,  these are used, alongside the total metallicity (Z), to define the abundance pattern
     'CO' : 0.0,
     'd2m' : 0.3,
     'alpha' : 0.0,
     'scaling' : None,
 
+    # --- cloudy model
+    'cloudy_version' : 'c17.03',
+
     # --- cloudy parameters
-    'log10radius': -2, # radius in log10 parsecs
+    'log10U': -2,
+    'log10radius': -2,  # radius in log10 parsecs, only important for spherical geometry
     'covering_factor': 1.0, # covering factor. Keep as 1 as it is more efficient to simply combine SEDs to get != 1.0 values
-    'stop_T': 4000, # K
+    'stop_T': 4000,  # K
     'stop_efrac': -2,
-    'T_floor': 100, # K
-    'log10n_H': 2, # Hydrogen density
+    'T_floor': 100,  # K
+    'log10n_H': 2.5,  # Hydrogen density
     'z': 0.,
     'CMB': False,
     'cosmic_rays': False,
-    'resolution': 1.0, # relative resolution
+    'grains': False,
+    'geometry': 'planeparallel',
+    'resolution': 1.0, # relative resolution the saved continuum spectra
+    'output_abundances': True, # output abundances
+    'output_cont': True, # output continuum
+    'output_lines': True, # output lines
     }
 
 
 params = {
     'resolution': 0.1, # relative resolution
 }
+
+
+
+
 
 
 model_name = '_'.join(['default']+[f'{k}:{v}' for k, v in params.items()])
@@ -66,7 +75,7 @@ for k, v in params.items():
 
 # --- define cloudy path
 cloudy_path = f'~/Dropbox/Research/software/cloudy/{params["cloudy_version"]}/source/cloudy.exe'
-cloudy_path = f'/its/home/sw376/flare/software/cloudy/{params["cloudy_version"]}/source/cloudy.exe'
+# cloudy_path = f'/its/home/sw376/flare/software/cloudy/{params["cloudy_version"]}/source/cloudy.exe'
 
 
 
@@ -83,12 +92,12 @@ abundances = Abundances(Z=Z, alpha=params['alpha'], CO=params['CO'], d2m=params[
 lam = grid.lam
 lnu = grid.spectra['stellar'][params['ia'], params['iZ']]
 
-create_cloudy_input(model_name, lam, lnu, abundances, output_dir = './data/', **params)
+# this returns the relevant shape commands, in this case for a tabulated SED
+shape_commands = ShapeCommands.table_sed(model_name, lam, lnu, output_dir = './data/')
+
+create_cloudy_input(model_name, shape_commands, abundances, output_dir = './data/', **params)
 
 # --- define output filename
-
-
-
 
 os.chdir('./data')
 os.system(f'{cloudy_path} -r {model_name}')

--- a/generate_grids/cloudy/make_cloudy_input_grid.py
+++ b/generate_grids/cloudy/make_cloudy_input_grid.py
@@ -8,7 +8,7 @@ import yaml
 
 from synthesizer.abundances import Abundances
 from synthesizer.grid import Grid
-from synthesizer.cloudy import create_cloudy_input
+from synthesizer.cloudy import create_cloudy_input, ShapeCommands
 
 from write_submission_script import (apollo_submission_script,
                                      cosma7_submission_script)
@@ -266,8 +266,15 @@ def make_cloudy_input_grid(output_dir, grid, cloudy_params):
 
             cloudy_params['log10U'] = float(log10U)
 
-            create_cloudy_input(model_name, lam, lnu, abundances,
-                                output_dir=output_dir, **cloudy_params)
+            # this returns the relevant shape commands, in this case for a tabulated SED
+            shape_commands = ShapeCommands.table_sed(model_name, lam, lnu, output_dir = './data/')
+
+            # create cloudy input file
+            create_cloudy_input(model_name, shape_commands, abundances, output_dir = output_dir, **cloudy_params)
+
+            # # old function left in for now for reference
+            # create_cloudy_input(model_name, lam, lnu, abundances,
+            #                     output_dir=output_dir, **cloudy_params)
 
             # write filename out
             with open(f"{output_dir}/input_names.txt", "a") as myfile:


### PR DESCRIPTION

This PR describes changes mostly to the function to create cloudy input scripts. What I've done is separate out the spectral shape definition to leave a more generic input creation function. The spectra shape definitions have been separated into a separate class (`ShapeCommands`). At the moment this class holds a single function for using tabulated SEDs but it will be expanded to include other possibilities, including a Blackbody and cloudy's in-built AGN model. This PR is needed to enable proper development of both those.

Like all the cloudy/grid generation this is currently poorly documented because it's in transition and rather niche.

## Issue Type
<!-- ignore-task-list-start -->
- [ ] Bug
- [ ] Document
- [x] Enhancement
<!-- ignore-task-list-end -->

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
