### PR TITLE
Removing multiplications by 0 in Parametric generate_lnu

### DIFF
--- a/examples/parametric/create_parametric_image.py
+++ b/examples/parametric/create_parametric_image.py
@@ -6,6 +6,7 @@ Example for generating a rest-frame physical scale image. This example will:
 - Make an image of the galaxy, including an RGB image.
 """
 import os
+import time
 import numpy as np
 
 import matplotlib.pyplot as plt
@@ -45,7 +46,9 @@ if __name__ == '__main__':
     galaxy = Galaxy(sfzh, morph=morph)
 
     # Generate stellar spectra
+    start = time.time()
     galaxy.get_spectra_stellar(grid)
+    print("Got spectra, took %.5f seconds" % (time.time() - start))
 
     # Get a UVJ filter set
     filters = UVJ(new_lam=grid.lam)
@@ -64,7 +67,9 @@ if __name__ == '__main__':
     )
 
     # Get the photometric images
+    start = time.time()
     img.get_imgs()
+    print("Got Images, took %.5f seconds" % (time.time() - start))
 
     # Make and plot an rgb image
     img.make_rgb_image(rgb_filters={"R" : 'J',

--- a/synthesizer/parametric/galaxy.py
+++ b/synthesizer/parametric/galaxy.py
@@ -138,7 +138,7 @@ class Galaxy(BaseGalaxy):
 
         Args:
             grid (object, Grid):
-                The SPS Grid object from which to extract SEDS. 
+                The SPS Grid object from which to extract spectra. 
 
         Returns:
             Log of the ionising photon luminosity over the grid dimensions

--- a/synthesizer/parametric/galaxy.py
+++ b/synthesizer/parametric/galaxy.py
@@ -138,7 +138,7 @@ class Galaxy(BaseGalaxy):
 
         Args:
             grid (object, Grid):
-                Grid object
+                The SPS Grid object from which to extract SEDS. 
 
         Returns:
             Log of the ionising photon luminosity over the grid dimensions
@@ -148,12 +148,37 @@ class Galaxy(BaseGalaxy):
 
     def generate_lnu(self, grid, spectra_name, old=False, young=False):
         """
-        calculate pure stellar emission
+        Calculate rest frame spectra from an SPS Grid.
+
+        This is a flexible base method which extracts the rest frame spectra of
+        this galaxy from the SPS grid based on the passed arguments. More
+        sophisticated types of spectra are produced by the get_spectra_*
+        methods on BaseGalaxy, which call this method.
+
+        Args:
+            grid (object, Grid):
+                The SPS Grid object from which to extract spectra.
+            spectra_name (str):
+                A string denoting the desired type of spectra. Must match a
+                key on the Grid.
+            old (bool/float):
+                Are we extracting only old stars? If so only SFZH bins with
+                log10(Ages) > old will be included in the spectra. Defaults to
+                False.
+            young (bool/float):
+                Are we extracting only young stars? If so only SFZH bins with
+                log10(Ages) <= young will be included in the spectra. Defaults
+                to False.
+
+        Returns:
+            The Galaxy's rest frame spectra in erg / s / Hz.
         """
 
+        # Ensure arguments make sense
         if old * young:
             raise ValueError("Cannot provide old and young stars together")
 
+        # MAke the mask for relevent SFZH bins
         if old:
             sfzh_mask = (self.sfzh.log10ages > old)
         elif young:


### PR DESCRIPTION
Closes #156.

 Introduces a mask for non-zero indices in SFZH. Removing these redundant calculations results in a 1/3 speed up, possibly more for a realistically large grid which would have more 0s to remove. 

Also improved the documentation of the function. 

I have confirmed the answer given by examples is unchanged by this change.

## Issue Type
<!-- ignore-task-list-start -->
- [x] Document
- [x] Enhancement
<!-- ignore-task-list-end -->

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
