### PR TITLE
Accounting for . in grid file paths

### DIFF
--- a/synthesizer/grid.py
+++ b/synthesizer/grid.py
@@ -176,7 +176,8 @@ class Grid:
         self.grid_dir = grid_dir
 
         # Have we been passed an extension?
-        if len(grid_name.split(".")) > 1:
+        if (grid_name.split(".")[-1] == "hdf5" 
+            or grid_name.split(".")[-1] == "h5"):
             self.grid_ext = grid_name.split(".")[-1]
         else:
             self.grid_ext = "hdf5"


### PR DESCRIPTION
Temporary fix for grid filenames including `.`s. The code for now checks if the last string split by "." is "hdf5" or "h5".

In the long run filenames should be modified to exclude fullstops. Adopting concatenation for version numbers and `p` to present points in real parameters.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
