### PR TITLE
fix c extension paths

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,13 +96,13 @@ class BuildExt(build_ext):
 extensions = [
     Extension(path, sources=[source])
     for path, source in {
-        "synthesizer/extensions/csed":
+        "synthesizer.extensions.csed":
             "synthesizer/extensions/csed.c",
-        "synthesizer/extensions/weights":
+        "synthesizer.extensions.weights":
             "synthesizer/extensions/weights.c",
-        "synthesizer/imaging/extensions/sph_kernel_calc":
+        "synthesizer.imaging.extensions.sph_kernel_calc":
             "synthesizer/imaging/extensions/sph_kernel_calc.c",
-        "synthesizer/imaging/extensions/ckernel_functions":
+        "synthesizer.imaging.extensions.ckernel_functions":
             "synthesizer/imaging/extensions/ckernel_functions.c",
     }.items()
 


### PR DESCRIPTION
Bug in setup.py that rpevented extensions being installed with `pip`

## Issue Type
<!-- ignore-task-list-start -->
- [ x ] Bug
<!-- ignore-task-list-end -->

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
