### PR TITLE
Fixed SFZH plot alignment

### DIFF
--- a/synthesizer/parametric/sfzh.py
+++ b/synthesizer/parametric/sfzh.py
@@ -89,16 +89,19 @@ class BinnedSFZH:
         fig, ax, haxx, haxy = single_histxy()
 
         # this is technically incorrect because metallicity is not on a an actual grid.
-        ax.imshow(
-            self.sfzh.T,
-            origin="lower",
-            extent=[
-                *self.log10ages_lims,
-                self.log10metallicities[0],
-                self.log10metallicities[-1],
-            ],
-            cmap=cmr.sunburst,
-            aspect="auto",
+        # ax.imshow(
+        #     self.sfzh.T,
+        #     origin="lower",
+        #     extent=[
+        #         *self.log10ages_lims,
+        #         self.log10metallicities[0],
+        #         self.log10metallicities[-1],
+        #     ],
+        #     cmap=cmr.sunburst,
+        #     aspect="auto",
+        # )
+        ax.pcolormesh(
+            self.log10ages, self.log10metallicities, self.sfzh.T, cmap=cmr.sunburst
         )
 
         # --- add binned Z to right of the plot
@@ -128,12 +131,16 @@ class BinnedSFZH:
             haxx.plot(x, y / np.max(y))
 
         haxy.set_xlim([0.0, 1.2])
-        haxy.set_ylim(self.log10metallicities_lims)
+        haxy.set_ylim(*self.log10metallicities_lims)
         haxx.set_ylim([0.0, 1.2])
         haxx.set_xlim(self.log10ages_lims)
 
         ax.set_xlabel(mlabel("log_{10}(age/yr)"))
         ax.set_ylabel(mlabel("log_{10}Z"))
+
+        # Set the limits so all axes line up
+        ax.set_ylim(*self.log10metallicities_lims)
+        ax.set_xlim(*self.log10ages_lims)
 
         if show:
             plt.show()

--- a/synthesizer/parametric/sfzh.py
+++ b/synthesizer/parametric/sfzh.py
@@ -89,23 +89,11 @@ class BinnedSFZH:
         fig, ax, haxx, haxy = single_histxy()
 
         # this is technically incorrect because metallicity is not on a an actual grid.
-        # ax.imshow(
-        #     self.sfzh.T,
-        #     origin="lower",
-        #     extent=[
-        #         *self.log10ages_lims,
-        #         self.log10metallicities[0],
-        #         self.log10metallicities[-1],
-        #     ],
-        #     cmap=cmr.sunburst,
-        #     aspect="auto",
-        # )
         ax.pcolormesh(
             self.log10ages, self.log10metallicities, self.sfzh.T, cmap=cmr.sunburst
         )
 
         # --- add binned Z to right of the plot
-        # haxx.step(log10ages, sfh, where='mid', color='k')
         haxy.fill_betweenx(
             self.log10metallicities,
             self.Z / np.max(self.Z),
@@ -115,7 +103,6 @@ class BinnedSFZH:
         )
 
         # --- add binned SFH to top of the plot
-        # haxx.step(log10ages, sfh, where='mid', color='k')
         haxx.fill_between(
             self.log10ages,
             self.sfh / np.max(self.sfh),


### PR DESCRIPTION
This PR changes `imshow` to `pcolormesh` to ensure the alignment between SFZH grid plot and the 1D plots on the sides.

Closes #251 

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
