### PR TITLE
Included method to apply IGM to rest frame SED.

### DIFF
--- a/synthesizer/sed.py
+++ b/synthesizer/sed.py
@@ -235,6 +235,19 @@ class Sed:
         if igm:
             self._fnu *= igm.T(z, self.obslam)
 
+    def apply_igm_to_lnu(self, igm):
+        """
+        Apply an IGM transmission curve to the rest frame SED.
+        
+        Args:
+          igm:
+            IGM object from which the tranmission can be extracted. These can
+            be found in synthesizer.igm.
+        """
+
+        self._lnu *= igm.T(z, self.lam)
+        
+
     def get_broadband_fluxes(self, fc, verbose=True):  # broad band flux/nJy
         """
         Calculate broadband luminosities using a FilterCollection object


### PR DESCRIPTION
Addresses #155. There was no way to apply an IGM transmission curve to the rest frame SED. Now this may be a rare desire but better to include functionality to allow it. This has introduced a single method: `SED.apply_igm_to_lnu`. 

Note, I have adopted the Google docstring format for it. 

## Issue Type
<!-- ignore-task-list-start -->
- [x] Enhancement
<!-- ignore-task-list-end -->

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [N.A] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
