### PR TITLE
Abundances improvements

### DIFF
--- a/examples/abundances.py
+++ b/examples/abundances.py
@@ -2,44 +2,49 @@
 Demonstrate the use of the abundances module
 """
 
-from synthesizer.abundances import Abundances, plot_abundance_pattern
+from synthesizer.abundances import Abundances, plot_abundance_pattern, plot_multiple_abundance_patterns
 
 
 # by default Abundances creates a solar abundance pattern with no depletion
 a1 = Abundances()
 print(a1)
-print(f'max d2m: {a1.get_max_d2m():.2f}')
 
 # you can access the logarithmic abundances (log10(X/H)) of an element like this:
-print(f"log10(O/H): {a1.a['O']:.2f}")
+print(f"log10(O/H): {a1.total['O']:.2f}")
 # or this
 print(f"log10(O/H): {a1['O']:.2f}")
 
 # we can change the metallicity
-a2 = Abundances(Z=0.01)
+a2 = Abundances(Z=0.01) 
 print(a2)
 
 
 # or alpha-enhancement
-a3 = Abundances(Z=0.01, alpha=0.6, CO=0.0)
+a3 = Abundances(Z=0.01, alpha=0.6)
 print(a3)
-# print(a3.metallicity())
 
-print(f"[O/Fe] = {a3.solar_relative_abundance('O', ref_element='Fe'):.2f}")  # [O/Fe]
+# we can print a relative solar abundance like this:
+print(f"[O/Fe] = {a3.solar_relative_abundance('O', ref_element='Fe'):.2f}")  
+# or like this:
+print(f"[O/Fe] = {a3['[O/Fe]']:.2f}")  
 
-plot_abundance_pattern([a2, a3], [r'Z=0.01', r'Z=0.01; \alpha = 0.6'],
-                       show=True, ylim=[-7., -3.])
+# there are also a helper functions for plotting one or more abundance patterns, here we plot two abundance patterns with different alpha abundances
+plot_multiple_abundance_patterns([a2, a3], labels=[r'Z=0.01', r'Z=0.01; \alpha = 0.6'], show=True, ylim=[-7., -3.])
 
 
 # or the dust-to-metal ratio
 a4 = Abundances(Z=0.01, d2m=0.3)
 print(a4)
 
-print(f"[O/Fe] = {a4.solar_relative_abundance('O', ref_element='Fe'):.2f}")  # [O/Fe]
-plot_abundance_pattern([a2, a4], [r'Z=0.01', rf'Z=0.01; d2m = {a4.d2m}'],
-                       show=True, ylim=[-7., -3.])
+# when d2m > 0.0 total, gas, and dust abundance patterns are provided e.g.
+
+print(f'log10(C/H) total: {a4.total["C"]:.2f}')
+print(f'log10(C/H) gas: {a4.gas["C"]:.2f}')
+print(f'log10(C/H) dust: {a4.dust["C"]:.2f}')
+
+# we can plot the abundance pattern of each component
+
+plot_abundance_pattern(a4, show=True, ylim=[-7., -3.], lines = ['total', 'gas', 'dust'])
 
 
-# asking for a dust-to-metal ratio above the maximum set by the default depletion pattern should throw an exception
-# a5 = Abundances(Z=0.01, d2m=0.7)
-# print(a5)
+

--- a/synthesizer/cloudy.py
+++ b/synthesizer/cloudy.py
@@ -171,7 +171,7 @@ def create_cloudy_input(model_name, shape_commands, abundances,
     # --- Define the chemical composition
     for ele in ['He'] + abundances.metals:
         cinput.append((f'element abundance {abundances.name[ele]} '
-                       f'{abundances.a[ele]} no grains\n'))
+                       f'{abundances.gas[ele]} no grains\n'))
 
     """
     add graphite and silicate grains


### PR DESCRIPTION
I have improved the clarity of `abundances.py` by calculating the total, gas, and dust abundance patterns. For no depletion gas == total and dust = 0.0. Cloudy should take gas by default since we specify grains later for self-consistency.

Example is updated as is `cloudy.py`.

No documentation yet, but this can be generated from the example. 

## Issue Type
<!-- ignore-task-list-start -->
- [ ] Bug
- [ ] Document
- [x] Enhancement
<!-- ignore-task-list-end -->

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
