### PR TITLE
Fixed Issue with calculate_ew absorption feature indices

### DIFF
--- a/synthesizer/sed.py
+++ b/synthesizer/sed.py
@@ -333,15 +333,15 @@ class Sed:
         flux = flux * (wavelength ** 2)
 
         # Define the wavelength range of the absorption feature
-        absorption_start = index[0]
-        absorption_end = index[1]
+        absorption_start = index[1]
+        absorption_end = index[2]
 
         # Define the wavelength ranges of the two sets of continuum
-        blue_start = index[2]
-        blue_end = index[3]
+        blue_start = index[3]
+        blue_end = index[4]
 
-        red_start = index[4]
-        red_end = index[5]
+        red_start = index[5]
+        red_end = index[6]
 
         # Compute the average continuum level
         continuum_indices = np.where((wavelength >= absorption_start) & (wavelength <= absorption_end))[0]


### PR DESCRIPTION
Due to the addition of absorption feature labels as the first column in 'uv_dict', all indices for the list 'index' required to be incremented by 1 (i.e., index[0] becomes index[1], etc...).

## Issue Type
<!-- ignore-task-list-start -->
- [x] Bug
<!-- ignore-task-list-end -->

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
