### PR TITLE
Simplify the arguments for parametric.Stars

### DIFF
--- a/docs/source/galaxies/galaxy_obj.ipynb
+++ b/docs/source/galaxies/galaxy_obj.ipynb
@@ -46,7 +46,7 @@
     "sfh = SFH.Constant(duration=100 * Myr)\n",
     "\n",
     "# Initialise the parametric Stars object\n",
-    "param_stars = ParametricStars(grid.log10age, grid.metallicity, sf_hist_func=sfh, metal_dist_func=zh, initial_mass=10**9)\n",
+    "param_stars = ParametricStars(grid.log10age, grid.metallicity, sf_hist=sfh, metal_dist=zh, initial_mass=10**9)\n",
     "\n",
     "# Define the number of stellar particles we want\n",
     "n = 10000\n",

--- a/docs/source/imaging/parametric_imaging.ipynb
+++ b/docs/source/imaging/parametric_imaging.ipynb
@@ -145,7 +145,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stars = Stars(grid.log10age, grid.metallicity, sf_hist_func=sfh, metal_dist_func=metal_dist,\n",
+    "stars = Stars(grid.log10age, grid.metallicity, sf_hist=sfh, metal_dist=metal_dist,\n",
     "              morphology=morph, initial_mass=10**9)\n",
     "print(stars)"
    ]
@@ -307,7 +307,7 @@
     "print(\"Morphology computed, took:\", time.time() - morph_start)\n",
     "\n",
     "# Create the Stars object\n",
-    "stars = Stars(grid.log10age, grid.metallicity, sf_hist_func=sfh, metal_dist_func=metal_dist,\n",
+    "stars = Stars(grid.log10age, grid.metallicity, sf_hist=sfh, metal_dist=metal_dist,\n",
     "              morphology=morph, initial_mass=10**9.5)\n",
     "print(stars)\n",
     "\n",

--- a/docs/source/parametric/generate_composite_galaxy.ipynb
+++ b/docs/source/parametric/generate_composite_galaxy.ipynb
@@ -176,7 +176,7 @@
    "outputs": [],
    "source": [
     "stars = Stars(\n",
-    "    grid.log10age, grid.metallicity, sf_hist_func=sfh, metal_dist_func=metal_dist, initial_mass=stellar_mass, morphology=morph\n",
+    "    grid.log10age, grid.metallicity, sf_hist=sfh, metal_dist=metal_dist, initial_mass=stellar_mass, morphology=morph\n",
     ")"
    ]
   },
@@ -249,8 +249,8 @@
     "\n",
     "# Define the parameters of the star formation and metal enrichment histories\n",
     "stellar_mass = 1E10\n",
-    "sfzh = Stars(\n",
-    "    grid.log10age, grid.metallicity, instant_sf=10. * Myr, instant_metallicity=0.01, morphology=morph,\n",
+    "stars = Stars(\n",
+    "    grid.log10age, grid.metallicity, sf_hist=10. * Myr, metal_dist=0.01, morphology=morph,\n",
     "    initial_mass=stellar_mass)\n",
     "\n",
     "# Get galaxy object\n",

--- a/docs/source/parametric/generate_lines.ipynb
+++ b/docs/source/parametric/generate_lines.ipynb
@@ -62,7 +62,7 @@
     "metal_dist = ZDist.DeltaConstant(log10metallicity=-2.0)  # constant metallicity\n",
     "\n",
     "# get the 2D star formation and metal enrichment history for the given SPS grid. This is (age, Z).\n",
-    "stars = Stars(grid.log10age, grid.metallicity, sf_hist_func=sfh, metal_dist_func=metal_dist, initial_mass=10**8.5)\n",
+    "stars = Stars(grid.log10age, grid.metallicity, sf_hist=sfh, metal_dist=metal_dist, initial_mass=10**8.5)\n",
     "\n",
     "# create the Galaxy object\n",
     "galaxy = Galaxy(stars)\n",

--- a/docs/source/parametric/generate_sed.ipynb
+++ b/docs/source/parametric/generate_sed.ipynb
@@ -67,7 +67,7 @@
     "metal_dist = ZDist.DeltaConstant(log10metallicity=-2.0)  # constant metallicity\n",
     "\n",
     "# get the 2D star formation and metal enrichment history for the given SPS grid. This is (age, Z).\n",
-    "stars = Stars(grid.log10age, grid.metallicity, sf_hist_func=sfh, metal_dist_func=metal_dist, initial_mass=10 ** 8)\n",
+    "stars = Stars(grid.log10age, grid.metallicity, sf_hist=sfh, metal_dist=metal_dist, initial_mass=10 ** 8)\n",
     "print(stars)"
    ]
   },

--- a/docs/source/parametric/make_stars.ipynb
+++ b/docs/source/parametric/make_stars.ipynb
@@ -62,7 +62,7 @@
     "metallicities = 10**log10metallicities\n",
     "\n",
     "# Get the instantaneous Stars\n",
-    "inst_stars = Stars(log10ages, metallicities, instant_sf=100 * Myr, instant_metallicity=10**-3, initial_mass=10 ** 9)"
+    "inst_stars = Stars(log10ages, metallicities, sf_hist=100 * Myr, metal_dist=10**-3, initial_mass=10 ** 9)"
    ]
   },
   {
@@ -171,7 +171,7 @@
     "print(sfh)\n",
     "\n",
     "# Create the Stars object\n",
-    "const_stars = Stars(log10ages, metallicities, sf_hist_func=sfh, metal_dist_func=metal_dist, initial_mass=10**9)\n",
+    "const_stars = Stars(log10ages, metallicities, sf_hist=sfh, metal_dist=metal_dist, initial_mass=10**9)\n",
     "print(const_stars)\n",
     "fig, ax = const_stars.plot_sfzh(show=True)"
    ]
@@ -200,7 +200,7 @@
     "print(sfh)\n",
     "\n",
     "# Create the Stars object\n",
-    "exp_stars = Stars(log10ages, metallicities, sf_hist_func=sfh, metal_dist_func=metal_dist, initial_mass=10**9.5)\n",
+    "exp_stars = Stars(log10ages, metallicities, sf_hist=sfh, metal_dist=metal_dist, initial_mass=10**9.5)\n",
     "print(exp_stars)\n",
     "fig, ax = exp_stars.plot_sfzh(show=True)"
    ]
@@ -225,7 +225,7 @@
     "print(sfh)\n",
     "\n",
     "# Create the Stars object\n",
-    "logn_stars = Stars(log10ages, metallicities, sf_hist_func=sfh, instant_metallicity=0.005, initial_mass=10**9)\n",
+    "logn_stars = Stars(log10ages, metallicities, sf_hist=sfh, metal_dist=0.005, initial_mass=10**9)\n",
     "print(logn_stars)\n",
     "fig, ax = logn_stars.plot_sfzh(show=True)"
    ]
@@ -359,7 +359,7 @@
     "print(sfh)\n",
     "\n",
     "# Create the Stars object\n",
-    "custom_stars = Stars(log10ages, metallicities, sf_hist_func=sfh, metal_dist_func=metal_dist, initial_mass=10**9)\n",
+    "custom_stars = Stars(log10ages, metallicities, sf_hist=sfh, metal_dist=metal_dist, initial_mass=10**9)\n",
     "print(custom_stars)\n",
     "fig, ax = custom_stars.plot_sfzh(show=True)\n",
     "\n"

--- a/examples/general/plot_photometry.py
+++ b/examples/general/plot_photometry.py
@@ -51,9 +51,9 @@ if __name__ == "__main__":
     stars = Stars(
         grid.log10age,
         grid.metallicity,
-        sf_hist_func=sfh,
-        metal_dist_func=metal_dist,
-        initial_mass=stellar_mass
+        sf_hist=sfh,
+        metal_dist=metal_dist,
+        initial_mass=stellar_mass,
     )
 
     # create a galaxy object
@@ -78,7 +78,9 @@ if __name__ == "__main__":
     seds = {}
     for z in zs:
         # Generate spectra using pacman model (complex)
-        seds[z] = galaxy.stars.get_spectra_pacman(grid, fesc=0.5, fesc_LyA=0.5, tau_v=0.1)
+        seds[z] = galaxy.stars.get_spectra_pacman(
+            grid, fesc=0.5, fesc_LyA=0.5, tau_v=0.1
+        )
 
         # Generate observed frame spectra
         seds[z].get_fnu(cosmo, z, igm=Madau96)

--- a/examples/imaging/image_addition.py
+++ b/examples/imaging/image_addition.py
@@ -36,10 +36,10 @@ stellar_mass = 1e10
 stars = Stars(
     grid.log10age,
     grid.metallicity,
-    instant_sf=10.,
-    instant_metallicity=0.01,
+    metal_dist=10.0,
+    metal_dist=0.01,
     initial_mass=stellar_mass,
-    morphology=morph
+    morphology=morph,
 )
 
 # Get galaxy object

--- a/examples/parametric/generate_lines.py
+++ b/examples/parametric/generate_lines.py
@@ -27,18 +27,16 @@ if __name__ == "__main__":
     grid_dir = "../../tests/test_grid/"
 
     # open the grid
-    grid = Grid(grid_name, grid_dir=grid_dir, read_spectra=False, 
-                read_lines=True)
+    grid = Grid(grid_name, grid_dir=grid_dir, read_spectra=False, read_lines=True)
 
     # define the functional form of the star formation and metal enrichment
     # histories
     sfh = SFH.Constant(duration=100 * Myr)
     metal_dist = ZDist.DeltaConstant(log10metallicity=-2.0)
 
-    # get the 2D star formation and metal enrichment history for the given SPS 
+    # get the 2D star formation and metal enrichment history for the given SPS
     # grid and print summary.
-    stars = Stars(grid.log10age, grid.metallicity, sf_hist_func=sfh,
-                 metal_dist_func=metal_dist)
+    stars = Stars(grid.log10age, grid.metallicity, sf_hist=sfh, metal_dist=metal_dist)
     print(stars)
 
     # create the Galaxy object and print a summary

--- a/examples/parametric/plot_create_image.py
+++ b/examples/parametric/plot_create_image.py
@@ -42,8 +42,8 @@ if __name__ == "__main__":
     sfzh = Stars(
         grid.log10age,
         grid.metallicity,
-        sf_hist_func=sfh,
-        metal_dist_func=metal_dist,
+        sf_hist=sfh,
+        metal_dist=metal_dist,
         initial_mass=10**9,
         morphology=morph,
     )

--- a/examples/parametric/plot_equivalent_width.py
+++ b/examples/parametric/plot_equivalent_width.py
@@ -32,9 +32,39 @@ def set_index():
     """
 
     index = [1370, 1400, 1425, 1460, 1501, 1533, 1550, 1719, 1853]
-    index_window = [[1360, 1380], [1385, 1410], [1413, 1435], [1450, 1470], [1496, 1506], [1530, 1537], [1530, 1560], [1705, 1729], [1838, 1858]]
-    blue_window = [[1345, 1354], [1345, 1354], [1345, 1354], [1436, 1447], [1482, 1491], [1482, 1491], [1482, 1491], [1675, 1684], [1797, 1807]]
-    red_window = [[1436, 1447], [1436, 1447], [1436, 1447], [1482, 1491], [1583, 1593], [1583, 1593], [1583, 1593], [1751, 1761], [1871, 1883]]
+    index_window = [
+        [1360, 1380],
+        [1385, 1410],
+        [1413, 1435],
+        [1450, 1470],
+        [1496, 1506],
+        [1530, 1537],
+        [1530, 1560],
+        [1705, 1729],
+        [1838, 1858],
+    ]
+    blue_window = [
+        [1345, 1354],
+        [1345, 1354],
+        [1345, 1354],
+        [1436, 1447],
+        [1482, 1491],
+        [1482, 1491],
+        [1482, 1491],
+        [1675, 1684],
+        [1797, 1807],
+    ]
+    red_window = [
+        [1436, 1447],
+        [1436, 1447],
+        [1436, 1447],
+        [1482, 1491],
+        [1583, 1593],
+        [1583, 1593],
+        [1583, 1593],
+        [1751, 1761],
+        [1871, 1883],
+    ]
 
     return index, index_window, blue_window, red_window
 
@@ -57,7 +87,7 @@ def get_ew(index, feature, blue, red, Z, smass, grid, EqW, mode):
     Raises:
         ValueError: If mode is invalid.
     """
-    
+
     sfh_p = {"duration": 100 * Myr}
 
     Z_p = {"metallicity": Z}  # can also use linear metallicity e.g. {'Z': 0.01}
@@ -75,9 +105,9 @@ def get_ew(index, feature, blue, red, Z, smass, grid, EqW, mode):
     sfzh = Stars(
         grid.log10age,
         grid.metallicity,
-        sf_hist_func=sfh,
-        metal_dist_func=metal_dist,
-        initial_mass=stellar_mass
+        sf_hist=sfh,
+        metal_dist=metal_dist,
+        initial_mass=stellar_mass,
     )
 
     # --- create a galaxy object
@@ -107,7 +137,7 @@ def equivalent_width(grids, uv_index, index_window, blue_window, red_window):
     Returns:
         None
     """
-    
+
     # -- Calculate the equivalent width for each defined index
     for i, index in enumerate(uv_index):
         grid = Grid(grids, grid_dir=grid_dir)

--- a/examples/parametric/plot_observed_sed.py
+++ b/examples/parametric/plot_observed_sed.py
@@ -54,8 +54,8 @@ if __name__ == "__main__":
     stars = Stars(
         grid.log10age,
         grid.metallicity,
-        sf_hist_func=sfh,
-        metal_dist_func=metal_dist,
+        sf_hist=sfh,
+        metal_dist=metal_dist,
         initial_mass=stellar_mass,
     )
 

--- a/examples/parametric/plot_sed.py
+++ b/examples/parametric/plot_sed.py
@@ -44,8 +44,8 @@ if __name__ == "__main__":
     stars = Stars(
         grid.log10age,
         grid.metallicity,
-        sf_hist_func=sfh,
-        metal_dist_func=metal_dist,
+        sf_hist=sfh,
+        metal_dist=metal_dist,
         initial_mass=stellar_mass,
     )
 

--- a/examples/particle/plot_compare_parametric_particle.py
+++ b/examples/particle/plot_compare_parametric_particle.py
@@ -39,10 +39,7 @@ metal_dist = ZDist.DeltaConstant(**Z_p)
 sfh_p = {"duration": 100 * Myr}
 sfh = SFH.Constant(**sfh_p)  # constant star formation
 sfzh = ParametricStars(
-    grid.log10age,
-    grid.metallicity,
-    sf_hist_func=sfh,
-    metal_dist_func=metal_dist
+    grid.log10age, grid.metallicity, sf_hist=sfh, metal_dist=metal_dist
 )
 
 # --------------------------------------------
@@ -59,7 +56,7 @@ plt.plot(
 # --------------------------------------------
 # CREATE PARTICLE SED
 
-for N in [1, 10, 100]: # , 1000]:
+for N in [1, 10, 100]:  # , 1000]:
     # --- create stars object
     stars = sample_sfhz(sfzh.sfzh, sfzh.log10ages, sfzh.log10metallicities, N)
     # ensure that the total mass = 1 irrespective of N. This can be also acheived by setting the mass of the star particles in sample_sfhz but this will be easier most of the time.

--- a/examples/particle/plot_create_sampled_sed.py
+++ b/examples/particle/plot_create_sampled_sed.py
@@ -32,12 +32,7 @@ metal_dist = ZDist.DeltaConstant(**Z_p)
 
 sfh_p = {"duration": 100 * Myr}
 sfh = SFH.Constant(**sfh_p)  # constant star formation
-sfzh = ParametricStars(
-    log10ages,
-    metallicities,
-    sf_hist_func=sfh,
-    metal_dist_func=metal_dist
-)
+sfzh = ParametricStars(log10ages, metallicities, sf_hist=sfh, metal_dist=metal_dist)
 print(sfzh)
 # sfzh.plot()
 

--- a/examples/particle/plot_get_los_attenutation.py
+++ b/examples/particle/plot_get_los_attenutation.py
@@ -54,12 +54,12 @@ mass = 10**10
 param_stars = ParametricStars(
     log10ages,
     metallicities,
-    sf_hist_func=sfh,
-    metal_dist_func=metal_dist,
+    sf_hist=sfh,
+    metal_dist=metal_dist,
     initial_mass=mass,
 )
 
-for n in [10, 100]: # , 1000, 10000]:
+for n in [10, 100]:  # , 1000, 10000]:
     xs = []
     loop_ys = []
     tree_ys = []

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -13,7 +13,7 @@ Example usage:
 """
 import numpy as np
 from scipy import integrate
-from unyt import yr, unyt_quantity
+from unyt import unyt_quantity, unyt_array
 
 
 import matplotlib.pyplot as plt
@@ -24,7 +24,8 @@ from synthesizer.components import StarsComponent
 from synthesizer.line import Line
 from synthesizer.stats import weighted_median, weighted_mean
 from synthesizer.plt import single_histxy, mlabel
-from synthesizer.parametric import SFH, ZDist
+from synthesizer.parametric.sf_hist import Common as SFHCommon
+from synthesizer.parametric.metal_dist import Common as ZDistCommon
 from synthesizer.units import Quantity
 
 
@@ -129,14 +130,14 @@ class Stars(StarsComponent):
             sfzh (array-like, float)
                 An array describing the binned SFZH. If provided all following
                 arguments are ignored.
-            sf_hist (float/array-like, float/SFH.*)
+            sf_hist (float/unyt_quantity/array-like, float/SFH.*)
                 Either:
                     - An age at which to compute an instantaneous SFH, i.e. all
                       stellar mass populating a single SFH bin.
                     - An array describing the star formation history.
                     -  An instance of one of the child classes of SFH. This
                        will be used to calculate an array describing the SFH.
-            metal_dist (float/array-like, float/ZDist.*)
+            metal_dist (float/unyt_quantity/array-like, float/ZDist.*)
                 Either:
                     - A metallicity at which to compute an instantaneous
                       ZH, i.e. all stellar mass populating a single Z bin.
@@ -162,15 +163,15 @@ class Stars(StarsComponent):
         ]
 
         # Store the SFH we've been given, this is either...
-        if issubclass(sf_hist, SFH.Common):
+        if issubclass(type(sf_hist), SFHCommon):
             self.sf_hist_func = sf_hist  # a SFH function
             self.sf_hist = None
             instant_sf = None
-        elif isinstance(sf_hist, float):
+        elif isinstance(sf_hist, (unyt_quantity, float)):
             instant_sf = sf_hist  # an instantaneous SFH
             self.sf_hist_func = None
             self.sf_hist = None
-        elif isinstance(sf_hist, np.ndarray):
+        elif isinstance(sf_hist, (unyt_array, np.ndarray)):
             self.sf_hist = sf_hist  # a numpy array
             self.sf_hist_func = None
             instant_sf = None
@@ -186,15 +187,15 @@ class Stars(StarsComponent):
             )
 
         # Store the metallicity distribution we've been given, this is either...
-        if issubclass(metal_dist, ZDist.Common):
+        if issubclass(type(metal_dist), ZDistCommon):
             self.metal_dist_func = metal_dist  # a ZDist function
             self.metal_dist = None
             instant_metallicity = None
-        elif isinstance(metal_dist, float):
+        elif isinstance(metal_dist, (unyt_quantity, float)):
             instant_metallicity = metal_dist  # an instantaneous SFH
             self.metal_dist_func = None
             self.metal_dist = None
-        elif isinstance(metal_dist, np.ndarray):
+        elif isinstance(metal_dist, (unyt_array, np.ndarray)):
             self.metal_dist = metal_dist  # a numpy array
             self.metal_dist_func = None
             instant_metallicity = None

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -24,6 +24,7 @@ from synthesizer.components import StarsComponent
 from synthesizer.line import Line
 from synthesizer.stats import weighted_median, weighted_mean
 from synthesizer.plt import single_histxy, mlabel
+from synthesizer.parametric import SFH, ZDist
 from synthesizer.units import Quantity
 
 
@@ -160,17 +161,53 @@ class Stars(StarsComponent):
             self.log10metallicities[-1],
         ]
 
-        # Store the function used to make the star formation history if given
-        self.sf_hist_func = sf_hist_func
+        # Store the SFH we've been given, this is either...
+        if issubclass(sf_hist, SFH.Common):
+            self.sf_hist_func = sf_hist  # a SFH function
+            self.sf_hist = None
+            instant_sf = None
+        elif isinstance(sf_hist, float):
+            instant_sf = sf_hist  # an instantaneous SFH
+            self.sf_hist_func = None
+            self.sf_hist = None
+        elif isinstance(sf_hist, np.ndarray):
+            self.sf_hist = sf_hist  # a numpy array
+            self.sf_hist_func = None
+            instant_sf = None
+        elif sf_hist is None:
+            self.sf_hist = None  # we must have been passed a SFZH
+            self.sf_hist_func = None
+            instant_sf = None
+        else:
+            raise exceptions.InconsistentArguments(
+                f"Unrecognised sf_hist type ({type(sf_hist)}! This should be"
+                " either a float, an instance of a SFH function from the "
+                "SFH module, or a single float."
+            )
 
-        # Store the function used to make the metallicity history if given
-        self.metal_dist_func = metal_dist_func
-
-        # Store the SFH array (if None recalculated below)
-        self.sf_hist = sf_hist
-
-        # Store the ZH array (if None recalculated below)
-        self.metal_dist = metal_dist
+        # Store the metallicity distribution we've been given, this is either...
+        if issubclass(metal_dist, ZDist.Common):
+            self.metal_dist_func = metal_dist  # a ZDist function
+            self.metal_dist = None
+            instant_metallicity = None
+        elif isinstance(metal_dist, float):
+            instant_metallicity = metal_dist  # an instantaneous SFH
+            self.metal_dist_func = None
+            self.metal_dist = None
+        elif isinstance(metal_dist, np.ndarray):
+            self.metal_dist = metal_dist  # a numpy array
+            self.metal_dist_func = None
+            instant_metallicity = None
+        elif metal_dist is None:
+            self.metal_dist = None  # we must have been passed a SFZH
+            self.metal_dist_func = None
+            instant_metallicity = None
+        else:
+            raise exceptions.InconsistentArguments(
+                f"Unrecognised metal_dist type ({type(metal_dist)}! This "
+                "should be either a float, an instance of a ZDist function "
+                "from the ZDist module, or a single float."
+            )
 
         # Store the total initial stellar mass
         self.initial_mass = initial_mass

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -92,18 +92,14 @@ class Stars(StarsComponent):
     initial_mass = Quantity()
 
     def __init__(
-            self,
-            log10ages,
-            metallicities,
-            initial_mass=1.0,
-            morphology=None,
-            sfzh=None,
-            sf_hist=None,
-            metal_dist=None,
-            sf_hist_func=None,
-            metal_dist_func=None,
-            instant_sf=None,
-            instant_metallicity=None,
+        self,
+        log10ages,
+        metallicities,
+        initial_mass=1.0,
+        morphology=None,
+        sfzh=None,
+        sf_hist=None,
+        metal_dist=None,
     ):
         """
         Initialise the parametric stellar population.
@@ -132,28 +128,25 @@ class Stars(StarsComponent):
             sfzh (array-like, float)
                 An array describing the binned SFZH. If provided all following
                 arguments are ignored.
-            sf_hist (array-like, float)
-                An array describing the star formation history.
-            metal_dist (array-like, float)
-                An array describing the metallity distribution.
-            sf_hist_func (SFH.*)
-                An instance of one of the child classes of SFH. This will be
-                used to calculate sf_hist and takes precendence over a passed
-                sf_hist if both are present.
-            metal_dist_func (ZH.*)
-                An instance of one of the child classes of ZH. This will be
-                used to calculate metal_dist and takes precendence over a
-                passed metal_dist if both are present.
-            instant_sf (float)
-                An age at which to compute an instantaneous SFH, i.e. all
-                stellar mass populating a single SFH bin.
-            instant_metallicity (float)
-                A metallicity at which to compute an instantaneous ZH, i.e. all
-                stellar populating a single ZH bin.
+            sf_hist (float/array-like, float/SFH.*)
+                Either:
+                    - An age at which to compute an instantaneous SFH, i.e. all
+                      stellar mass populating a single SFH bin.
+                    - An array describing the star formation history.
+                    -  An instance of one of the child classes of SFH. This
+                       will be used to calculate an array describing the SFH.
+            metal_dist (float/array-like, float/ZDist.*)
+                Either:
+                    - A metallicity at which to compute an instantaneous
+                      ZH, i.e. all stellar mass populating a single Z bin.
+                    - An array describing the metallity distribution.
+                    - An instance of one of the child classes of ZH. This
+                      will be used to calculate an array describing the
+                      metallicity distribution.
         """
 
         # Instantiate the parent
-        StarsComponent.__init__(self, 10 ** log10ages, metallicities)
+        StarsComponent.__init__(self, 10**log10ages, metallicities)
 
         # Set the age grid properties
         self.log10ages = log10ages
@@ -185,7 +178,6 @@ class Stars(StarsComponent):
         # If we have been handed an explict SFZH grid we can ignore all the
         # calculation methods
         if sfzh is not None:
-
             # Store the SFZH grid
             self.sfzh = sfzh
 
@@ -196,7 +188,6 @@ class Stars(StarsComponent):
             self.metal_dist = np.sum(self.sfzh, axis=0)
 
         else:
-
             # Set up the array ready for the calculation
             self.sfzh = np.zeros((len(log10ages), len(metallicities)))
 
@@ -212,9 +203,7 @@ class Stars(StarsComponent):
             # Regular linearly
             self.metallicity_grid_type = "Z"
 
-        elif len(set(
-                self.log10metallicities[:-1] - self.log10metallicities[1:]
-        )) == 1:
+        elif len(set(self.log10metallicities[:-1] - self.log10metallicities[1:])) == 1:
             # Regular in logspace
             self.metallicity_grid_type = "log10Z"
 
@@ -244,7 +233,6 @@ class Stars(StarsComponent):
 
         # Handle the instantaneous SFH case
         if instant_sf is not None:
-
             # Create SFH array
             self.sf_hist = np.zeros(self.ages.size)
 
@@ -260,7 +248,6 @@ class Stars(StarsComponent):
 
         # Handle the instantaneous ZH case
         if instant_metallicity is not None:
-
             # Create SFH array
             self.metal_dist = np.zeros(self.metallicities.size)
 
@@ -270,7 +257,6 @@ class Stars(StarsComponent):
 
         # Calculate SFH from function if necessary
         if self.sf_hist_func is not None and self.sf_hist is None:
-
             # Set up SFH array
             self.sf_hist = np.zeros(self.ages.size)
 
@@ -284,7 +270,6 @@ class Stars(StarsComponent):
 
         # Calculate SFH from function if necessary
         if self.metal_dist_func is not None and self.metal_dist is None:
-
             # Set up SFH array
             self.metal_dist = np.zeros(self.metallicities.size)
 
@@ -368,9 +353,7 @@ class Stars(StarsComponent):
         sfzh = np.expand_dims(self.sfzh, axis=2)
 
         # Account for the SFZH mask in the non-zero indices
-        non_zero_inds = (
-            non_zero_inds[0][sfzh_mask], non_zero_inds[1][sfzh_mask]
-        )
+        non_zero_inds = (non_zero_inds[0][sfzh_mask], non_zero_inds[1][sfzh_mask])
 
         # Compute the spectra
         spectra = np.sum(
@@ -408,7 +391,6 @@ class Stars(StarsComponent):
 
         # If the line_id is a str denoting a single line
         if isinstance(line_id, str):
-
             # Get the grid information we need
             grid_line = grid.lines[line_id]
             wavelength = grid_line["wavelength"]
@@ -419,9 +401,7 @@ class Stars(StarsComponent):
             )
 
             # Continuum at line wavelength, erg/s/Hz
-            continuum = np.sum(
-                grid_line["continuum"] * self.sfzh, axis=(0, 1)
-            )
+            continuum = np.sum(grid_line["continuum"] * self.sfzh, axis=(0, 1))
 
             # NOTE: this is currently incorrect and should be made of the
             # separated nebular and stellar continuum emission
@@ -436,7 +416,6 @@ class Stars(StarsComponent):
 
         # Else if the line is list or tuple denoting a doublet (or higher)
         elif isinstance(line_id, (list, tuple)):
-
             # Set up containers for the line information
             luminosity = []
             continuum = []
@@ -452,16 +431,12 @@ class Stars(StarsComponent):
                 # Line luminosity erg/s
                 luminosity.append(
                     (1 - fesc)
-                    * np.sum(
-                        grid_line["luminosity"] * self.sfzh, axis=(0, 1)
-                    )
+                    * np.sum(grid_line["luminosity"] * self.sfzh, axis=(0, 1))
                 )
 
                 # Continuum at line wavelength, erg/s/Hz
                 continuum.append(
-                    np.sum(
-                        grid_line["continuum"] * self.sfzh, axis=(0, 1)
-                    )
+                    np.sum(grid_line["continuum"] * self.sfzh, axis=(0, 1))
                 )
 
         else:
@@ -520,8 +495,9 @@ class Stars(StarsComponent):
                 The other instance of Stars to add to this one.
         """
 
-        if (np.all(self.log10ages == other_stars.log10ages) and
-            np.all(self.metallicities == other_stars.metallicities)):
+        if np.all(self.log10ages == other_stars.log10ages) and np.all(
+            self.metallicities == other_stars.metallicities
+        ):
             new_sfzh = self.sfzh + other_stars.sfzh
 
         else:


### PR DESCRIPTION
Instead of arguments for each possible type of input to `Stars`, there is now only `sfzh` for providing SFZH arrays, and `sf_hist` and `metal_dist` which can be either instantaneous values, arrays, or function classes for defining the SFH and metallicity distribution respectively. 

Internally the same attributes for each case exist as before to make the parsing and production with each method simpler. This also signposts clearly what is stored in each attribute rather than having an attribute that can be multiple possible data types. 

All examples and docs have been updated.

Closes #420 (Noice!).

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
