### PR TITLE
Fixed the bulge in composite galaxy docs

### DIFF
--- a/docs/source/parametric/generate_composite_galaxy.ipynb
+++ b/docs/source/parametric/generate_composite_galaxy.ipynb
@@ -136,7 +136,7 @@
    "source": [
     "sfh_p = {'duration': 10 * Myr}\n",
     "Z_p = {'log10metallicity': -2.0}  # can also use linear metallicity e.g. {'Z': 0.01}\n",
-    "stellar_mass = 10 ** 8.5"
+    "stellar_mass = 10 ** 9"
    ]
   },
   {
@@ -245,10 +245,10 @@
    "outputs": [],
    "source": [
     "# Define bulge morphology\n",
-    "morph = Sersic2D(r_eff_kpc=1. * kpc, n=4.)\n",
+    "morph = Sersic2D(r_eff_kpc=0.5 * kpc, n=4.)\n",
     "\n",
     "# Define the parameters of the star formation and metal enrichment histories\n",
-    "stellar_mass = 1E10\n",
+    "stellar_mass = 10 ** 8.5\n",
     "stars = Stars(\n",
     "    grid.log10age, grid.metallicity, instant_sf=10. * Myr, instant_metallicity=0.01, morphology=morph,\n",
     "    initial_mass=stellar_mass)\n",

--- a/docs/source/parametric/generate_composite_galaxy.ipynb
+++ b/docs/source/parametric/generate_composite_galaxy.ipynb
@@ -249,7 +249,7 @@
     "\n",
     "# Define the parameters of the star formation and metal enrichment histories\n",
     "stellar_mass = 1E10\n",
-    "sfzh = Stars(\n",
+    "stars = Stars(\n",
     "    grid.log10age, grid.metallicity, instant_sf=10. * Myr, instant_metallicity=0.01, morphology=morph,\n",
     "    initial_mass=stellar_mass)\n",
     "\n",


### PR DESCRIPTION
Instead of `stars` the bulge stars object was accidentally named `sfzh` from the old version resulting in the disk being plotted twice. This is now fixed with some extra parameter tweaking for a "pleasing" result.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
