### PR TITLE
Grid spectra fixes

### DIFF
--- a/synthesizer/particle/galaxy.py
+++ b/synthesizer/particle/galaxy.py
@@ -191,7 +191,7 @@ class Galaxy(BaseGalaxy):
         # Set up the inputs to the C function.
         grid_props = [
             np.ascontiguousarray(grid.log10age, dtype=np.float64),
-            np.ascontiguousarray(grid.metallicity, dtype=np.float64)
+            np.ascontiguousarray(np.log10(grid.metallicity), dtype=np.float64)
         ]
         part_props = [
             np.ascontiguousarray(

--- a/synthesizer/particle/stars.py
+++ b/synthesizer/particle/stars.py
@@ -101,7 +101,7 @@ class Stars(Particles):
             initial_masses (array-like, float)
                 The intial stellar mass of each particle in Msun.
             ages (array-like, float)
-                The age of each stellar particle in Myrs.
+                The age of each stellar particle in yrs.
             metallicities (array-like, float)
                 The metallicity of each stellar particle.
             redshift (float)


### PR DESCRIPTION
Fixes three separate issues / bugs, of varying degrees of importance:
- fixes a bug in the `_prepare_sed_args` particle galaxy method, that meant grid metallicities were passed in linear, whilst particle metallicities were in log
- Fixes the load data method for IllustrisTNG to fix some unit issues, and filter out wind particles
- Fixes the Stars class docstring to give the correct units on particle ages (yr, not Myr)

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
