### PR TITLE
Reducing memory overhead in plot_composite_galaxy

### DIFF
--- a/docs/source/parametric/generate_composite_galaxy.ipynb
+++ b/docs/source/parametric/generate_composite_galaxy.ipynb
@@ -67,7 +67,7 @@
    "source": [
     "grid_dir = '../../../tests/test_grid'\n",
     "grid_name = 'test_grid'\n",
-    "grid = Grid(grid_name, grid_dir=grid_dir)"
+    "grid = Grid(grid_name, grid_dir=grid_dir, new_lam=np.logspace(3, 4.2, 1000))"
    ]
   },
   {
@@ -347,8 +347,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "synthesizer-env",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/examples/parametric/plot_composite_galaxy.py
+++ b/examples/parametric/plot_composite_galaxy.py
@@ -16,10 +16,8 @@ import numpy as np
 
 from synthesizer.grid import Grid
 from synthesizer.parametric.morphology import Sersic2D
-from synthesizer.parametric.sfzh import (SFH,
-                                         ZH,
-                                         generate_sfzh,
-                                         generate_instant_sfzh)
+from synthesizer.parametric.sfzh import SFH, ZH
+from synthesizer.parametric.sfzh import generate_sfzh, generate_instant_sfzh
 from synthesizer.parametric.galaxy import Galaxy
 from synthesizer.filters import UVJ
 
@@ -32,7 +30,7 @@ if __name__ == "__main__":
     # Define the grid
     grid_name = "test_grid"
     grid_dir = "../../tests/test_grid/"
-    grid = Grid(grid_name, grid_dir=grid_dir)
+    grid = Grid(grid_name, grid_dir=grid_dir, new_lam=np.logspace(3, 4.2, 1000))
 
     # Get a UVJ filter collection
     filters = UVJ()
@@ -89,7 +87,7 @@ if __name__ == "__main__":
     # Define bulge morphology
     morph = Sersic2D(r_eff_kpc=1.0 * kpc, n=4.0)
 
-    # Define the parameters of the star formation and metal enrichment 
+    # Define the parameters of the star formation and metal enrichment
     # histories
     stellar_mass = 2e10
     sfzh = generate_instant_sfzh(
@@ -133,19 +131,16 @@ if __name__ == "__main__":
     # Plot the spectra of both components
 
     sed = disk.spectra["incident"]
-    plt.plot(np.log10(sed.lam), np.log10(sed.lnu), lw=1, alpha=0.8, c="b", 
-             label="disk")
+    plt.plot(np.log10(sed.lam), np.log10(sed.lnu), lw=1, alpha=0.8, c="b", label="disk")
 
     sed = bulge.spectra["incident"]
     plt.plot(
-        np.log10(sed.lam), np.log10(sed.lnu), lw=1, alpha=0.8, c="r", 
-        label="bulge"
+        np.log10(sed.lam), np.log10(sed.lnu), lw=1, alpha=0.8, c="r", label="bulge"
     )
 
     sed = combined.spectra["incident"]
     plt.plot(
-        np.log10(sed.lam), np.log10(sed.lnu), lw=2, alpha=0.8, c="k", 
-        label="combined"
+        np.log10(sed.lam), np.log10(sed.lnu), lw=2, alpha=0.8, c="k", label="combined"
     )
 
     plt.xlim(3.0, 4.3)


### PR DESCRIPTION
Could Close #359 if the citied segfault is indeed to do with the memory available as I'm guessing. Loading the new test grid the images would be ~(50, 50, 80000). Overkill for this example. If this PR does not error then this is almost certainly the case and this PR does close the issue.

The fix is to pass a lower resolution wavelength grid at `Grid` instantiation. As in other imaging examples. Sadly this will always be a necessary evil for IFU creation. Although it is computationally more efficient to make the IFU and make images from it we may want to pivot and only make IFUs specifically when they are wanted. 

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
