### PR TITLE
compile docs in workflow

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -1,0 +1,37 @@
+name: Synthesizer docs
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  if_merged:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sphinx Build
+        run: |
+          cd docs
+          sudo apt install pandoc
+          pip install -r requirements.txt
+          make clean
+          make html
+          cd ../
+      - name: Commit documentation changes
+        run: |
+          git clone https://github.com/flaresimulations/synthesizer.git --branch gh-pages --single-branch gh-pages
+          cp -r docs/build/html/* gh-pages/
+          cd gh-pages
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add .
+          git commit -m "Update documentation" -a || true
+          # The above command will fail if no changes were present, so we ignore
+          # the return code.
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          branch: gh-pages
+          directory: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}        

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -40,6 +40,7 @@ jobs:
     - name: Sphinx Build
       uses: ammaraskar/sphinx-action@0.4
       with:
+        pre-build-command: "pip install -r requirements && pip install -e ."
         docs-folder: "docs/"
     - name: Test with pytest
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,6 +35,7 @@ jobs:
       # uses: ammaraskar/sphinx-action@0.4
       run: |
         cd docs
+        apt install pandoc
         pip install -r requirements.txt
         make clean
         make html

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -37,6 +37,10 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude broken_examples
+    - name: Sphinx Build
+      uses: ammaraskar/sphinx-action@0.4
+      with:
+        docs-folder: "docs/"
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,16 +31,6 @@ jobs:
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install -e .
-    - name: Sphinx Build
-      # uses: ammaraskar/sphinx-action@0.4
-      run: |
-        cd docs
-        sudo apt install pandoc
-        pip install -r requirements.txt
-        make clean
-        make html
-      # with:
-      #   docs-folder: "docs/"
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -52,3 +42,10 @@ jobs:
         pytest
         # find examples/ -name "*.py" -exec pytest {} \;
         find docs/source/ -name "*.ipynb" -exec pytest --nbmake {} \;
+    - name: Sphinx Build
+      run: |
+        cd docs
+        sudo apt install pandoc
+        pip install -r requirements.txt
+        make clean
+        make html

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,18 +31,20 @@ jobs:
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install -e .
-        pip install -r docs/requirements.txt
+    - name: Sphinx Build
+      # uses: ammaraskar/sphinx-action@0.4
+      run: |
+        cd docs
+        make clean
+        make html
+      # with:
+      #   docs-folder: "docs/"
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude broken_examples
-    - name: Sphinx Build
-      uses: ammaraskar/sphinx-action@0.4
-      with:
-    
-        docs-folder: "docs/"
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,7 +31,7 @@ jobs:
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install -e .
-        pip install -f docs/requirements.txt
+        pip install -r docs/requirements.txt
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,6 +35,7 @@ jobs:
       # uses: ammaraskar/sphinx-action@0.4
       run: |
         cd docs
+        pip install -r requirements.txt
         make clean
         make html
       # with:

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,7 +35,7 @@ jobs:
       # uses: ammaraskar/sphinx-action@0.4
       run: |
         cd docs
-        apt install pandoc
+        sudo apt install pandoc
         pip install -r requirements.txt
         make clean
         make html

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,6 +31,7 @@ jobs:
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install -e .
+        pip install -f docs/requirements.txt
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
@@ -40,7 +41,7 @@ jobs:
     - name: Sphinx Build
       uses: ammaraskar/sphinx-action@0.4
       with:
-        pre-build-command: "pip install -r requirements && pip install -e ."
+    
         docs-folder: "docs/"
     - name: Test with pytest
       run: |

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,3 +7,4 @@ ipython
 sphinx_gallery
 pillow
 sphinx-toolbox
+nbsphinx

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,6 +18,7 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('../../synthesizer'))  # Source code dir relative to this file
 sys.path.insert(0, os.path.abspath('../../'))  # Source code dir relative to this file
+sys.path.insert(0, os.path.abspath('../'))
 sys.path.insert(0, os.path.abspath("."))
 
 extensions = [

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,8 +20,6 @@ sys.path.insert(0, os.path.abspath('../../synthesizer'))  # Source code dir rela
 sys.path.insert(0, os.path.abspath('../../'))  # Source code dir relative to this file
 sys.path.insert(0, os.path.abspath("."))
 
-import synthesizer
-
 extensions = [
 	"nbsphinx",
     'sphinx.ext.napoleon',

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,6 +20,8 @@ sys.path.insert(0, os.path.abspath('../../synthesizer'))  # Source code dir rela
 sys.path.insert(0, os.path.abspath('../../'))  # Source code dir relative to this file
 sys.path.insert(0, os.path.abspath("."))
 
+import synthesizer
+
 extensions = [
 	"nbsphinx",
     'sphinx.ext.napoleon',


### PR DESCRIPTION
Documentation updates 

- Compile docs as part of testing workflow, will fail if docs fail. This acts as a way of testing the examples directory, since these are run as part of the sphinx-gallery workflow
- Publishes compiled docs to github pages when a PR is merged to main

## Issue Type
- Enhancement

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
