### PR TITLE
Add luminosity and wavelength aliases

### DIFF
--- a/docs/source/sed.ipynb
+++ b/docs/source/sed.ipynb
@@ -121,6 +121,26 @@
   {
    "attachments": {},
    "cell_type": "markdown",
+   "id": "4e274835",
+   "metadata": {},
+   "source": [
+    "These also have more descriptive aliases:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef68fa8f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(sed.wavelength)\n",
+    "print(sed.luminosity_nu)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
    "id": "363f3759",
    "metadata": {},
    "source": [
@@ -747,8 +767,27 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "3fbdfee1eda89f517d14c65aaeb395605ea48cc827c54c8ae1828e532ec42817"
+   }
   }
  },
  "nbformat": 4,

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -276,9 +276,31 @@ class Sed:
 
         Returns
             luminosity (unyt_array)
-                The pectral luminosity density per Angstrom array.
+                The spectral luminosity density per Angstrom array.
         """
         return self.nu * self.lnu / self.lam
+
+    @property
+    def luminosity_nu(self):
+        """
+        Alias to lnu.
+
+        Returns
+            luminosity (unyt_array)
+                The spectral luminosity density per Hz array.
+        """
+        return self.lnu 
+    
+    @property
+    def luminosity_lambda(self):
+        """
+        Alias to llam.
+
+        Returns
+            luminosity (unyt_array)
+                The spectral luminosity density per Angstrom array.
+        """
+        return self.llam
 
     @property
     def _spec_dims(self):

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -301,6 +301,17 @@ class Sed:
                 The spectral luminosity density per Angstrom array.
         """
         return self.llam
+    
+    @property
+    def wavelength(self):
+        """
+        Alias to lam (wavelength array).
+
+        Returns
+            wavelength (unyt_array)
+                The wavelength array.
+        """
+        return self.lam
 
     @property
     def _spec_dims(self):


### PR DESCRIPTION
Added `luminosity_nu`, `luminosity_lambda`, and `wavelength` as aliases to `lnu`, `llam`, and `lam` respectively. Added description to sed doc notebook.

Closes #410 

## Issue Type
<!-- delete options below as required -->
- Bug
- Document
- [x] Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
