### PR TITLE
Improves the performance of spectra creation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ from distutils.errors import CompileError
 
 # We first need a numpy install to run setup.py
 from setuptools import dist
-dist.Distribution().fetch_build_eggs(['numpy==1.23.4'])
+
+dist.Distribution().fetch_build_eggs(["numpy==1.23.4"])
 
 import numpy as np
 
@@ -39,11 +40,19 @@ def has_flags(compiler, flags):
 
 # Build a build extension class that allows for finer selection of flags.
 
+
 class BuildExt(build_ext):
     # Never check these; they're always added.
     # Note that we don't support MSVC here.
-    compile_flags = {"unix": ["-std=c99", "-w", "-O3",
-                              "-ffast-math", "-I{:s}".format(np.get_include())]}
+    compile_flags = {
+        "unix": [
+            "-std=c99",
+            "-w",
+            "-O3",
+            "-ffast-math",
+            "-I{:s}".format(np.get_include()),
+        ]
+    }
 
     def build_extensions(self):
         ct = self.compiler.compiler_type
@@ -96,20 +105,13 @@ class BuildExt(build_ext):
 extensions = [
     Extension(path, sources=[source])
     for path, source in {
-        "synthesizer.extensions.csed":
-            "synthesizer/extensions/csed.c",
-        "synthesizer.extensions.weights":
-            "synthesizer/extensions/weights.c",
-        "synthesizer.extensions.los":
-            "synthesizer/extensions/los.c",
-        "synthesizer.imaging.extensions.sph_kernel_calc":
-            "synthesizer/imaging/extensions/sph_kernel_calc.c",
-        "synthesizer.imaging.extensions.ckernel_functions":
-            "synthesizer/imaging/extensions/ckernel_functions.c",
+        "synthesizer.extensions.integrated_spectra": "synthesizer/extensions/integrated_spectra.c",
+        "synthesizer.extensions.particle_spectra": "synthesizer/extensions/particle_spectra.c",
+        "synthesizer.extensions.weights": "synthesizer/extensions/weights.c",
+        "synthesizer.extensions.los": "synthesizer/extensions/los.c",
+        "synthesizer.imaging.extensions.sph_kernel_calc": "synthesizer/imaging/extensions/sph_kernel_calc.c",
+        "synthesizer.imaging.extensions.ckernel_functions": "synthesizer/imaging/extensions/ckernel_functions.c",
     }.items()
-
-    # Extension("synthesizer.weights", ["synthesizer/weights.pyx"], 
-    #     define_macros=[('CYTHON_TRACE', '1')])
 ]
 
 setup(
@@ -126,21 +128,21 @@ setup(
     install_requires=[  # Need to actually write the module to know this...
         "numpy>=1.14.5",
         "scipy>=1.7",
-
     ],
     # extras_require={"plotting": ["matplotlib>=2.2.0", "jupyter"]},
     # setup_requires=["pytest-runner", "flake8"],
     # tests_require=["pytest"],
     entry_points={
-        "console_scripts": ["init_bc03=grids.grid_bc03:main",
-                            "init_fsps=grids.grid_fsps:main"]
+        "console_scripts": [
+            "init_bc03=grids.grid_bc03:main",
+            "init_fsps=grids.grid_fsps:main",
+        ]
     },
     include_package_data=True,
     include_dirs=[np.get_include()],
     package_data={"synthesizer": ["*.c", "*.txt"]},
     cmdclass=dict(build_ext=BuildExt),
     ext_modules=extensions,
-
     # Need to populate these properly
     # license="GNU GPL v3",
     # classifiers=[

--- a/synthesizer/extensions/integrated_spectra.c
+++ b/synthesizer/extensions/integrated_spectra.c
@@ -1,14 +1,7 @@
 /******************************************************************************
- * Cython extension to calculate SED weights for star particles.
- * Calculates weights on an age / metallicity grid given the mass.
- * Args:
- *   z - 1 dimensional array of metallicity values (ascending)
- *   a - 1 dimensional array of age values (ascending)
- *   particle - 2 dimensional array of particle properties (N, 3)
- *   first column metallicity, second column age, third column mass
- * Returns:
- *   w - 2d array, dimensions (z, a), of weights to apply to SED array
-/*****************************************************************************/
+ * C extension to calculate integrated SEDs for a galaxy's star particles.
+ * Calculates weights on an arbitrary dimensional grid given the mass.
+ *****************************************************************************/
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -362,15 +355,15 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
     /* Get the weight. */
     const double weight = grid_weights[grid_ind];
 
+    /* Skip zero weight cells. */
+    if (weight <= 0)
+      continue;
+
     /* Get the spectra ind. */
     int unraveled_ind[ndim + 1];
     get_indices_from_flat(grid_ind, ndim, dims, unraveled_ind);
     unraveled_ind[ndim] = 0;
     int spectra_ind = get_flat_index(unraveled_ind, dims, ndim + 1);
-
-    /* Skip zero weight cells. */
-    if (weight <= 0)
-      continue;
 
     /* Add this grid cell's contribution to the spectra */
     for (int ilam = 0; ilam < nlam; ilam++) {

--- a/synthesizer/extensions/integrated_spectra.c
+++ b/synthesizer/extensions/integrated_spectra.c
@@ -58,23 +58,6 @@ int get_flat_index(const int *multi_index, const int *dims, const int ndims) {
 }
 
 /**
- * @brief Compute a flat grid index based on the grid dimensions for instances
- *        where the length of each dimension is always 2.
- *
- * @param indices: An array of N-dimensional indices.
- * @param dims: The length of each dimension.
- * @param ndim: The number of dimensions.
- */
-int get_flat_index_subarray(const int *multi_index, int ndims) {
-  int index = 0, stride = 1;
-  for (int i = ndims - 1; i >= 0; i--) {
-    index += stride * multi_index[i];
-    stride *= 2;
-  }
-  return index;
-}
-
-/**
  * @brief Calculates the mass fractions in each right most grid cell along
  *        each dimension.
  *
@@ -393,6 +376,8 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
 
   /* Clean up memory! */
   free(grid_weights);
+  free(part_props);
+  free(grid_props);
 
   /* Reconstruct the python array to return. */
   npy_intp np_dims[1] = {

--- a/synthesizer/extensions/integrated_spectra.c
+++ b/synthesizer/extensions/integrated_spectra.c
@@ -24,11 +24,12 @@
 #define bzero(b, len) (memset((b), '\0', (len)), (void)0)
 
 /**
- * @brief Compute a flat grid index based on the grid dimensions.
+ * @brief Compute an ndimensional index from a flat index.
  *
- * @param indices: An array of N-dimensional indices.
- * @param dims: The length of each dimension.
- * @param ndim: The number of dimensions.
+ * @param flat_ind: The flattened index to unravel.
+ * @param ndim: The number of dimensions for the unraveled index.
+ * @param dims: The size of each dimension.
+ * @param indices: The output N-dimensional indices.
  */
 void get_indices_from_flat(int flat_ind, int ndim, const int *dims,
                            int *indices) {
@@ -43,7 +44,7 @@ void get_indices_from_flat(int flat_ind, int ndim, const int *dims,
 /**
  * @brief Compute a flat grid index based on the grid dimensions.
  *
- * @param indices: An array of N-dimensional indices.
+ * @param multi_index: An array of N-dimensional indices.
  * @param dims: The length of each dimension.
  * @param ndim: The number of dimensions.
  */
@@ -61,12 +62,14 @@ int get_flat_index(const int *multi_index, const int *dims, const int ndims) {
  * @brief Calculates the mass fractions in each right most grid cell along
  *        each dimension.
  *
- * @param grid_tuple: The tuple contain each array of grid properties.
- * @param part_tuple: The tuple containing each array of particle properties.
+ * @param grid_props: An array of the properties along each grid axis.
+ * @param part_props: An array of the particle properties, in the same property
+ *                    order as grid props.
  * @param p: Index of the current particle.
  * @param ndim: The number of grid dimensions.
  * @param dims: The length of each grid dimension.
- * @param indices: The array for storing N-dimensional grid indicies.
+ * @param npart: The number of particles in total.
+ * @param frac_indices: The array for storing N-dimensional grid indicies.
  * @param fracs: The array for storing the mass fractions. NOTE: The left most
  *               grid cell's mass fraction is simply (1 - frac[dim])
  */
@@ -138,17 +141,20 @@ void frac_loop(const double *grid_props, const double *part_props, int p,
 /**
  * @brief This calculates the grid weights in each grid cell.
  *
- * To do this for an N-dimensional array this is done recursively.
+ * To do this for an N-dimensional array this is done recursively one dimension
+ * at a time.
  *
  * @param mass: The mass of the current particle.
- * @param part_tuple: The tuple containing each array of particle properties.
- * @param p: Index of the current particle.
- * @param dim: The current dimension in the recursion.
- * @param ndim: The number of grid dimensions.
- * @param dims: The length of each grid dimension.
- * @param indices: The array for storing N-dimensional grid indicies.
+ * @param sub_indices: The indices in the 2**ndim subset of grid points being
+ *                     computed in the current recursion (entries are 0 or 1).
+ * @param frac_indices: The array for storing N-dimensional grid indicies.
+ * @param low_indices: The index of the bottom corner grid point.
+ * @param weights: The weight of each grid point.
  * @param fracs: The array for storing the mass fractions. NOTE: The left most
  *               grid cell's mass fraction is simply (1 - frac[dim])
+ * @param dim: The current dimension in the recursion.
+ * @param dims: The length of each grid dimension.
+ * @param ndim: The number of grid dimensions.
  */
 void recursive_weight_loop(const double mass, short int *sub_indices,
                            int *frac_indices, int *low_indices, double *weights,
@@ -207,16 +213,16 @@ void recursive_weight_loop(const double mass, short int *sub_indices,
 /**
  * @brief Computes an integrated SED for a collection of particles.
  *
- * @param np_stellar_spectra:
- * @param np_total_spectra:
- * @param grid_tuple:
- * @param part_tuple:
- * @param part_mass:
- * @param fesc:
- * @param len_tuple:
- * @param grid_dim:
- * @param npart:
- * @param nlam:
+ * @param np_grid_spectra: The SPS spectra array.
+ * @param grid_tuple: The tuple containing arrays of grid axis properties.
+ * @param part_tuple: The tuple of particle property arrays (in the same order
+ *                    as grid_tuple).
+ * @param np_part_mass: The particle mass array.
+ * @param fesc: The escape fraction.
+ * @param np_ndims: The size of each grid axis.
+ * @param ndim: The number of grid axes.
+ * @param npart: The number of particles.
+ * @param nlam: The number of wavelength elements.
  */
 PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
 

--- a/synthesizer/extensions/integrated_spectra.c
+++ b/synthesizer/extensions/integrated_spectra.c
@@ -52,6 +52,37 @@ int get_flat_index(const int *multi_index, const int *dims, const int ndims) {
 }
 
 /**
+ * @brief Performs a binary search for the index of an array corresponding to
+ * a value.
+ *
+ * @param low: The initial low index (probably beginning of array).
+ * @param high: The initial high index (probably size of array).
+ * @param arr: The array to search in.
+ * @param val: The value to search for.
+ */
+int binary_search(int low, int high, const double *arr, const double val) {
+
+  /* While we don't have a pair of adjacent indices. */
+  int diff = high - low;
+  while (diff > 1) {
+
+    /* Define the midpoint. */
+    int mid = low + floor(diff / 2);
+
+    /* Where is the midpoint relative to the value? */
+    if (arr[mid] < val) {
+      low = mid;
+    } else {
+      high = mid;
+    }
+
+    /* Compute the new range. */
+    diff = high - low;
+  }
+  return low;
+}
+
+/**
  * @brief Calculates the mass fractions in each right most grid cell along
  *        each dimension.
  *
@@ -97,23 +128,9 @@ void frac_loop(const double **grid_props, const double **part_props, int p,
       fracs[dim] = 0;
     } else {
 
-      /* While we don't have a pair of adjacent indices. */
-      int diff = high - low;
-      while (diff > 1) {
-
-        /* Define the midpoint. */
-        int mid = low + floor(diff / 2);
-
-        /* Where is the midpoint relative to the value? */
-        if (grid_prop[mid] < part_val) {
-          low = mid;
-        } else {
-          high = mid;
-        }
-
-        /* Compute the new range. */
-        diff = high - low;
-      }
+      /* Find the grid index corresponding to this particle property. */
+      low = binary_search(low, high, grid_prop, part_val);
+      high = low + 1;
 
       /* Calculate the fraction. Note, this represents the mass fraction in
        * the high cell. */

--- a/synthesizer/extensions/integrated_spectra.c
+++ b/synthesizer/extensions/integrated_spectra.c
@@ -1,27 +1,44 @@
 /******************************************************************************
- * Cython extension to calculate SED weights for star particles. 
+ * Cython extension to calculate SED weights for star particles.
  * Calculates weights on an age / metallicity grid given the mass.
- * Args: 
+ * Args:
  *   z - 1 dimensional array of metallicity values (ascending)
- *   a - 1 dimensional array of age values (ascending) 
- *   particle - 2 dimensional array of particle properties (N, 3) 
- *   first column metallicity, second column age, third column mass 
- * Returns: 
- *   w - 2d array, dimensions (z, a), of weights to apply to SED array 
+ *   a - 1 dimensional array of age values (ascending)
+ *   particle - 2 dimensional array of particle properties (N, 3)
+ *   first column metallicity, second column age, third column mass
+ * Returns:
+ *   w - 2d array, dimensions (z, a), of weights to apply to SED array
 /*****************************************************************************/
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <math.h>
 
 #include <Python.h>
 
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
-#include <numpy/ndarraytypes.h>
 #include <numpy/ndarrayobject.h>
+#include <numpy/ndarraytypes.h>
 
 /* Define a macro to handle that bzero is non-standard. */
-#define bzero(b,len) (memset((b), '\0', (len)), (void) 0)
+#define bzero(b, len) (memset((b), '\0', (len)), (void)0)
+
+/**
+ * @brief Compute a flat grid index based on the grid dimensions.
+ *
+ * @param indices: An array of N-dimensional indices.
+ * @param dims: The length of each dimension.
+ * @param ndim: The number of dimensions.
+ */
+void get_indices_from_flat(int flat_ind, int ndim, const int *dims,
+                           int *indices) {
+
+  /* Loop over indices calculating each one. */
+  for (int i = 0; i < ndim; i++) {
+    indices[i] = flat_ind % dims[i];
+    flat_ind /= dims[i];
+  }
+}
 
 /**
  * @brief Compute a flat grid index based on the grid dimensions.
@@ -31,13 +48,13 @@
  * @param ndim: The number of dimensions.
  */
 int get_flat_index(const int *multi_index, const int *dims, const int ndims) {
-    int index = 0, stride = 1;
-    for (int i = ndims - 1; i >= 0; i--) {
-        index += stride * multi_index[i];
-        stride *= dims[i];
-    }
-    
-    return index;
+  int index = 0, stride = 1;
+  for (int i = ndims - 1; i >= 0; i--) {
+    index += stride * multi_index[i];
+    stride *= dims[i];
+  }
+
+  return index;
 }
 
 /**
@@ -49,12 +66,12 @@ int get_flat_index(const int *multi_index, const int *dims, const int ndims) {
  * @param ndim: The number of dimensions.
  */
 int get_flat_index_subarray(const int *multi_index, int ndims) {
-    int index = 0, stride = 1;
-    for (int i = ndims - 1; i >= 0; i--) {
-        index += stride * multi_index[i];
-        stride *= 2;
-    }
-    return index;
+  int index = 0, stride = 1;
+  for (int i = ndims - 1; i >= 0; i--) {
+    index += stride * multi_index[i];
+    stride *= 2;
+  }
+  return index;
 }
 
 /**
@@ -70,13 +87,13 @@ int get_flat_index_subarray(const int *multi_index, int ndims) {
  * @param fracs: The array for storing the mass fractions. NOTE: The left most
  *               grid cell's mass fraction is simply (1 - frac[dim])
  */
-void frac_loop(const double *grid_props, const double *part_props,
-               int p, const int ndim, const int *dims, const int npart,
+void frac_loop(const double *grid_props, const double *part_props, int p,
+               const int ndim, const int *dims, const int npart,
                int *frac_indices, double *fracs) {
 
   /* Loop over dimensions. */
   for (int dim = 0; dim < ndim; dim++) {
-    
+
     /* Get the grid and particle start indices for this property. */
     int grid_start = 0;
     int part_start = 0;
@@ -105,34 +122,33 @@ void frac_loop(const double *grid_props, const double *part_props,
       low = grid_start + dims[dim];
       fracs[dim] = 0;
     } else {
-      
+
       /* While we don't have a pair of adjacent indices. */
       int diff = high - low;
       while (diff > 1) {
-        
+
         /* Define the midpoint. */
         int mid = low + floor(diff / 2);
-        
+
         /* Where is the midpoint relative to the value? */
         if (grid_props[mid] < part_val) {
           low = mid;
         } else {
-          high = mid; 
+          high = mid;
         }
 
         /* Compute the new range. */
         diff = high - low;
       }
-      
+
       /* Calculate the fraction. Note, this represents the mass fraction in
        * the high cell. */
       fracs[dim] =
-        (part_val - grid_props[low]) / (grid_props[high] - grid_props[low]);
+          (part_val - grid_props[low]) / (grid_props[high] - grid_props[low]);
     }
 
     /* Set these indices. */
     frac_indices[dim] = low - grid_start;
-    
   }
 }
 
@@ -151,12 +167,10 @@ void frac_loop(const double *grid_props, const double *part_props,
  * @param fracs: The array for storing the mass fractions. NOTE: The left most
  *               grid cell's mass fraction is simply (1 - frac[dim])
  */
-void recursive_weight_loop(const double mass, int *sub_indices,
+void recursive_weight_loop(const double mass, short *sub_indices,
                            int *frac_indices, int *low_indices,
-                           int *weight_indices,
-                           double *weights, double *fracs,
-                           int dim, const int *dims,
-                           const int ndim) {
+                           int *weight_indices, double *weights, double *fracs,
+                           int dim, const int *dims, const int ndim) {
 
   /* Are we done yet? */
   if (dim >= ndim) {
@@ -165,12 +179,13 @@ void recursive_weight_loop(const double mass, int *sub_indices,
     const int weight_ind = get_flat_index_subarray(sub_indices, ndim);
 
     /* Get the flattened index into the grid array. */
-    weight_indices[weight_ind] = get_flat_index(frac_indices, dims, ndim + 1);
+    weight_indices[weight_ind] = get_flat_index(frac_indices, dims, ndim);
 
     /* Check whether we need a weight in this cell. */
     for (int i = 0; i < ndim; i++) {
       if ((sub_indices[i] == 1 && fracs[i] == 0 && frac_indices[i] == 0) ||
-          (sub_indices[i] == 1 && fracs[i] == 0 && frac_indices[i] == dims[i])) {
+          (sub_indices[i] == 1 && fracs[i] == 0 &&
+           frac_indices[i] == dims[i])) {
         weights[weight_ind] = 0;
         return;
       }
@@ -186,8 +201,7 @@ void recursive_weight_loop(const double mass, int *sub_indices,
         weights[weight_ind] *= (1 - fracs[i]);
       }
     }
-    
-    
+
     /* We're done! */
     return;
   }
@@ -200,7 +214,7 @@ void recursive_weight_loop(const double mass, int *sub_indices,
 
     /* Where are we in the grid array? */
     frac_indices[dim] = low_indices[dim] + i;
-    
+
     /* Recurse... */
     recursive_weight_loop(mass, sub_indices, frac_indices, low_indices,
                           weight_indices, weights, fracs, dim + 1, dims, ndim);
@@ -230,15 +244,18 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
   const PyArrayObject *np_grid_spectra;
   const PyArrayObject *np_part_mass, *np_ndims;
 
-  if(!PyArg_ParseTuple(args, "OOOOdOiii",
-                       &np_grid_spectra, &grid_tuple, &part_tuple,
-                       &np_part_mass, &fesc, &np_ndims, &ndim, &npart, &nlam))
+  if (!PyArg_ParseTuple(args, "OOOOdOiii", &np_grid_spectra, &grid_tuple,
+                        &part_tuple, &np_part_mass, &fesc, &np_ndims, &ndim,
+                        &npart, &nlam))
     return NULL;
 
   /* Quick check to make sure our inputs are valid. */
-  if (ndim == 0) return NULL;
-  if (npart == 0) return NULL;
-  if (nlam == 0) return NULL;
+  if (ndim == 0)
+    return NULL;
+  if (npart == 0)
+    return NULL;
+  if (nlam == 0)
+    return NULL;
 
   /* Extract a pointer to the spectra grids */
   const double *grid_spectra = PyArray_DATA(np_grid_spectra);
@@ -262,25 +279,32 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
   bzero(weights, nweights * sizeof(double));
 
   /* Allocate a single array for grid properties*/
+  /* NOTE: ndim by definition excludes the wavelength axis. */
   int nprops = 0;
-  for (int dim = 0; dim < ndim; dim++) nprops += dims[dim];
+  for (int dim = 0; dim < ndim; dim++)
+    nprops += dims[dim];
   double *grid_props = malloc(nprops * sizeof(double));
 
-  /* Get the grid size. */
-  int grid_size = nlam;
+  /* How many grid elements are there? (excluding wavelength axis)*/
+  int grid_size = 1;
   for (int dim = 0; dim < ndim; dim++)
     grid_size *= dims[dim];
 
+  /* Allocate an array to hold the grid weights. */
+  double *grid_weights = malloc(grid_size * sizeof(double));
+  bzero(grid_weights, grid_size * sizeof(double));
+
   /* Unpack the grid property arrays into a single contiguous array. */
   for (int idim = 0; idim < ndim; idim++) {
-    
+
     /* Extract the data from the numpy array. */
     const PyArrayObject *np_grid_arr = PyTuple_GetItem(grid_tuple, idim);
     const double *grid_arr = PyArray_DATA(np_grid_arr);
 
     /* Get the start index for this data. */
     int start = 0;
-    for (int jdim = 0; jdim < idim; jdim++) start += dims[jdim];
+    for (int jdim = 0; jdim < idim; jdim++)
+      start += dims[jdim];
 
     /* Assign this data to the property array. */
     for (int ind = start; ind < start + dims[idim]; ind++)
@@ -292,14 +316,15 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
 
   /* Unpack the particle property arrays into a single contiguous array. */
   for (int idim = 0; idim < ndim; idim++) {
-    
+
     /* Extract the data from the numpy array. */
     const PyArrayObject *np_part_arr = PyTuple_GetItem(part_tuple, idim);
     const double *part_arr = PyArray_DATA(np_part_arr);
 
     /* Get the start index for this data. */
     int start = 0;
-    for (int jdim = 0; jdim < idim; jdim++) start += npart;
+    for (int jdim = 0; jdim < idim; jdim++)
+      start += npart;
 
     /* Assign this data to the property array. */
     for (int ind = start; ind < start + npart; ind++)
@@ -314,7 +339,7 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
   int *low_indices = malloc((ndim + 1) * sizeof(int));
   int *weight_indices = malloc(nweights * sizeof(int));
   short int *sub_indices = malloc(ndim * sizeof(short int));
-    
+
   /* Loop over particles. */
   for (int p = 0; p < npart; p++) {
 
@@ -336,7 +361,7 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
     /* Compute grid indices and the mass faction in each grid cell. */
     frac_loop(grid_props, part_props, p, ndim, dims, npart, frac_indices,
               fracs);
-      
+
     /* Make a copy of the indices of the fraction to avoid double addition. */
     for (int ind = 0; ind < ndim + 1; ind++) {
       low_indices[ind] = frac_indices[ind];
@@ -344,7 +369,7 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
 
     /* Compute the weights and flattened grid indices. */
     recursive_weight_loop(mass, sub_indices, frac_indices, low_indices,
-                          weight_indices, weights, fracs, /*dim*/0, dims,
+                          weight_indices, weights, fracs, /*dim*/ 0, dims,
                           ndim);
 
     /* Loop over weights and their indices. */
@@ -352,231 +377,82 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
 
       /* Get this weight and it's flattened index. */
       const double weight = weights[i];
-      const int spectra_ind = weight_indices[i];
+      const int grid_ind = weight_indices[i];
 
       /* Skip zero weight cells. */
-      if (weight <= 0) continue;
-
-      /* Skip badly behaved indices. */
-      if (spectra_ind < 0 || spectra_ind > grid_size) {
-        printf("WARNING: Stellar particle found outside grid!\n");
+      if (weight <= 0)
         continue;
-      }
-      
-      /* Add this particle's contribution to the spectra */
-      for (int ilam = 0; ilam < nlam; ilam++) {
 
-        /* Are we doing total or stellar? */
-        spectra[ilam] +=
-          grid_spectra[spectra_ind + ilam] * (1 - fesc) * weight; 
-      }
-    }
-  }
-  
-  /* Reconstruct the python array to return. */
-  npy_intp np_dims[1] = {nlam,};
-  PyArrayObject *out_spectra =
-    (PyArrayObject *) PyArray_SimpleNewFromData(1, np_dims, NPY_FLOAT64,
-                                                spectra);
-  
-  return Py_BuildValue("N", out_spectra);
-}
-
-/**
- * @brief Computes an integrated SED for a collection of particles.
- *
- * @param np_stellar_spectra:
- * @param np_total_spectra:
- * @param grid_tuple:
- * @param part_tuple:
- * @param part_mass:
- * @param fesc:
- * @param len_tuple:
- * @param ndim:
- * @param npart:
- * @param nlam:
- */
-PyObject *compute_particle_seds(PyObject *self, PyObject *args) {
-  
-  const int ndim;
-  const int npart, nlam;
-  const double fesc;
-  const PyObject *grid_tuple, *part_tuple;
-  const PyArrayObject *np_grid_spectra;
-  const PyArrayObject *np_part_mass, *np_ndims;
-
-  if(!PyArg_ParseTuple(args, "OOOOdOiii",
-                       &np_grid_spectra, &grid_tuple, &part_tuple,
-                       &np_part_mass, &fesc, &np_ndims, &ndim, &npart, &nlam))
-    return NULL;
-
-  /* Quick check to make sure our inputs are valid. */
-  if (ndim == 0) return NULL;
-  if (npart == 0) return NULL;
-  if (nlam == 0) return NULL;
-
-  /* Extract a pointer to the spectra grids */
-  const double *grid_spectra = PyArray_DATA(np_grid_spectra);
-
-  /* Set up arrays to hold the SEDs themselves. */
-  double *spectra = malloc(npart * nlam * sizeof(double));
-  bzero(spectra, npart * nlam * sizeof(double));
-
-  /* Extract a pointer to the grid dims */
-  const int *dims = PyArray_DATA(np_ndims);
-
-  /* Extract a pointer to the particle masses. */
-  const double *part_mass = PyArray_DATA(np_part_mass);
-
-  /* Compute the number of weights we need. */
-  const int nweights = pow(2, ndim) + 0.1;
-
-  /* Define an array to hold this particle's weights. */
-  double *weights = malloc(nweights * sizeof(double));
-  bzero(weights, nweights * sizeof(double));
-
-  /* Allocate a single array for grid properties*/
-  int nprops = 0;
-  for (int dim = 0; dim < ndim; dim++) nprops += dims[dim];
-  double *grid_props = malloc(nprops * sizeof(double));
-
-  /* Get the grid size. */
-  int grid_size = nlam;
-  for (int dim = 0; dim < ndim; dim++)
-    grid_size *= dims[dim];
-
-  /* Unpack the grid property arrays into a single contiguous array. */
-  for (int idim = 0; idim < ndim; idim++) {
-    
-    /* Extract the data from the numpy array. */
-    const PyArrayObject *np_grid_arr = PyTuple_GetItem(grid_tuple, idim);
-    const double *grid_arr = PyArray_DATA(np_grid_arr);
-
-    /* Get the start index for this data. */
-    int start = 0;
-    for (int jdim = 0; jdim < idim; jdim++) start += dims[jdim];
-
-    /* Assign this data to the property array. */
-    for (int ind = start; ind < start + dims[idim]; ind++)
-      grid_props[ind] = grid_arr[ind - start];
-  }
-
-  /* Allocate a single array for particle properties. */
-  double *part_props = malloc(npart * ndim * sizeof(double));
-
-  /* Unpack the particle property arrays into a single contiguous array. */
-  for (int idim = 0; idim < ndim; idim++) {
-    
-    /* Extract the data from the numpy array. */
-    const PyArrayObject *np_part_arr = PyTuple_GetItem(part_tuple, idim);
-    const double *part_arr = PyArray_DATA(np_part_arr);
-
-    /* Get the start index for this data. */
-    int start = 0;
-    for (int jdim = 0; jdim < idim; jdim++) start += npart;
-
-    /* Assign this data to the property array. */
-    for (int ind = start; ind < start + npart; ind++)
-      part_props[ind] = part_arr[ind - start];
-  }
-
-  /* Set up arrays to store grid indices for the weights, mass fractions
-   * and indices.
-   * NOTE: the wavelength index on frac_indices is always 0. */
-  double *fracs = malloc(ndim * sizeof(double));
-  int *frac_indices = malloc((ndim + 1) * sizeof(int));
-  int *low_indices = malloc((ndim + 1) * sizeof(int));
-  int *weight_indices = malloc(nweights * sizeof(int));
-  short int *sub_indices = malloc(ndim * sizeof(double));
-    
-  /* Loop over particles. */
-  for (int p = 0; p < npart; p++) {
-
-    /* Reset arrays. */
-    for (int ind = 0; ind < nweights; ind++)
-      weight_indices[ind] = 0;
-    for (int ind = 0; ind < ndim; ind++) {
-      fracs[ind] = 0;
-      sub_indices[ind] = 0;
-    }
-    for (int ind = 0; ind < ndim + 1; ind++) {
-      frac_indices[ind] = 0;
-      low_indices[ind] = 0;
-    }
-
-    /* Get this particle's mass. */
-    const double mass = part_mass[p];
-
-    /* Compute grid indices and the mass faction in each grid cell. */
-    frac_loop(grid_props, part_props, p, ndim, dims, npart, frac_indices,
-              fracs);
-      
-    /* Make a copy of the indices of the fraction to avoid double addition. */
-    for (int ind = 0; ind < ndim + 1; ind++) {
-      low_indices[ind] = frac_indices[ind];
-    }
-
-    /* Compute the weights and flattened grid indices. */
-    recursive_weight_loop(mass, sub_indices, frac_indices, low_indices,
-                          weight_indices, weights, fracs, /*dim*/0, dims,
-                          ndim);
-
-    /* Loop over weights and their indices. */
-    for (int i = 0; i < nweights; i++) {
-
-      /* Get this weight and it's flattened index. */
-      const double weight = weights[i];
-      const int spectra_ind = weight_indices[i];
-
-      /* Skip badly behaved indices. */
-      if (spectra_ind < 0 || spectra_ind > grid_size) {
+      /* Skip and warn about badly behaved indices. */
+      if (grid_ind < 0 || grid_ind > grid_size) {
         printf("WARNING: Stellar particle found outside grid!\n");
         continue;
       }
 
-      /* Add this particle's contribution to the spectra */
-      for (int ilam = 0; ilam < nlam; ilam++) {
+      /* Add weight to this grid cell. */
+      grid_weights[grid_ind] += weight;
 
-        /* Are we doing total or stellar? */
-        spectra[p * nlam + ilam] +=
-          grid_spectra[spectra_ind + ilam] * (1 - fesc) * weight; 
-      }
+    } /* Loop over 2 ** ndim weights. */
+  }   /* Loop over particles. */
+
+  /* Loop over grid cells. */
+  for (int grid_ind = 0; grid_ind < grid_size; grid_ind++) {
+
+    /* Get the weight. */
+    const double weight = grid_weights[grid_ind];
+
+    /* Get the spectra ind. */
+    int unraveled_ind[ndim + 1];
+    get_indices_from_flat(grid_ind, ndim, dims, unraveled_ind);
+    unraveled_ind[ndim] = 0;
+    int spectra_ind = get_flat_index(unraveled_ind, dims, ndim + 1);
+
+    /* Skip zero weight cells. */
+    if (weight <= 0)
+      continue;
+
+    /* Add this grid cell's contribution to the spectra */
+    for (int ilam = 0; ilam < nlam; ilam++) {
+
+      /* Add the contribution to this wavelength. */
+      spectra[ilam] += grid_spectra[spectra_ind + ilam] * (1 - fesc) * weight;
     }
   }
-  
+
+  /* Clean up memory! */
+  free(grid_weights);
+
   /* Reconstruct the python array to return. */
-  npy_intp np_dims[2] = {npart, nlam,};
-  PyArrayObject *out_spectra =
-    (PyArrayObject *) PyArray_SimpleNewFromData(2, np_dims, NPY_FLOAT64,
-                                                spectra);
-  
+  npy_intp np_dims[1] = {
+      nlam,
+  };
+  PyArrayObject *out_spectra = (PyArrayObject *)PyArray_SimpleNewFromData(
+      1, np_dims, NPY_FLOAT64, spectra);
+
   return Py_BuildValue("N", out_spectra);
 }
 
 /* Below is all the gubbins needed to make the module importable in Python. */
 static PyMethodDef SedMethods[] = {
-  {"compute_integrated_sed", compute_integrated_sed, METH_VARARGS,
-   "Method for calculating integrated intrinsic spectra."},
-  {"compute_particle_seds", compute_particle_seds, METH_VARARGS,
-   "Method for calculating particle intrinsic spectra."},
-  {NULL, NULL, 0, NULL} 
-};
+    {"compute_integrated_sed", compute_integrated_sed, METH_VARARGS,
+     "Method for calculating integrated intrinsic spectra."},
+    {NULL, NULL, 0, NULL}};
 
 /* Make this importable. */
 static struct PyModuleDef moduledef = {
-        PyModuleDef_HEAD_INIT,
-        "make_sed",                          /* m_name */
-        "A module to calculate seds",              /* m_doc */
-        -1,                                        /* m_size */
-        SedMethods,                                /* m_methods */
-        NULL,                                      /* m_reload */
-        NULL,                                      /* m_traverse */
-        NULL,                                      /* m_clear */
-        NULL,                                      /* m_free */
-    };
+    PyModuleDef_HEAD_INIT,
+    "make_sed",                              /* m_name */
+    "A module to calculate integrated seds", /* m_doc */
+    -1,                                      /* m_size */
+    SedMethods,                              /* m_methods */
+    NULL,                                    /* m_reload */
+    NULL,                                    /* m_traverse */
+    NULL,                                    /* m_clear */
+    NULL,                                    /* m_free */
+};
 
-PyMODINIT_FUNC PyInit_csed(void) {
-    PyObject *m = PyModule_Create(&moduledef);
-    import_array();
-    return m;
+PyMODINIT_FUNC PyInit_integrated_spectra(void) {
+  PyObject *m = PyModule_Create(&moduledef);
+  import_array();
+  return m;
 }

--- a/synthesizer/extensions/particle_spectra.c
+++ b/synthesizer/extensions/particle_spectra.c
@@ -50,6 +50,7 @@ int get_flat_index(const int *multi_index, const int *dims, const int ndims) {
 
   return index;
 }
+
 /**
  * @brief Calculates the mass fractions in each right most grid cell along
  *        each dimension.
@@ -65,39 +66,34 @@ int get_flat_index(const int *multi_index, const int *dims, const int ndims) {
  * @param fracs: The array for storing the mass fractions. NOTE: The left most
  *               grid cell's mass fraction is simply (1 - frac[dim])
  */
-void frac_loop(const double *grid_props, const double *part_props, int p,
+void frac_loop(const double **grid_props, const double **part_props, int p,
                const int ndim, const int *dims, const int npart,
                int *frac_indices, double *fracs) {
 
   /* Loop over dimensions. */
   for (int dim = 0; dim < ndim; dim++) {
 
-    /* Get the grid and particle start indices for this property. */
-    int grid_start = 0;
-    int part_start = 0;
-    for (int jdim = 0; jdim < dim; jdim++) {
-      grid_start += dims[jdim];
-      part_start += npart;
-    }
+    /* Get this array of grid properties */
+    const double *grid_prop = grid_props[dim];
 
     /* Get this particle property. */
-    const double part_val = part_props[part_start + p];
+    const double part_val = part_props[dim][p];
 
     /**************************************************************************
      * Get the cells corresponding to this particle and compute the fraction.
      *************************************************************************/
 
     /* Define the starting indices. */
-    int low = grid_start, high = grid_start + dims[dim] - 1;
+    int low = 0, high = dims[dim] - 1;
 
     /* Here we need to handle if we are outside the range of values. If so
      * there's no point in searching and we return the edge nearest to the
      * value. */
-    if (part_val <= grid_props[low]) {
-      low = grid_start;
+    if (part_val <= grid_prop[low]) {
+      low = 0;
       fracs[dim] = 0;
-    } else if (part_val > grid_props[high]) {
-      low = grid_start + dims[dim];
+    } else if (part_val > grid_prop[high]) {
+      low = dims[dim];
       fracs[dim] = 0;
     } else {
 
@@ -109,7 +105,7 @@ void frac_loop(const double *grid_props, const double *part_props, int p,
         int mid = low + floor(diff / 2);
 
         /* Where is the midpoint relative to the value? */
-        if (grid_props[mid] < part_val) {
+        if (grid_prop[mid] < part_val) {
           low = mid;
         } else {
           high = mid;
@@ -122,11 +118,11 @@ void frac_loop(const double *grid_props, const double *part_props, int p,
       /* Calculate the fraction. Note, this represents the mass fraction in
        * the high cell. */
       fracs[dim] =
-          (part_val - grid_props[low]) / (grid_props[high] - grid_props[low]);
+          (part_val - grid_prop[low]) / (grid_prop[high] - grid_prop[low]);
     }
 
     /* Set these indices. */
-    frac_indices[dim] = low - grid_start;
+    frac_indices[dim] = low;
   }
 }
 
@@ -258,7 +254,7 @@ PyObject *compute_particle_seds(PyObject *self, PyObject *args) {
   int nprops = 0;
   for (int dim = 0; dim < ndim; dim++)
     nprops += dims[dim];
-  double *grid_props = malloc(nprops * sizeof(double));
+  const double **grid_props = malloc(nprops * sizeof(double *));
 
   /* How many grid elements are there? (excluding wavelength axis)*/
   int grid_size = 1;
@@ -276,18 +272,12 @@ PyObject *compute_particle_seds(PyObject *self, PyObject *args) {
     const PyArrayObject *np_grid_arr = PyTuple_GetItem(grid_tuple, idim);
     const double *grid_arr = PyArray_DATA(np_grid_arr);
 
-    /* Get the start index for this data. */
-    int start = 0;
-    for (int jdim = 0; jdim < idim; jdim++)
-      start += dims[jdim];
-
     /* Assign this data to the property array. */
-    for (int ind = start; ind < start + dims[idim]; ind++)
-      grid_props[ind] = grid_arr[ind - start];
+    grid_props[idim] = grid_arr;
   }
 
   /* Allocate a single array for particle properties. */
-  double *part_props = malloc(npart * ndim * sizeof(double));
+  const double **part_props = malloc(npart * ndim * sizeof(double *));
 
   /* Unpack the particle property arrays into a single contiguous array. */
   for (int idim = 0; idim < ndim; idim++) {
@@ -296,14 +286,8 @@ PyObject *compute_particle_seds(PyObject *self, PyObject *args) {
     const PyArrayObject *np_part_arr = PyTuple_GetItem(part_tuple, idim);
     const double *part_arr = PyArray_DATA(np_part_arr);
 
-    /* Get the start index for this data. */
-    int start = 0;
-    for (int jdim = 0; jdim < idim; jdim++)
-      start += npart;
-
     /* Assign this data to the property array. */
-    for (int ind = start; ind < start + npart; ind++)
-      part_props[ind] = part_arr[ind - start];
+    part_props[idim] = part_arr;
   }
 
   /* Set up arrays to store grid indices for the weights, mass fractions

--- a/synthesizer/extensions/particle_spectra.c
+++ b/synthesizer/extensions/particle_spectra.c
@@ -1,0 +1,409 @@
+/******************************************************************************
+ * Cython extension to calculate SED weights for star particles.
+ * Calculates weights on an age / metallicity grid given the mass.
+ * Args:
+ *   z - 1 dimensional array of metallicity values (ascending)
+ *   a - 1 dimensional array of age values (ascending)
+ *   particle - 2 dimensional array of particle properties (N, 3)
+ *   first column metallicity, second column age, third column mass
+ * Returns:
+ *   w - 2d array, dimensions (z, a), of weights to apply to SED array
+/*****************************************************************************/
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <Python.h>
+
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
+#include <numpy/ndarrayobject.h>
+#include <numpy/ndarraytypes.h>
+
+/* Define a macro to handle that bzero is non-standard. */
+#define bzero(b, len) (memset((b), '\0', (len)), (void)0)
+
+/**
+ * @brief Compute a flat grid index based on the grid dimensions.
+ *
+ * @param indices: An array of N-dimensional indices.
+ * @param dims: The length of each dimension.
+ * @param ndim: The number of dimensions.
+ */
+int get_flat_index(const int *multi_index, const int *dims, const int ndims) {
+  int index = 0, stride = 1;
+  for (int i = ndims - 1; i >= 0; i--) {
+    index += stride * multi_index[i];
+    stride *= dims[i];
+  }
+
+  return index;
+}
+
+/**
+ * @brief Compute a flat grid index based on the grid dimensions for instances
+ *        where the length of each dimension is always 2.
+ *
+ * @param indices: An array of N-dimensional indices.
+ * @param dims: The length of each dimension.
+ * @param ndim: The number of dimensions.
+ */
+int get_flat_index_subarray(const int *multi_index, int ndims) {
+  int index = 0, stride = 1;
+  for (int i = ndims - 1; i >= 0; i--) {
+    index += stride * multi_index[i];
+    stride *= 2;
+  }
+  return index;
+}
+
+/**
+ * @brief Calculates the mass fractions in each right most grid cell along
+ *        each dimension.
+ *
+ * @param grid_tuple: The tuple contain each array of grid properties.
+ * @param part_tuple: The tuple containing each array of particle properties.
+ * @param p: Index of the current particle.
+ * @param ndim: The number of grid dimensions.
+ * @param dims: The length of each grid dimension.
+ * @param indices: The array for storing N-dimensional grid indicies.
+ * @param fracs: The array for storing the mass fractions. NOTE: The left most
+ *               grid cell's mass fraction is simply (1 - frac[dim])
+ */
+void frac_loop(const double *grid_props, const double *part_props, int p,
+               const int ndim, const int *dims, const int npart,
+               int *frac_indices, double *fracs) {
+
+  /* Loop over dimensions. */
+  for (int dim = 0; dim < ndim; dim++) {
+
+    /* Get the grid and particle start indices for this property. */
+    int grid_start = 0;
+    int part_start = 0;
+    for (int jdim = 0; jdim < dim; jdim++) {
+      grid_start += dims[jdim];
+      part_start += npart;
+    }
+
+    /* Get this particle property. */
+    const double part_val = part_props[part_start + p];
+
+    /**************************************************************************
+     * Get the cells corresponding to this particle and compute the fraction.
+     *************************************************************************/
+
+    /* Define the starting indices. */
+    int low = grid_start, high = grid_start + dims[dim] - 1;
+
+    /* Here we need to handle if we are outside the range of values. If so
+     * there's no point in searching and we return the edge nearest to the
+     * value. */
+    if (part_val <= grid_props[low]) {
+      low = grid_start;
+      fracs[dim] = 0;
+    } else if (part_val > grid_props[high]) {
+      low = grid_start + dims[dim];
+      fracs[dim] = 0;
+    } else {
+
+      /* While we don't have a pair of adjacent indices. */
+      int diff = high - low;
+      while (diff > 1) {
+
+        /* Define the midpoint. */
+        int mid = low + floor(diff / 2);
+
+        /* Where is the midpoint relative to the value? */
+        if (grid_props[mid] < part_val) {
+          low = mid;
+        } else {
+          high = mid;
+        }
+
+        /* Compute the new range. */
+        diff = high - low;
+      }
+
+      /* Calculate the fraction. Note, this represents the mass fraction in
+       * the high cell. */
+      fracs[dim] =
+          (part_val - grid_props[low]) / (grid_props[high] - grid_props[low]);
+    }
+
+    /* Set these indices. */
+    frac_indices[dim] = low - grid_start;
+  }
+}
+
+/**
+ * @brief This calculates the grid weights in each grid cell.
+ *
+ * To do this for an N-dimensional array this is done recursively.
+ *
+ * @param mass: The mass of the current particle.
+ * @param part_tuple: The tuple containing each array of particle properties.
+ * @param p: Index of the current particle.
+ * @param dim: The current dimension in the recursion.
+ * @param ndim: The number of grid dimensions.
+ * @param dims: The length of each grid dimension.
+ * @param indices: The array for storing N-dimensional grid indicies.
+ * @param fracs: The array for storing the mass fractions. NOTE: The left most
+ *               grid cell's mass fraction is simply (1 - frac[dim])
+ */
+void recursive_weight_loop(const double mass, int *sub_indices,
+                           int *frac_indices, int *low_indices,
+                           int *weight_indices, double *weights, double *fracs,
+                           int dim, const int *dims, const int ndim) {
+
+  /* Are we done yet? */
+  if (dim >= ndim) {
+
+    /* Get the index for this particle in the weights array. */
+    const int weight_ind = get_flat_index_subarray(sub_indices, ndim);
+
+    /* Get the flattened index into the grid array. */
+    weight_indices[weight_ind] = get_flat_index(frac_indices, dims, ndim + 1);
+
+    /* Check whether we need a weight in this cell. */
+    for (int i = 0; i < ndim; i++) {
+      if ((sub_indices[i] == 1 && fracs[i] == 0 && frac_indices[i] == 0) ||
+          (sub_indices[i] == 1 && fracs[i] == 0 &&
+           frac_indices[i] == dims[i])) {
+        weights[weight_ind] = 0;
+        return;
+      }
+    }
+
+    /* Compute the weight. */
+    weights[weight_ind] = mass;
+    for (int i = 0; i < ndim; i++) {
+
+      if (sub_indices[i]) {
+        weights[weight_ind] *= fracs[i];
+      } else {
+        weights[weight_ind] *= (1 - fracs[i]);
+      }
+    }
+
+    /* We're done! */
+    return;
+  }
+
+  /* Loop over this dimension */
+  for (int i = 0; i < ndim; i++) {
+
+    /* Where are we in the sub_array? */
+    sub_indices[dim] = i;
+
+    /* Where are we in the grid array? */
+    frac_indices[dim] = low_indices[dim] + i;
+
+    /* Recurse... */
+    recursive_weight_loop(mass, sub_indices, frac_indices, low_indices,
+                          weight_indices, weights, fracs, dim + 1, dims, ndim);
+  }
+}
+
+/**
+ * @brief Computes an integrated SED for a collection of particles.
+ *
+ * @param np_stellar_spectra:
+ * @param np_total_spectra:
+ * @param grid_tuple:
+ * @param part_tuple:
+ * @param part_mass:
+ * @param fesc:
+ * @param len_tuple:
+ * @param ndim:
+ * @param npart:
+ * @param nlam:
+ */
+PyObject *compute_particle_seds(PyObject *self, PyObject *args) {
+
+  const int ndim;
+  const int npart, nlam;
+  const double fesc;
+  const PyObject *grid_tuple, *part_tuple;
+  const PyArrayObject *np_grid_spectra;
+  const PyArrayObject *np_part_mass, *np_ndims;
+
+  if (!PyArg_ParseTuple(args, "OOOOdOiii", &np_grid_spectra, &grid_tuple,
+                        &part_tuple, &np_part_mass, &fesc, &np_ndims, &ndim,
+                        &npart, &nlam))
+    return NULL;
+
+  /* Quick check to make sure our inputs are valid. */
+  if (ndim == 0)
+    return NULL;
+  if (npart == 0)
+    return NULL;
+  if (nlam == 0)
+    return NULL;
+
+  /* Extract a pointer to the spectra grids */
+  const double *grid_spectra = PyArray_DATA(np_grid_spectra);
+
+  /* Set up arrays to hold the SEDs themselves. */
+  double *spectra = malloc(npart * nlam * sizeof(double));
+  bzero(spectra, npart * nlam * sizeof(double));
+
+  /* Extract a pointer to the grid dims */
+  const int *dims = PyArray_DATA(np_ndims);
+
+  /* Extract a pointer to the particle masses. */
+  const double *part_mass = PyArray_DATA(np_part_mass);
+
+  /* Compute the number of weights we need. */
+  const int nweights = pow(2, ndim) + 0.1;
+
+  /* Define an array to hold this particle's weights. */
+  double *weights = malloc(nweights * sizeof(double));
+  bzero(weights, nweights * sizeof(double));
+
+  /* Allocate a single array for grid properties*/
+  int nprops = 0;
+  for (int dim = 0; dim < ndim; dim++)
+    nprops += dims[dim];
+  double *grid_props = malloc(nprops * sizeof(double));
+
+  /* Get the grid size. */
+  int grid_size = nlam;
+  for (int dim = 0; dim < ndim; dim++)
+    grid_size *= dims[dim];
+
+  /* Unpack the grid property arrays into a single contiguous array. */
+  for (int idim = 0; idim < ndim; idim++) {
+
+    /* Extract the data from the numpy array. */
+    const PyArrayObject *np_grid_arr = PyTuple_GetItem(grid_tuple, idim);
+    const double *grid_arr = PyArray_DATA(np_grid_arr);
+
+    /* Get the start index for this data. */
+    int start = 0;
+    for (int jdim = 0; jdim < idim; jdim++)
+      start += dims[jdim];
+
+    /* Assign this data to the property array. */
+    for (int ind = start; ind < start + dims[idim]; ind++)
+      grid_props[ind] = grid_arr[ind - start];
+  }
+
+  /* Allocate a single array for particle properties. */
+  double *part_props = malloc(npart * ndim * sizeof(double));
+
+  /* Unpack the particle property arrays into a single contiguous array. */
+  for (int idim = 0; idim < ndim; idim++) {
+
+    /* Extract the data from the numpy array. */
+    const PyArrayObject *np_part_arr = PyTuple_GetItem(part_tuple, idim);
+    const double *part_arr = PyArray_DATA(np_part_arr);
+
+    /* Get the start index for this data. */
+    int start = 0;
+    for (int jdim = 0; jdim < idim; jdim++)
+      start += npart;
+
+    /* Assign this data to the property array. */
+    for (int ind = start; ind < start + npart; ind++)
+      part_props[ind] = part_arr[ind - start];
+  }
+
+  /* Set up arrays to store grid indices for the weights, mass fractions
+   * and indices.
+   * NOTE: the wavelength index on frac_indices is always 0. */
+  double *fracs = malloc(ndim * sizeof(double));
+  int *frac_indices = malloc((ndim + 1) * sizeof(int));
+  int *low_indices = malloc((ndim + 1) * sizeof(int));
+  int *weight_indices = malloc(nweights * sizeof(int));
+  short int *sub_indices = malloc(ndim * sizeof(double));
+
+  /* Loop over particles. */
+  for (int p = 0; p < npart; p++) {
+
+    /* Reset arrays. */
+    for (int ind = 0; ind < nweights; ind++)
+      weight_indices[ind] = 0;
+    for (int ind = 0; ind < ndim; ind++) {
+      fracs[ind] = 0;
+      sub_indices[ind] = 0;
+    }
+    for (int ind = 0; ind < ndim + 1; ind++) {
+      frac_indices[ind] = 0;
+      low_indices[ind] = 0;
+    }
+
+    /* Get this particle's mass. */
+    const double mass = part_mass[p];
+
+    /* Compute grid indices and the mass faction in each grid cell. */
+    frac_loop(grid_props, part_props, p, ndim, dims, npart, frac_indices,
+              fracs);
+
+    /* Make a copy of the indices of the fraction to avoid double addition. */
+    for (int ind = 0; ind < ndim + 1; ind++) {
+      low_indices[ind] = frac_indices[ind];
+    }
+
+    /* Compute the weights and flattened grid indices. */
+    recursive_weight_loop(mass, sub_indices, frac_indices, low_indices,
+                          weight_indices, weights, fracs, /*dim*/ 0, dims,
+                          ndim);
+
+    /* Loop over weights and their indices. */
+    for (int i = 0; i < nweights; i++) {
+
+      /* Get this weight and it's flattened index. */
+      const double weight = weights[i];
+      const int grid_ind = weight_indices[i];
+
+      /* Skip and warn about badly behaved indices. */
+      if (grid_ind < 0 || grid_ind > grid_size) {
+        printf("WARNING: Stellar particle found outside grid!\n");
+        continue;
+      }
+
+      /* Add this particle's contribution to the spectra */
+      for (int ilam = 0; ilam < nlam; ilam++) {
+
+        /* Are we doing total or stellar? */
+        spectra[p * nlam + ilam] +=
+            grid_spectra[grid_ind + ilam] * (1 - fesc) * weight;
+      }
+    }
+  }
+
+  /* Reconstruct the python array to return. */
+  npy_intp np_dims[2] = {
+      npart,
+      nlam,
+  };
+  PyArrayObject *out_spectra = (PyArrayObject *)PyArray_SimpleNewFromData(
+      2, np_dims, NPY_FLOAT64, spectra);
+
+  return Py_BuildValue("N", out_spectra);
+}
+
+/* Below is all the gubbins needed to make the module importable in Python. */
+static PyMethodDef SedMethods[] = {
+    {"compute_particle_seds", compute_particle_seds, METH_VARARGS,
+     "Method for calculating particle intrinsic spectra."},
+    {NULL, NULL, 0, NULL}};
+
+/* Make this importable. */
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "make_particle_sed",                   /* m_name */
+    "A module to calculate particle seds", /* m_doc */
+    -1,                                    /* m_size */
+    SedMethods,                            /* m_methods */
+    NULL,                                  /* m_reload */
+    NULL,                                  /* m_traverse */
+    NULL,                                  /* m_clear */
+    NULL,                                  /* m_free */
+};
+
+PyMODINIT_FUNC PyInit_integrated_spectra(void) {
+  PyObject *m = PyModule_Create(&moduledef);
+  import_array();
+  return m;
+}

--- a/synthesizer/particle/galaxy.py
+++ b/synthesizer/particle/galaxy.py
@@ -350,9 +350,7 @@ class Galaxy(BaseGalaxy):
                 "Star object is missing coordinates!"
             )
         if self.gas.coordinates is None:
-            raise exceptions.InconsistentArguments(
-                "Gas object is missing coordinates!"
-            )
+            raise exceptions.InconsistentArguments("Gas object is missing coordinates!")
         if self.gas.smoothing_lengths is None:
             raise exceptions.InconsistentArguments(
                 "Gas object is missing smoothing lengths!"
@@ -362,14 +360,12 @@ class Galaxy(BaseGalaxy):
                 "Gas object is missing metallicities!"
             )
         if self.gas.masses is None:
-            raise exceptions.InconsistentArguments(
-                "Gas object is missing masses!"
-            )
+            raise exceptions.InconsistentArguments("Gas object is missing masses!")
         if self.gas.dust_to_metal_ratio is None:
             raise exceptions.InconsistentArguments(
                 "Gas object is missing DTMs (dust_to_metal_ratio)!"
             )
-            
+
         # Set up the kernel inputs to the C function.
         kernel = np.ascontiguousarray(kernel, dtype=np.float64)
         kdim = kernel.size
@@ -457,7 +453,7 @@ class Galaxy(BaseGalaxy):
 
             return np.zeros(len(grid.lam))
 
-        from ..extensions.csed import compute_integrated_sed
+        from ..extensions.integrated_spectra import compute_integrated_sed
 
         # Prepare the arguments for the C function.
         args = self._prepare_sed_args(
@@ -515,7 +511,7 @@ class Galaxy(BaseGalaxy):
 
             return np.zeros(len(grid.lam))
 
-        from ..extensions.csed import compute_particle_seds
+        from ..extensions.particle_spectra import compute_particle_seds
 
         # Prepare the arguments for the C function.
         args = self._prepare_sed_args(
@@ -590,7 +586,7 @@ class Galaxy(BaseGalaxy):
         return linecont
 
     def get_particle_spectra_incident(
-            self, grid, young=False, old=False, label="", update=True
+        self, grid, young=False, old=False, label="", update=True
     ):
         """
         Generate the incident (equivalent to pure stellar for stars) spectra
@@ -959,7 +955,7 @@ class Galaxy(BaseGalaxy):
     ):
         """
         Calculate the gamma parameter controlling the optical depth
-        due to dust dependent on the mass and metallicity of star forming 
+        due to dust dependent on the mass and metallicity of star forming
         gas.
 
         gamma = (Z_SF / Z_MW) * (M_SF / M_star) * (1 / beta)
@@ -979,21 +975,21 @@ class Galaxy(BaseGalaxy):
                 metallicity normsalition value, defaults to Zahid+14
                 value for the Milky Way (0.035)
             sf_gas_metallicity (array):
-                custom star forming gas metallicity array. If None, 
+                custom star forming gas metallicity array. If None,
                 defaults to value attached to this galaxy object.
             sf_gas_mass (array):
-                custom star forming gas mass array. If None, 
+                custom star forming gas mass array. If None,
                 defaults to value attached to this galaxy object.
             stellar_mass (array):
-                custom stellar mass array. If None, defaults to value 
+                custom stellar mass array. If None, defaults to value
                 attached to this galaxy object.
             gamma_min (float):
-                lower limit of the gamma parameter. If None, no lower 
-                limit implemented. Default = None                 
+                lower limit of the gamma parameter. If None, no lower
+                limit implemented. Default = None
             gamma_max (float):
-                upper limit of the gamma parameter. If None, no upper 
-                limit implemented. Default = None                 
-                
+                upper limit of the gamma parameter. If None, no upper
+                limit implemented. Default = None
+
         Returns:
             gamma (array):
                 gamma scaling parameter for this galaxy
@@ -1017,12 +1013,16 @@ class Galaxy(BaseGalaxy):
             else:
                 stellar_mass = self.stellar_mass
 
-        if sf_gas_mass == 0.:
-            gamma = 0.
-        elif stellar_mass == 0.:
+        if sf_gas_mass == 0.0:
+            gamma = 0.0
+        elif stellar_mass == 0.0:
             gamma = 1.0
         else:
-            gamma = (sf_gas_metallicity / Z_norm) * (sf_gas_mass / stellar_mass) * (1.0 / beta)
+            gamma = (
+                (sf_gas_metallicity / Z_norm)
+                * (sf_gas_mass / stellar_mass)
+                * (1.0 / beta)
+            )
 
         if gamma_min is not None:
             gamma[gamma < gamma_min] = gamma_min


### PR DESCRIPTION
@christopherlovell observed that integrated spectra were taking surprisingly long to compute for a high-resolution wavelength array. This PR solves that while significantly improving the readability, documentation, and (particle) performance of the spectra extensions.

- Spectra extensions are now divided into an integrated and particle extension.
- Wavelength elements are looped over only once for each non-zero weight in integrated spectra computation.
- Particles now update the spectra during recursion removing some unnecessary looping.
- All function descriptions are now complete.

 In doing this simplification and optimization the results changed but now seem much more sensible than what was there previously. I likely uncovered and fixed an indexing bug without realizing it in this process... Luckily nothing has been published using it so far.

## Issue Type
<!-- delete options below as required -->
- Bug
- Enhancement

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
