### PR TITLE
Fix age mask units

### DIFF
--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -6,6 +6,7 @@ and methods common between them.
 """
 import numpy as np
 import matplotlib.pyplot as plt
+from unyt import Myr, unyt_quantity
 
 from synthesizer import exceptions
 from synthesizer.dust.attenuation import PowerLaw
@@ -125,6 +126,9 @@ class StarsComponent:
                 The line contribution spectra.
         """
 
+        # Make sure young and old in Myr, if provided
+        young, old = self.check_young_old_units(young, old)
+
         # Generate contribution of line emission alone and reduce the
         # contribution of Lyman-alpha
         linecont = self.generate_lnu(
@@ -162,6 +166,9 @@ class StarsComponent:
             Sed
                 An Sed object containing the stellar spectra.
         """
+
+        # Make sure young and old in Myr, if provided
+        young, old = self.check_young_old_units(young, old)
 
         # Get the incident spectra
         lnu = self.generate_lnu(grid, "incident", young=young, old=old)
@@ -208,6 +215,9 @@ class StarsComponent:
                 An Sed object containing the transmitted spectra.
         """
 
+        # Make sure young and old in Myr, if provided
+        young, old = self.check_young_old_units(young, old)
+
         # Get the transmitted spectra
         lnu = (1.0 - fesc) * self.generate_lnu(
             grid, "transmitted", young=young, old=old
@@ -253,6 +263,9 @@ class StarsComponent:
             Sed
                 An Sed object containing the nebular spectra.
         """
+
+        # Make sure young and old in Myr, if provided
+        young, old = self.check_young_old_units(young, old)
 
         # Get the nebular emission spectra
         lnu = self.generate_lnu(grid, "nebular", young=young, old=old)
@@ -317,6 +330,9 @@ class StarsComponent:
             Sed
                 An Sed object containing the intrinsic spectra.
         """
+
+        # Make sure young and old in Myr, if provided
+        young, old = self.check_young_old_units(young, old)
 
         # The incident emission
         incident = self.get_spectra_incident(
@@ -410,6 +426,9 @@ class StarsComponent:
             Sed
                 An Sed object containing the dust attenuated spectra.
         """
+
+        # Make sure young and old in Myr, if provided
+        young, old = self.check_young_old_units(young, old)
 
         # Generate intrinsic spectra using full star formation and metal
         # enrichment history or all particles
@@ -936,6 +955,34 @@ class StarsComponent:
             dust_curve_nebular=dust_curve,
             dust_curve_stellar=dust_curve,
         )
+
+    def check_young_old_units(self, young, old):
+        """
+        Checks whether the `young` and `old` arguments to many
+        spectra generation methods are in the right units (Myr)
+
+        Args:
+            young (bool, float):
+                If not False, specifies age in Myr at which to filter
+                for young star particles.
+            old (bool, float):
+                If not False, specifies age in Myr at which to filter
+                for old star particles.
+        """
+
+        if young:
+            if isinstance(young, (unyt_quantity)):
+                young = young.to("Myr")
+            else:
+                young *= Myr
+
+        if old:
+            if isinstance(old, (unyt_quantity)):
+                old = old.to("Myr")
+            else:
+                old *= Myr
+
+        return young, old
 
     def plot_spectra(
             self,

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -56,9 +56,9 @@ class Stars(Particles, StarsComponent):
         alpha_enhancement (array-like, float)
             The alpha enhancement [alpha/Fe] of each stellar particle.
         log10ages (array-like, float)
-            Convnience attribute containing log10(age).
+            Convenience attribute containing log10(age in yr).
         log10metallicities (array-like, float)
-            Convnience attribute containing log10(metallicity).
+            Convenience attribute containing log10(metallicity).
         resampled (bool)
             Flag for whether the young particles have been resampled.
         current_masses (array-like, float)
@@ -203,6 +203,7 @@ class Stars(Particles, StarsComponent):
         self.s_hydrogen = s_hydrogen
 
         # Compute useful logged quantities
+        # TODO: should be changed to a property to avoid data duplication
         self.log10ages = np.log10(self.ages)
         self.log10metallicities = np.log10(self.metallicities)
 

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -640,10 +640,10 @@ class Stars(Particles, StarsComponent):
         # Get the appropriate mask
         if young:
             # Mask out old stars
-            s = self.log10ages <= np.log10(young)
+            s = self.log10ages <= np.log10(young * 1e6)
         elif old:
             # Mask out young stars
-            s = self.log10ages > np.log10(old)
+            s = self.log10ages > np.log10(old * 1e6)
         else:
             # Nothing to mask out
             s = np.ones(self.nparticles, dtype=bool)

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -297,7 +297,11 @@ class Stars(Particles, StarsComponent):
         part_mass = np.ascontiguousarray(
             self._initial_masses[mask], dtype=np.float64
         )
-        npart = np.int32(self.nparticles)
+
+        # Make sure we set the number of particles to the size of the mask
+        npart = np.int32(np.sum(mask))
+
+        # Make sure we get the wavelength index of the grid array
         nlam = np.int32(grid.spectra[spectra_type].shape[-1])
 
         # Slice the spectral grids and pad them with copies of the edges.
@@ -383,9 +387,7 @@ class Stars(Particles, StarsComponent):
         )
 
         # Get the integrated spectra in grid units (erg / s / Hz)
-        spec = compute_integrated_sed(*args)
-
-        return spec
+        return compute_integrated_sed(*args)
 
     def generate_line(self, grid, line_id, fesc):
         """
@@ -641,10 +643,10 @@ class Stars(Particles, StarsComponent):
         # Get the appropriate mask
         if young:
             # Mask out old stars
-            s = self.log10ages <= np.log10(young * 1e6)
+            s = self.log10ages <= np.log10(young.to("yr"))
         elif old:
             # Mask out young stars
-            s = self.log10ages > np.log10(old * 1e6)
+            s = self.log10ages > np.log10(old.to("yr"))
         else:
             # Nothing to mask out
             s = np.ones(self.nparticles, dtype=bool)


### PR DESCRIPTION
Currently the age mask on a stars particle object compares in years, but is expecting `young` / `old` to be in Myr. 
- added method to check the units of `young` and `old` ni all the specrta generation methods
- fixes a bug in `_prepare_sed_args` where the particle number was set to the original array size, not the size of the mask
- docstring updated

## Issue Type
- Bug

## Checklist
<!-- - [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
