### PR TITLE
Fix particle spectra methods

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -40,8 +40,7 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
-        # find examples/ -name "*.py" -exec pytest {} \;
-        find docs/source/ -name "*.ipynb" -exec pytest --nbmake {} \;
+        pytest --nbmake docs/source/*.ipynb docs/source/*/*.ipynb
     - name: Sphinx Build
       run: |
         cd docs

--- a/docs/source/imaging/particle_imaging.ipynb
+++ b/docs/source/imaging/particle_imaging.ipynb
@@ -220,7 +220,7 @@
     "spectra_start = time.time()\n",
     "\n",
     "# Calculate the stellar rest frame SEDs for all particles in erg / s / Hz\n",
-    "sed = galaxy.get_particle_spectra_stellar(grid)\n",
+    "sed = galaxy.get_particle_spectra_incident(grid)\n",
     "\n",
     "# Calculate the observed SED in nJy\n",
     "sed.get_fnu(cosmo, stars.redshift, igm=None)\n",

--- a/synthesizer/base_galaxy.py
+++ b/synthesizer/base_galaxy.py
@@ -227,7 +227,7 @@ class BaseGalaxy:
             grid, update=update, young=young, old=old, label=label
         )
 
-        # the emission which escapeds the gas
+        # the emission which escapes the gas
         if fesc > 0:
             escaped = Sed(grid.lam, fesc * incident._lnu)
 

--- a/synthesizer/particle/blackholes.py
+++ b/synthesizer/particle/blackholes.py
@@ -51,12 +51,15 @@ class BlackHoles(Particles):
     # Define the allowed attributes
     __slots__ = [
         "_masses",
+        "_coordinates",
+        "_velocities",
         "metallicities",
         "nparticles",
         "redshift",
         "_accretion_rate",
         "_bb_temperature",
         "_bol_luminosity",
+        "_softening_lengths",
         "nbh",
     ]
 

--- a/synthesizer/particle/galaxy.py
+++ b/synthesizer/particle/galaxy.py
@@ -102,7 +102,7 @@ class Galaxy(BaseGalaxy):
         """
         Calculate integrated stellar properties
         """
-        self.n_starparticles = self.stars.nparticles
+        self.n_starparticles = self.stars.nparticles  # TODO: why do we need this?
 
         # Define integrated properties of this galaxy
         if self.stars.current_masses is not None:
@@ -467,12 +467,9 @@ class Galaxy(BaseGalaxy):
 
         pass
 
-    def get_particle_spectra_stellar(self, grid, update=True):
+    def get_particle_spectra_incident(self, grid, update=True):
         """
-        Calculate intrinsic spectra for all *individual* stellar particles.
-        The stellar SED component is always created, the intrinsic SED
-        component is only computed if the "total" grid is available from
-        the passed grid.
+        Calculate incident spectra for all *individual* stellar particles.
 
         TODO: need to be able to apply masks to get young and old stars.
         # young=False,
@@ -516,13 +513,9 @@ class Galaxy(BaseGalaxy):
 
         return sed
 
-    def get_particle_spectra_intrinsic(self, grid, fesc=0.0, update=True):
+    def get_particle_spectra_reprocessed(self, grid, fesc=0.0, update=True):
         """
-        Calculate intrinsic spectra for all *individual* stellar particles.
-
-        [is this still true?] The stellar SED component is always created, the intrinsic SED
-        component is only computed if the "total" grid is available from
-        the passed grid.
+        Calculate reprocessed spectra for all *individual* stellar particles.
 
         TODO: need to be able to apply masks to get young and old stars.
         # young=False,
@@ -578,10 +571,6 @@ class Galaxy(BaseGalaxy):
         """
         Calculate attenuated spectra for all *individual* stellar
         particles according to a simple screen.
-
-        [is this still true?] The stellar SED component is always created,
-        the intrinsic SED component is only computed if the "total" grid
-        is available from the passed grid.
 
         TODO: need to be able to apply masks to get young and old stars.
         # young=False,

--- a/synthesizer/particle/galaxy.py
+++ b/synthesizer/particle/galaxy.py
@@ -102,7 +102,6 @@ class Galaxy(BaseGalaxy):
         """
         Calculate integrated stellar properties
         """
-        self.n_starparticles = self.stars.nparticles  # TODO: why do we need this?
 
         # Define integrated properties of this galaxy
         if self.stars.current_masses is not None:
@@ -112,7 +111,6 @@ class Galaxy(BaseGalaxy):
         """
         Calculate integrated gas properties
         """
-        self.n_gasparticles = self.gas.nparticles
 
         # Define integrated properties of this galaxy
         if self.gas.masses is not None:
@@ -455,7 +453,7 @@ class Galaxy(BaseGalaxy):
         elif old:
             s = self.stars.log10ages > np.log10(old)
         else:
-            s = np.ones(self.n_starparticles, dtype=bool)
+            s = np.ones(self.stars.nparticles, dtype=bool)
 
         return s
 

--- a/synthesizer/survey.py
+++ b/synthesizer/survey.py
@@ -441,10 +441,10 @@ class Survey:
         for gal in self.galaxies:
             # Are we getting a flux or rest frame?
             if spectra_type == "incident":
-                sed = gal.get_particle_spectra_stellar(grid)
+                sed = gal.get_particle_spectra_incident(grid)
                 gal.spectra_array[spectra_type] = sed
             elif spectra_type == "intrinsic":
-                sed = gal.get_particle_spectra_intrinsic(grid)
+                sed = gal.get_particle_spectra_reprocessed(grid)
                 gal.spectra_array[spectra_type] = sed
 
             # Get the flux


### PR DESCRIPTION
Fixes names of particle methods to be consistent with adopted grid naming scheme and the exiting integrated methods. 

Also the following minor fixes:
- fixes a bug in the workflow whereby pytests on doc notebooks would fail but wouldn't interrupt the workflow, as they were run individually
- adds some attributes to the particle/blackholes class that led to failures in one of the docs

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
