### PR TITLE
set gamma to zero for zero gas mass galaxies

### DIFF
--- a/synthesizer/particle/galaxy.py
+++ b/synthesizer/particle/galaxy.py
@@ -780,7 +780,10 @@ class Galaxy(BaseGalaxy):
             else:
                 stellar_mass = self.stellar_mass
 
-        gamma = (sf_gas_metallicity / Z14) * (sf_gas_mass / stellar_mass) * (1.0 / beta)
+        if sf_gas_mass == 0.:
+            gamma = 0.
+        else:
+            gamma = (sf_gas_metallicity / Z14) * (sf_gas_mass / stellar_mass) * (1.0 / beta)
 
         return gamma
 


### PR DESCRIPTION
Fix so that method returns zero rather than nan

## Issue Type
- Bug

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
