### PR TITLE
Adds the ability to create a FilterCollection without specifying a wavelength array

### DIFF
--- a/synthesizer/filters.py
+++ b/synthesizer/filters.py
@@ -438,17 +438,18 @@ class FilterCollection:
             new_lam = np.arange(min_lam, max_lam + resolution, resolution)
 
             if verbose:
-                print("Wavelength array found: \n"
-                      + "    min=%.2e Angstrom\n" % min_lam
-                      + "    max=%.2e\n" % max_lam
-                      + "    size=%d" % new_lam.size)
+                print("Calcualted wavelength array: \n"
+                      + "min = %.2e Angstrom\n" % min_lam
+                      + "max = %.2e Angstrom\n" % max_lam
+                      + "FilterCollection.lam.size = %d" % new_lam.size)
 
         # Set the wavelength array
         self.lam = new_lam
 
         # Loop over filters unifying them onto this wavelength array
-        for f in self.filters:
-            self.filters[f]._interpolate_wavelength(self.lam)
+        for fcode in self.filters:
+            f = self.filters[fcode]
+            f.t = f._interpolate_wavelength(self.lam)
 
     def _transmission_curve_ax(self, ax):
         """


### PR DESCRIPTION
Following the Slack discussion, this PR implements `FilterCollection.resample_filters` which enables the resampling of filters on a wavelength array.  

This method is then called during initialisation if `new_lam=None` and finds a wavelength array that encompasses all included `Filter`s at the resolution of the highest resolution filter curve. Thus fixing the bug encountered when not passing a wavelength array.

## Issue Type
<!-- ignore-task-list-start -->
- [x] Bug
- [x] Document
- [x] Enhancement
<!-- ignore-task-list-end -->

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
