### PR TITLE
Fix bug in grid __str__ method

### DIFF
--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -418,9 +418,9 @@ class Grid:
             pstr += f"{axis}: {getattr(self, axis)} \n"
         for k, v in self.parameters.items():
             pstr += f"{k}: {v} \n"
-        if self.spectra:
-            pstr += f"available lines: {self.available_lines}\n"
         if self.lines:
+            pstr += f"available lines: {self.available_lines}\n"
+        if self.spectra:
             pstr += f"available spectra: {self.available_spectra}\n"
         pstr += "-" * 30 + "\n"
 


### PR DESCRIPTION
Fix conditions the wrong way around

## Issue Type
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
