### PR TITLE
reduce compute of various examples and docs

### DIFF
--- a/docs/source/imaging/particle_imaging.ipynb
+++ b/docs/source/imaging/particle_imaging.ipynb
@@ -116,7 +116,7 @@
     "stars_start = time.time()\n",
     "\n",
     "# Define the number of stellar particles\n",
-    "n = 10000\n",
+    "n = 1000\n",
     "\n",
     "# Generate some random coordinates\n",
     "coords = CoordinateGenerator.generate_3D_gaussian(n)\n",

--- a/examples/particle/plot_compare_parametric_particle.py
+++ b/examples/particle/plot_compare_parametric_particle.py
@@ -54,7 +54,7 @@ plt.plot(
 # --------------------------------------------
 # CREATE PARTICLE SED
 
-for N in [1, 10, 100, 1000]:
+for N in [1, 10, 100]: # , 1000]:
     # --- create stars object
     stars = sample_sfhz(sfzh, N)
     # ensure that the total mass = 1 irrespective of N. This can be also acheived by setting the mass of the star particles in sample_sfhz but this will be easier most of the time.

--- a/examples/particle/plot_generate_coordinates.py
+++ b/examples/particle/plot_generate_coordinates.py
@@ -16,7 +16,7 @@ from synthesizer.particle.image import ImageGenerator
 # script_path = os.path.abspath(os.path.dirname(__file__))
 
 # --- create a set of particles assuming a 3D gaussian
-coords = CoordinateGenerator.generate_3D_gaussian(10000)
+coords = CoordinateGenerator.generate_3D_gaussian(1000)
 
 print(coords)
 print(coords.shape)


### PR DESCRIPTION
Reduce the particle number in a few examples to reduce the compute time, as this seems to be causing workflows to fall over in some instances

## Issue Type
- Bug

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
