### PR TITLE
Better handling of grid file extension

### DIFF
--- a/synthesizer/grid.py
+++ b/synthesizer/grid.py
@@ -189,7 +189,7 @@ class Grid:
         if len(grid_name.split(".")) > 1:
             self.grid_ext = grid_name.split(".")[-1]
         else:
-            self.grid_ext = ".hdf5"
+            self.grid_ext = "hdf5"
 
         # Strip the extension off the name (harmless if no extension)
         self.grid_name = grid_name.replace(".hdf5", "").replace(".h5", "")


### PR DESCRIPTION
This PR closes #315. It does so by checking if a file extension has been handed to the Grid. If so it strips it from the name and stores it to be added to the full path. If an extension has not been passed the default ".hdf5" is assumed. This allows users to pass ".h5" extensions which was previously not possible.

There is a lot of missing documentation in `grid.py` but I have at least added a description of the attributes in the class doc string in this PR. **Please check I'm correct about what `self.parameters` is**.


## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
