### PR TITLE
357 parametric line att

### DIFF
--- a/docs/source/parametric/generate_lines.ipynb
+++ b/docs/source/parametric/generate_lines.ipynb
@@ -142,6 +142,23 @@
    "source": [
     "print(galaxy)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, lets get the attenuated line properties:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lines_att = galaxy.get_line_attenuated(grid, line_ids, fesc=0.0, tau_v_BC=0., tau_v_ISM=0.5)\n",
+    "print (lines_att)"
+   ]
   }
  ],
  "metadata": {

--- a/synthesizer/parametric/galaxy.py
+++ b/synthesizer/parametric/galaxy.py
@@ -336,8 +336,8 @@ class Galaxy(BaseGalaxy):
         fesc=0.0,
         tau_v_BC=None,
         tau_v_ISM=None,
-        dust_curve_nebular=PowerLaw(slope=-1.0),
-        dust_curve_stellar=PowerLaw(slope=-1.0),
+        dust_curve_BC=PowerLaw(slope=-1.0),
+        dust_curve_ISM=PowerLaw(slope=-1.0),
         update=True,
     ):
         """
@@ -356,16 +356,16 @@ class Galaxy(BaseGalaxy):
         fesc : float
             The Lyman continuum escape fraction, the fraction of
             ionising photons that entirely escape
-        tau_v_nebular : float
-            V-band optical depth of the nebular emission
-        tau_v_stellar : float
-            V-band optical depth of the stellar emission
-        dust_curve_nebular : obj (dust_curve)
+        tau_v_BC : float
+            V-band optical depth of the birth cloud
+        tau_v_ISM : float
+            V-band optical depth of the diffuse ISM
+        dust_curve_BC : obj (dust_curve)
             A dust_curve object specifying the dust curve
-            for the nebular emission
-        dust_curve_stellar : obj (dust_curve)
+            for the birth cloud
+        dust_curve_ISM : obj (dust_curve)
             A dust_curve object specifying the dust curve
-            for the stellar emission
+            for the diffuse ISM
 
         Returns
         -------
@@ -387,10 +387,10 @@ class Galaxy(BaseGalaxy):
 
         for line_id, intrinsic_line in intrinsic_lines.lines.items():
             # calculate attenuation
-            T_BC = dust_curve_nebular.get_transmission(
+            T_BC = dust_curve_BC.get_transmission(
                 tau_v_BC, intrinsic_line._wavelength
             )
-            T_ISM = dust_curve_stellar.get_transmission(
+            T_ISM = dust_curve_ISM.get_transmission(
                 tau_v_ISM, intrinsic_line._wavelength
             )
 

--- a/synthesizer/parametric/galaxy.py
+++ b/synthesizer/parametric/galaxy.py
@@ -426,7 +426,7 @@ class Galaxy(BaseGalaxy):
         line_ids,
         fesc=0.0,
         tau_v=None,
-        dust_curve=PowerLaw({"slope": -1.0}),
+        dust_curve=PowerLaw(slope=-1.0),
         update=True,
     ):
         """
@@ -460,8 +460,8 @@ class Galaxy(BaseGalaxy):
             grid,
             line_ids,
             fesc=fesc,
-            tau_v_nebular=tau_v,
-            tau_v_stellar=tau_v,
+            tau_v_BC=0,
+            tau_v_ISM=tau_v,
             dust_curve_nebular=dust_curve,
             dust_curve_stellar=dust_curve,
         )

--- a/synthesizer/parametric/galaxy.py
+++ b/synthesizer/parametric/galaxy.py
@@ -334,10 +334,10 @@ class Galaxy(BaseGalaxy):
         grid,
         line_ids,
         fesc=0.0,
-        tau_v_nebular=None,
-        tau_v_stellar=None,
-        dust_curve_nebular=PowerLaw({"slope": -1.0}),
-        dust_curve_stellar=PowerLaw({"slope": -1.0}),
+        tau_v_BC=None,
+        tau_v_ISM=None,
+        dust_curve_nebular=PowerLaw(slope=-1.0),
+        dust_curve_stellar=PowerLaw(slope=-1.0),
         update=True,
     ):
         """
@@ -385,17 +385,17 @@ class Galaxy(BaseGalaxy):
         # dictionary holding lines
         lines = {}
 
-        for line_id, intrinsic_line in intrinsic_lines.items():
+        for line_id, intrinsic_line in intrinsic_lines.lines.items():
             # calculate attenuation
-            T_nebular = dust_curve_nebular.attenuate(
-                tau_v_nebular, intrinsic_line._wavelength
+            T_BC = dust_curve_nebular.get_transmission(
+                tau_v_BC, intrinsic_line._wavelength
             )
-            T_stellar = dust_curve_stellar.attenuate(
-                tau_v_stellar, intrinsic_line._wavelength
+            T_ISM = dust_curve_stellar.get_transmission(
+                tau_v_ISM, intrinsic_line._wavelength
             )
 
-            luminosity = intrinsic_line._luminosity * T_nebular
-            continuum = intrinsic_line._continuum * T_stellar
+            luminosity = intrinsic_line._luminosity * T_BC * T_ISM 
+            continuum = intrinsic_line._continuum * T_ISM
 
             line = Line(
                 intrinsic_line.id, intrinsic_line._wavelength, luminosity, continuum


### PR DESCRIPTION
Bug in attenuated line generation for parametric galaxies. Correspondingly, have changed the nebular and stellar attenuation name to BC (birth cloud) and ISM. Also edited `get_line_screen` so that it did not add line attenuation twice.

Closes #357 

## Issue Type
- Bug
- Enhancement

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
