### PR TITLE
Added checks for required properties

### DIFF
--- a/synthesizer/particle/galaxy.py
+++ b/synthesizer/particle/galaxy.py
@@ -349,6 +349,32 @@ class Galaxy(BaseGalaxy):
                 "dust!"
             )
 
+        # Ensure we actually have the properties needed
+        if self.stars.coordinates is None:
+            raise exceptions.InconsistentArguments(
+                "Star object is missing coordinates!"
+            )
+        if self.gas.coordinates is None:
+            raise exceptions.InconsistentArguments(
+                "Gas object is missing coordinates!"
+            )
+        if self.gas.smoothing_lengths is None:
+            raise exceptions.InconsistentArguments(
+                "Gas object is missing smoothing lengths!"
+            )
+        if self.gas.metallicities is None:
+            raise exceptions.InconsistentArguments(
+                "Gas object is missing metallicities!"
+            )
+        if self.gas.masses is None:
+            raise exceptions.InconsistentArguments(
+                "Gas object is missing masses!"
+            )
+        if self.gas.dust_to_metal_ratio is None:
+            raise exceptions.InconsistentArguments(
+                "Gas object is missing DTMs (dust_to_metal_ratio)!"
+            )
+            
         # Set up the kernel inputs to the C function.
         kernel = np.ascontiguousarray(kernel, dtype=np.float64)
         kdim = kernel.size


### PR DESCRIPTION
Introduced logic to error if any of the required properties are missing for LOS dust optical depth calculation.

Closes #296

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
