### PR TITLE
galaxies should have a get observed spectra method

### DIFF
--- a/examples/parametric/plot_observed_sed.py
+++ b/examples/parametric/plot_observed_sed.py
@@ -66,11 +66,18 @@ if __name__ == "__main__":
     galaxy = Galaxy(stars, redshift=z)
 
     # generate spectra using pacman model (complex)
-    sed = galaxy.stars.get_spectra_pacman(grid, fesc=0.5, fesc_LyA=0.5, tau_v=0.1)
+    sed = galaxy.stars.get_spectra_pacman(
+        grid,
+        fesc=0.5,
+        fesc_LyA=0.5,
+        tau_v=0.1,
+    )
 
     # now calculate the observed frame spectra
     sed.get_fnu(
-        cosmo, z, igm=Madau96
+        cosmo,
+        z,
+        igm=Madau96,
     )  # generate observed frame spectra, assume Madau96 IGM model
 
     # measure broadband fluxes
@@ -80,11 +87,14 @@ if __name__ == "__main__":
     for filter, flux in fluxes.items():
         print(f"{filter}: {flux:.2f}")
 
+    # Calculate the observed spectra for all stellar spectra
+    galaxy.get_observed_spectra(cosmo, igm=Madau96)
+
     # make plot of observed including broadband fluxes (if filter collection
     # object given)
     galaxy.plot_observed_spectra(
         filters=fc,
         show=True,
         combined_spectra=False,
-        stellar_spectra=sed,
+        stellar_spectra=True,
     )

--- a/examples/parametric/plot_observed_sed.py
+++ b/examples/parametric/plot_observed_sed.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
         for f in ["F090W", "F115W", "F150W", "F200W", "F277W", "F356W", "F444W"]
     ]  # define a list of filter codes
     filter_codes += [f"JWST/MIRI.{f}" for f in ["F770W"]]
-    fc = FilterCollection(filter_codes)
+    fc = FilterCollection(filter_codes, new_lam=grid.lam)
 
     # define the parameters of the star formation and metal enrichment
     # histories

--- a/src/synthesizer/base_galaxy.py
+++ b/src/synthesizer/base_galaxy.py
@@ -6,6 +6,8 @@ only contains common attributes and methods to reduce boilerplate.
 import numpy as np
 import matplotlib.pyplot as plt
 
+from synthesizer import exceptions
+from synthesizer.igm import Inoue14
 from synthesizer.sed import Sed, plot_spectra, plot_observed_spectra
 
 
@@ -189,6 +191,56 @@ class BaseGalaxy:
         """
 
         return self.A(1500.0)
+
+    def get_observed_spectra(self, cosmo, igm=Inoue14):
+        """
+        Calculate the observed spectra for all Sed objects within this galaxy.
+
+        This will run Sed.get_fnu(...) and populate Sed.fnu (and sed.obslam
+        and sed.obsnu) for all spectra in:
+            - Galaxy.spectra
+            - Galaxy.stars.spectra
+            - Galaxy.gas.spectra (WIP)
+            - Galaxy.black_holes.spectra (WIP)
+
+        Args:
+            cosmo (astropy.cosmology.Cosmology)
+                The cosmology object containing the cosmological model used
+                to calculate the luminosity distance.
+            igm (igm)
+                The object describing the intergalactic medium (defaults to
+                Inoue14).
+
+        Raises:
+
+        """
+
+        # Ensure we have a redshift
+        if self.redshift is None:
+            raise exceptions.MissingAttribute(
+                "This Galaxy has no redshift! Fluxes can't be"
+                " calculated without one."
+            )
+
+        # Loop over all combined spectra
+        for sed in self.spectra.values():
+            # Calculate the observed spectra
+            sed.get_fnu(
+                cosmo=cosmo,
+                z=self.redshift,
+                igm=igm,
+            )
+
+        # Loop over all stellar spectra
+        for sed in self.spectra.values():
+            # Calculate the observed spectra
+            sed.get_fnu(
+                cosmo=cosmo,
+                z=self.redshift,
+                igm=igm,
+            )
+
+        # TODO: Once implemented do this for gas and black holes too
 
     def plot_spectra(
         self,

--- a/src/synthesizer/base_galaxy.py
+++ b/src/synthesizer/base_galaxy.py
@@ -232,7 +232,7 @@ class BaseGalaxy:
             )
 
         # Loop over all stellar spectra
-        for sed in self.spectra.values():
+        for sed in self.stars.spectra.values():
             # Calculate the observed spectra
             sed.get_fnu(
                 cosmo=cosmo,

--- a/src/synthesizer/exceptions.py
+++ b/src/synthesizer/exceptions.py
@@ -227,3 +227,21 @@ class UnrecognisedOption(Exception):
         if self.message:
             return "{0} ".format(self.message)
         return "Unrecognised option."
+
+
+class MissingAttribute(Exception):
+    """
+    Generic exception class for when a required attribute is missing on an
+    object.
+    """
+
+    def __init__(self, *args):
+        if args:
+            self.message = args[0]
+        else:
+            self.message = None
+
+    def __str__(self):
+        if self.message:
+            return "{0} ".format(self.message)
+        return "Missing attribute"


### PR DESCRIPTION
This PR adds the ability to calculate all observed spectra on a galaxy (`get_observed_spectra`) for both combined and component spectra (gas and black holes need to be included once implemented).

It also introduces a `MissingAttribute` error class to be used when an operation can't be performed because it requires an attribute which is `None`.

Closes #416 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
