### PR TITLE
Introduced for l in lines: syntax

### DIFF
--- a/examples/parametric/generate_lines.py
+++ b/examples/parametric/generate_lines.py
@@ -54,19 +54,19 @@ if __name__ == '__main__':
     lines = galaxy.get_line_intrinsic(grid, line_ids)
     print('-'*50)
     print('INTRINSIC')
-    for line_id, line in lines.items():
+    for line in lines:
         print(line)
 
     # --- calculate attenuated line properties assuming uniform dust (should leave EW unchanged)
     lines = galaxy.get_line_screen(grid, line_ids, tauV=0.5)
     print('-'*50)
     print('SCREEN')
-    for line_id, line in lines.items():
+    for line in lines:
         print(line)
 
     # --- calculate attenuated line properties assuming different dust affecting stellar and nebular components
     lines = galaxy.get_line_attenuated(grid, line_ids, tauV_stellar=0.1, tauV_nebular=0.5)
     print('-'*50)
     print('ATTENUATED')
-    for line_id, line in lines.items():
+    for line in lines:
         print(line)

--- a/synthesizer/line.py
+++ b/synthesizer/line.py
@@ -183,6 +183,10 @@ class LineCollection:
 
         # these should be filtered to only show ones that are available for the availalbe line_ids
 
+        # Atrributes to enable looping
+        self._current_ind = 0
+        self.nlines = len(self.line_ids)
+
         self.lineratios = LineRatios()
 
         self.available_ratios = self.lineratios.available_ratios
@@ -215,6 +219,30 @@ class LineCollection:
         pstr += "-"*10
 
         return pstr
+
+    def __iter__(self):
+        """
+        Overload iteration to allow simple looping over Line objects,
+        combined with __next__ this enables for l in LineCollection syntax
+        """
+        return self
+
+    def __next__(self):
+        """
+        Overload iteration to allow simple looping over Line objects,
+        combined with __iter__ this enables for l in LineCollection syntax
+        """
+
+        # Check we haven't finished
+        if self._current_ind >= self.nlines:
+            self._current_ind = 0
+            raise StopIteration
+        else:
+            # Increment index
+            self._current_ind += 1
+
+            # Return the filter
+            return self.lines[self.line_ids[self._current_ind - 1]]
 
     def get_ratio_(self, ab):
         """


### PR DESCRIPTION
Closes #246.

Overloads the iteration methods on `LineCollection` to enable `for l in lines:` iteration syntax.

Note that lines.py needs a lot of work on the documentation side of things and docs in general need writing to describe line interactions. This is beyond the scope of this PR. 

## Issue Type
<!-- ignore-task-list-start -->
- [x] Enhancement
<!-- ignore-task-list-end -->

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [N.A] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
