### PR TITLE
Fix attenuation n18

### DIFF
--- a/examples/general/plot_dustcurves.py
+++ b/examples/general/plot_dustcurves.py
@@ -15,7 +15,7 @@ import cmasher as cmr
 models = [
     "PowerLaw",
     'Calzetti2000',
-    # "MW_N18",
+    "MW_N18",
     "GrainsWD01",
     "GrainsWD01",
     "GrainsWD01",
@@ -24,6 +24,7 @@ models = [
 params = [
     {"slope": -1.0},
     {'slope': 0., 'cent_lam': 0.2175, 'ampl': 1.26, 'gamma': 0.0356},
+    {},
     {"model": "MW"},
     {"model": "SMC"},
     {"model": "LMC"},

--- a/src/synthesizer/dust/attenuation.py
+++ b/src/synthesizer/dust/attenuation.py
@@ -7,6 +7,7 @@ from dust_extinction.grain_models import WD01
 
 from synthesizer import exceptions
 
+
 this_dir, this_filename = os.path.split(__file__)
 
 __all__ = ["PowerLaw", "MW_N18", "Calzetti2000", "GrainsWD01"]
@@ -218,7 +219,7 @@ class MW_N18(AttenuationLaw):
 
         description = "MW extinction curve from Desika"
         AttenuationLaw.__init__(self, description)
-        self.data = np.load(f"{this_dir}/data/MW_N18.npz")
+        self.data = np.load(f"{this_dir}/../data/MW_N18.npz")
         self.tau_lam_v = np.interp(
             5500.0, self.data.f.mw_df_lam[::-1], self.data.f.mw_df_chi[::-1]
         )


### PR DESCRIPTION
Fixes data directory for `npz` files for the Milky Way attenuation in Narayanan+18. also updates example script to plot these.

We should look into extracting the relevant data into plain text files, as npz files are a security risk.

## Issue Type
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]()
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
