### PR TITLE
Use galactic base class for unyts to avoid overflow errors

### DIFF
--- a/synthesizer/units.py
+++ b/synthesizer/units.py
@@ -59,11 +59,11 @@ default_units = {
     "smoothing_lengths": Mpc,
     "softening_length": Mpc,
     "velocities": km / s,
-    "masses": Msun,
-    "initial_masses": Msun,
-    "current_masses": Msun,
+    "masses": Msun.in_base('galactic'),
+    "initial_masses": Msun.in_base('galactic'),
+    "current_masses": Msun.in_base('galactic'),
     "ages": yr,
-    "accretion_rate": Msun / yr,
+    "accretion_rate": Msun.in_base('galactic') / yr,
     "bol_luminosity": erg / s,
     "bb_temperature": K,
 }
@@ -239,15 +239,15 @@ class Units(metaclass=UnitSingleton):
         self.velocities = km / s
 
         # Masses
-        self.masses = Msun
-        self.initial_masses = Msun  # initial mass of stellar particles
-        self.current_masses = Msun  # current mass of stellar particles
+        self.masses = Msun.in_base('galactic')
+        self.initial_masses = Msun.in_base('galactic')  # initial mass of stellar particles
+        self.current_masses = Msun.in_base('galactic')  # current mass of stellar particles
 
         # Time quantities
         self.ages = yr  # Stellar ages
 
         # Black holes quantities
-        self.accretion_rate = Msun / yr
+        self.accretion_rate = Msun.in_base('galactic') / yr
         self.bol_luminosity = erg / s
         self.bb_temperature = K
 


### PR DESCRIPTION
Uses the 'galactic'` base class (see [here](https://unyt.readthedocs.io/en/stable/usage.html#other-unit-systems)) for solar masses, to avoid overflow errors when handling 32 bit floats and masses > 1e10 Msun.

## Issue Type
- Bug

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
