### PR TITLE
Adds missing case for combining two 1D spectra

### DIFF
--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -156,6 +156,9 @@ class Sed:
                 new_lnu = np.array((new_lnu,))
             elif new_lnu.ndim > other_lnu.ndim:
                 other_lnu = np.array((other_lnu,))
+            elif new_lnu.ndim == other_lnu.ndim == 1:
+                new_lnu = np.array((new_lnu,))
+                other_lnu = np.array((other_lnu,))
 
             # Concatenate this lnu array
             new_lnu = np.concatenate((new_lnu, other_lnu))


### PR DESCRIPTION
DWISOTT. This case was previously missing!

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
