### PR TITLE
A better error for when an integrated SED is passed to imaging

### DIFF
--- a/synthesizer/imaging/scene.py
+++ b/synthesizer/imaging/scene.py
@@ -382,7 +382,7 @@ class ParticleScene(Scene):
         """
 
         # Check what we've been given
-        self._check_part_args(resolution, stars, positions, centre, cosmo)
+        self._check_part_args(resolution, stars, positions, centre, cosmo, sed)
 
         # Initilise the parent class
         Scene.__init__(
@@ -434,7 +434,8 @@ class ParticleScene(Scene):
         # How many particle are there?
         self.npart = self.coords.shape[0]
 
-    def _check_part_args(self, resolution, stars, positions, centre, cosmo):
+    def _check_part_args(self, resolution, stars, positions, centre, cosmo,
+                         sed):
         """
         Ensures we have a valid combination of inputs.
         Parameters
@@ -459,6 +460,14 @@ class ParticleScene(Scene):
         # Get the spatial units
         spatial_unit = resolution.units
 
+        # Have we been given an integrated SED by accident?
+        if sed is not None:
+            if len(sed.lnu.shape) == 1:
+                raise exceptions.InconsistentArguments(
+                    "Particle Spectra are required for imaging, an integrated "
+                    "spectra has been passed."
+                )
+
         # Check the stars we have been given.
         if stars is not None:
 
@@ -482,6 +491,15 @@ class ParticleScene(Scene):
                     " can either be a single redshift for all stars or an "
                     "array of redshifts for each star."
                 )
+
+            # Need to ensure we have a per particle SED
+            if sed is not None:
+                if sed.lnu.shape[0] != stars.nparticles:
+                    raise exceptions.InconsistentArguments(
+                        "The shape of the SED array:", sed.lnu.shape,
+                        "does not agree with the number of stellar particles "
+                        "(%d)" % stars.nparticles
+                    )
 
         # Missing cosmology
         if spatial_unit.same_dimensions_as(arcsec) and cosmo is None:
@@ -514,6 +532,15 @@ class ParticleScene(Scene):
                         "The centre lies outside of the coordinate range. "
                         "Are they already centred?"
                     )
+
+        # Need to ensure we have a per particle SED
+        if sed is not None and positions is not None:
+            if sed.lnu.shape[0] != positions.shape[0]:
+                raise exceptions.InconsistentArguments(
+                    "The shape of the SED array:", sed.lnu.shape,
+                    "does not agree with the number of coordinates "
+                    "(%d)" % positions.shape[0]
+                )
 
     def _centre_coords(self):
         """


### PR DESCRIPTION
Implemented a catch for when an integrated SED is passed to image/IFU creation. 

Also included a catch for when the number of stars/positions doesn't agree with the SED. 

closes #211 

## Issue Type
<!-- ignore-task-list-start -->
- [x] Enhancement
<!-- ignore-task-list-end -->

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
