### PR TITLE
Removing test grid with Google drive Action

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -32,7 +32,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install -e .
         # Install google API for downloading test data
-        pip install --upgrade google-auth google-auth-oauthlib google-auth-httplib2 google-api-python-client
+        pip install --upgrade google-auth google-auth-oauthlib google-auth-httplib2 google-api-python-client gdown
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -31,12 +31,19 @@ jobs:
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install -e .
+        # Install google API for downloading test data
+        pip install --upgrade google-auth google-auth-oauthlib google-auth-httplib2 google-api-python-client
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude broken_examples
+    - name: Download test data
+      env:
+          GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
+      run: |
+        gdown https://drive.google.com/uc?id=1txY9PY-ejtRaMSZorpZSxGPsm6muvh9X --output tests/test_grid/test_grid.hdf5
     - name: Test with pytest
       run: |
         pytest

--- a/docs/source/imaging/parametric_imaging.ipynb
+++ b/docs/source/imaging/parametric_imaging.ipynb
@@ -62,7 +62,7 @@
     "# Define the grid\n",
     "grid_name = \"test_grid\"\n",
     "grid_dir = \"../../../tests/test_grid/\"\n",
-    "grid = Grid(grid_name, grid_dir=grid_dir)"
+    "grid = Grid(grid_name, grid_dir=grid_dir, new_lam=np.logspace(2, 5, 600))"
    ]
   },
   {

--- a/docs/source/imaging/particle_imaging.ipynb
+++ b/docs/source/imaging/particle_imaging.ipynb
@@ -64,7 +64,7 @@
     "# Define the grid\n",
     "grid_name = \"test_grid\"\n",
     "grid_dir = \"../../../tests/test_grid/\"\n",
-    "grid = Grid(grid_name, grid_dir=grid_dir)"
+    "grid = Grid(grid_name, grid_dir=grid_dir, new_lam=np.logspace(2, 5, 600))"
    ]
   },
   {

--- a/examples/particle/plot_create_survey_imgs.py
+++ b/examples/particle/plot_create_survey_imgs.py
@@ -40,7 +40,7 @@ start = time.time()
 # Define the grid
 grid_name = "test_grid"
 grid_dir = "../../tests/test_grid/"
-grid = Grid(grid_name, grid_dir=grid_dir)
+grid = Grid(grid_name, grid_dir=grid_dir, new_lam=np.logspace(2, 5, 600))
 
 # What redshift are we testing?
 redshift = 4

--- a/tests/get_test_grid.sh
+++ b/tests/get_test_grid.sh
@@ -1,2 +1,8 @@
+# This script will download the test grid from Google Drive.
+# The test grid is needed to run the scripts in examples and tests.
+#
+# The download uses gdown which interfaces with Google Drive to download the
+# file. Once downloaded the file can be found in tests/test_grid/ as defined by
+# the --output flag passed to gdown.
 pip install gdown
 gdown https://drive.google.com/uc?id=1txY9PY-ejtRaMSZorpZSxGPsm6muvh9X --output tests/test_grid/test_grid.hdf5

--- a/tests/get_test_grid.sh
+++ b/tests/get_test_grid.sh
@@ -1,0 +1,2 @@
+pip install gdown
+gdown https://drive.google.com/uc?id=1txY9PY-ejtRaMSZorpZSxGPsm6muvh9X --output tests/test_grid/test_grid.hdf5


### PR DESCRIPTION
This PR deletes the test grid and replaces it with a GitHub action that installs `gdown` (a pip installable interface to Google Drive) and downloads a bpass grid from [here](https://drive.google.com/file/d/1txY9PY-ejtRaMSZorpZSxGPsm6muvh9X/view?usp=sharing). 

This test grid is named `test_grid.hdf5` and stored in `tests/test_grid` meaning all examples still run without issue (modulo a couple of imaging ones that needed modifying to account for the extremely high wavelength resolution of the BPASS grid).  We can change the grid downloaded to any grid we want and the action will always rename it test_grid.hdf5.

This required adding a Google Drive API key to the repo's secrets. We can reuse this API key to store any data we want and download it in the action.

A user can also download the test grids via the `tests/get_test_grid.sh` script. This script will install `gdown` first (harmless if already installed) and will then download the test grid storing it at the expected location.

Closes #272 by using a real grid for the tests.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
