### PR TITLE
Plot keywords in component plot method

### DIFF
--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -991,6 +991,7 @@ class StarsComponent:
         ylimits=(),
         xlimits=(),
         figsize=(3.5, 5),
+        **kwargs
     ):
         """
         Plots either specific spectra (specified via spectra_to_plot) or all
@@ -1014,6 +1015,8 @@ class StarsComponent:
                 limits are found based on the ylimits.
             figsize (tuple)
                 Tuple with size 2 defining the figure size.
+            kwargs (dict)
+                arguments to the `sed.plot_spectra` method called from this wrapper
 
         Returns:
             fig (matplotlib.pyplot.figure)
@@ -1037,4 +1040,5 @@ class StarsComponent:
             xlimits=xlimits,
             figsize=figsize,
             draw_legend=isinstance(spectra, dict),
+            **kwargs
         )

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -1150,7 +1150,7 @@ def plot_spectra(
 
         # Don't draw a legend if not label given
         if label is None and draw_legend:
-            print("No label given, we will not draw a legened")
+            print("No label given, we will not draw a legend")
             draw_legend = False
 
     # If we don't already have a figure, make one


### PR DESCRIPTION
added a `kwargs` argument to the stellar component `plot_spectra` method that is passed to the sed `plot_spectra` method, to provide more control.

- also fixed a small typo in sed.py

## Issue Type
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]()
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [] I have made corresponding changes to the documentation
- [] My changes generate no pep8 errors
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
