### PR TITLE
Fixed the particle imaging docs.

### DIFF
--- a/src/synthesizer/imaging/scene.py
+++ b/src/synthesizer/imaging/scene.py
@@ -548,10 +548,10 @@ class ParticleScene(Scene):
 
         # Calculate the centre if necessary
         if self.centre is None:
-            self.centre = np.mean(self._coordinates, axis=0) * self.coordinates.units
+            self.centre = np.mean(self.coordinates, axis=0)
 
         # Centre the coordinates
-        self._coordinates -= self._centre
+        self.coordinates -= self.centre
 
     def _get_pixel_pos(self):
         """

--- a/src/synthesizer/load_data/load_camels.py
+++ b/src/synthesizer/load_data/load_camels.py
@@ -24,7 +24,7 @@ def _load_CAMELS(
     g_hsml,
     star_forming,
     redshift,
-    dtm=0.3
+    dtm=0.3,
 ):
     """
     Load CAMELS galaxies into a galaxy object
@@ -78,24 +78,24 @@ def _load_CAMELS(
         galaxies[i].redshift = redshift
 
         galaxies[i].load_stars(
-            imasses[b:e],
-            ages[b:e],
+            imasses[b:e] * Msun,
+            ages[b:e] * yr,
             metals[b:e],
             s_oxygen=s_oxygen[b:e],
             s_hydrogen=s_hydrogen[b:e],
-            coordinates=coods[b:e, :],
-            current_masses=masses[b:e],
+            coordinates=coods[b:e, :] * kpc,
+            current_masses=masses[b:e] * Msun,
             smoothing_lengths=s_hsml[b:e] * kpc,
         )
 
     begin, end = get_len(lens[:, 0])
     for i, (b, e) in enumerate(zip(begin, end)):
         galaxies[i].load_gas(
-            coordinates=g_coods[b:e],
-            masses=g_masses[b:e],
+            coordinates=g_coods[b:e] * kpc,
+            masses=g_masses[b:e] * Msun,
             metals=g_metallicities[b:e],
             star_forming=star_forming[b:e],
-            smoothing_lengths=g_hsml[b:e],
+            smoothing_lengths=g_hsml[b:e] * kpc,
             dust_to_metal_ratio=dtm,
         )
 
@@ -109,7 +109,7 @@ def load_CAMELS_IllustrisTNG(
     fof_dir=None,
     verbose=False,
     dtm=0.3,
-    physical=True
+    physical=True,
 ):
     """
     Load CAMELS-IllustrisTNG galaxies
@@ -152,7 +152,7 @@ def load_CAMELS_IllustrisTNG(
         g_hsml = hf["PartType0/SubfindHsml"][:]
 
         scale_factor = hf["Header"].attrs["Time"]
-        redshift = 1. / scale_factor - 1
+        redshift = 1.0 / scale_factor - 1
         Om0 = hf["Header"].attrs["Omega0"]
         h = hf["Header"].attrs["HubbleParam"]
 
@@ -238,7 +238,7 @@ def load_CAMELS_Astrid(
     snap_name="snap_090.hdf5",
     fof_name="fof_subhalo_tab_090.hdf5",
     fof_dir=None,
-    dtm=0.3
+    dtm=0.3,
 ):
     """
     Load CAMELS-Astrid galaxies
@@ -316,7 +316,7 @@ def load_CAMELS_Astrid(
         g_metallicities=g_metals,
         g_hsml=g_hsml,
         star_forming=star_forming,
-        dtm=dtm
+        dtm=dtm,
     )
 
 
@@ -325,7 +325,7 @@ def load_CAMELS_Simba(
     snap_name="snap_033.hdf5",
     fof_name="fof_subhalo_tab_033.hdf5",
     fof_dir=None,
-    dtm=0.3
+    dtm=0.3,
 ):
     """
     Load CAMELS-SIMBA galaxies

--- a/src/synthesizer/load_data/load_flares.py
+++ b/src/synthesizer/load_data/load_flares.py
@@ -1,6 +1,8 @@
 import h5py
 import numpy as np
 
+from unyt import Msun, kpc, yr
+
 from ..particle.galaxy import Galaxy
 from synthesizer.load_data.utils import get_len
 
@@ -46,12 +48,12 @@ def load_FLARES(f, region, tag):
     for i, (b, e) in enumerate(zip(begin, end)):
         galaxies[i] = Galaxy()
         galaxies[i].load_stars(
-            mass[b:e],
-            ages[b:e],
+            mass[b:e] * Msun,
+            ages[b:e] * yr,
             metals[b:e],
             s_oxygen=s_oxygen[b:e],
             s_hydrogen=s_hydrogen[b:e],
-            coordinates=coods[b:e, :],
+            coordinates=coods[b:e, :] * kpc,
         )
 
     return galaxies

--- a/src/synthesizer/load_data/load_scsam.py
+++ b/src/synthesizer/load_data/load_scsam.py
@@ -8,6 +8,8 @@ import numpy as np
 from scipy.interpolate import RegularGridInterpolator as RGI
 from scipy.interpolate import NearestNDInterpolator as NNI
 
+from unyt import Msun, kpc, yr
+
 from synthesizer.parametric.stars import Stars as ParametricStars
 from synthesizer.parametric.galaxy import Galaxy as ParametricGalaxy
 from synthesizer.particle.stars import Stars as ParticleStars
@@ -183,7 +185,11 @@ def _load_SCSAM_particle_galaxy(SFH, age_lst, Z_lst, verbose=False):
         print("Generating SED...")
 
     # Create stars object
-    stars = ParticleStars(initial_masses=p_imass, ages=p_age, metallicities=p_Z)
+    stars = ParticleStars(
+        initial_masses=p_imass * Msun,
+        ages=p_age * yr,
+        metallicities=p_Z
+    )
 
     if verbose:
         print("Creating galaxy object...")

--- a/src/synthesizer/load_data/load_simba.py
+++ b/src/synthesizer/load_data/load_simba.py
@@ -2,6 +2,7 @@ import h5py
 import numpy as np
 
 from astropy.cosmology import FlatLambdaCDM
+from unyt import Msun, kpc, yr
 
 from ..particle.galaxy import Galaxy
 
@@ -97,13 +98,13 @@ def load_Simba(
         galaxies[i] = Galaxy()
 
         galaxies[i].load_stars(
-            imasses[b:e],
-            ages[b:e],
+            imasses[b:e] * Msun,
+            ages[b:e] * yr,
             metallicity[b:e],
             s_oxygen=s_oxygen[b:e],
             s_hydrogen=s_hydrogen[b:e],
-            coordinates=coods[b:e, :],
-            current_masses=masses[b:e],
+            coordinates=coods[b:e, :] * kpc,
+            current_masses=masses[b:e] * Msun,
         )
 
     # get the gas particle begin / end indices
@@ -113,12 +114,12 @@ def load_Simba(
 
     for i, (b, e) in enumerate(zip(begin, end)):
         galaxies[i].load_gas(
-            coordinates=g_coods[b:e],
-            masses=g_masses[b:e],
+            coordinates=g_coods[b:e] * kpc,
+            masses=g_masses[b:e] * Msun,
             metals=g_metals[b:e],
             star_forming=star_forming[b:e],
-            smoothing_lengths=g_hsml[b:e],
-            dust_masses=g_dustmass[b:e],
+            smoothing_lengths=g_hsml[b:e] * kpc,
+            dust_masses=g_dustmass[b:e] * Msun,
         )
 
     return galaxies

--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -607,7 +607,8 @@ class Galaxy(BaseGalaxy):
                 Only used for smoothed images.
             kernel_threshold (float)
                 The kernel's impact parameter threshold (by default 1).
-            Returns
+
+        Returns
         -------
         Image : array-like
             A 2D array containing the image.
@@ -624,8 +625,8 @@ class Galaxy(BaseGalaxy):
             fov=fov,
             sed=sed,
             filters=filters,
-            coordinates=self.stars.coordinates,
-            smoothing_lengths=self.stars.smoothing_lengths,
+            coordinates=self.stars._coordinates,
+            smoothing_lengths=self.stars._smoothing_lengths,
             pixel_values=pixel_values,
             rest_frame=rest_frame,
             redshift=self.redshift,
@@ -717,9 +718,9 @@ class Galaxy(BaseGalaxy):
         img = ParticleImage(
             resolution=resolution,
             fov=fov,
-            coordinates=self.stars.coordinates,
-            smoothing_lengths=self.stars.smoothing_lengths,
-            pixel_values=self.stars.current_masses,
+            coordinates=self.stars._coordinates,
+            smoothing_lengths=self.stars._smoothing_lengths,
+            pixel_values=self.stars._current_masses,
             redshift=self.redshift,
             cosmo=cosmo,
             kernel=kernel,
@@ -779,9 +780,9 @@ class Galaxy(BaseGalaxy):
         img = ParticleImage(
             resolution=resolution,
             fov=fov,
-            coordinates=self.gas.coordinates,
-            smoothing_lengths=self.gas.smoothing_lengths,
-            pixel_values=self.gas.masses,
+            coordinates=self.gas._coordinates,
+            smoothing_lengths=self.gas._smoothing_lengths,
+            pixel_values=self.gas._masses,
             redshift=self.redshift,
             cosmo=cosmo,
             kernel=kernel,
@@ -843,9 +844,9 @@ class Galaxy(BaseGalaxy):
         img = ParticleImage(
             resolution=resolution,
             fov=fov,
-            coordinates=self.stars.coordinates,
-            smoothing_lengths=self.stars.smoothing_lengths,
-            pixel_values=self.stars.ages * self.stars.initial_masses,
+            coordinates=self.stars._coordinates,
+            smoothing_lengths=self.stars._smoothing_lengths,
+            pixel_values=self.stars._ages * self.stars._initial_masses,
             redshift=self.redshift,
             cosmo=cosmo,
             kernel=kernel,
@@ -870,9 +871,9 @@ class Galaxy(BaseGalaxy):
         mass_img = ParticleImage(
             resolution=resolution,
             fov=fov,
-            coordinates=self.stars.coordinates,
-            smoothing_lengths=self.stars.smoothing_lengths,
-            pixel_values=self.stars.initial_masses,
+            coordinates=self.stars._coordinates,
+            smoothing_lengths=self.stars._smoothing_lengths,
+            pixel_values=self.stars._initial_masses,
             redshift=self.redshift,
             cosmo=cosmo,
             kernel=kernel,
@@ -932,9 +933,9 @@ class Galaxy(BaseGalaxy):
         img = ParticleImage(
             resolution=resolution,
             fov=fov,
-            coordinates=self.stars.coordinates,
-            smoothing_lengths=self.stars.smoothing_lengths,
-            pixel_values=self.stars.metallicities * self.stars.current_masses,
+            coordinates=self.stars._coordinates,
+            smoothing_lengths=self.stars._smoothing_lengths,
+            pixel_values=self.stars.metallicities * self.stars._current_masses,
             redshift=self.redshift,
             cosmo=cosmo,
             kernel=kernel,
@@ -1006,9 +1007,9 @@ class Galaxy(BaseGalaxy):
         img = ParticleImage(
             resolution=resolution,
             fov=fov,
-            coordinates=self.gas.coordinates,
-            smoothing_lengths=self.gas.smoothing_lengths,
-            pixel_values=self.gas.metallicities * self.gas.masses,
+            coordinates=self.gas._coordinates,
+            smoothing_lengths=self.gas._smoothing_lengths,
+            pixel_values=self.gas.metallicities * self.gas._masses,
             redshift=self.redshift,
             cosmo=cosmo,
             kernel=kernel,
@@ -1076,9 +1077,9 @@ class Galaxy(BaseGalaxy):
         img = ParticleImage(
             resolution=resolution,
             fov=fov,
-            coordinates=self.stars.coordinates,
-            smoothing_lengths=self.stars.smoothing_lengths,
-            pixel_values=self.stars.metallicities * self.stars.current_masses,
+            coordinates=self.stars._coordinates,
+            smoothing_lengths=self.stars._smoothing_lengths,
+            pixel_values=self.stars.metallicities * self.stars._current_masses,
             redshift=self.redshift,
             cosmo=cosmo,
             kernel=kernel,
@@ -1140,9 +1141,9 @@ class Galaxy(BaseGalaxy):
         img = ParticleImage(
             resolution=resolution,
             fov=fov,
-            coordinates=self.gas.coordinates,
-            smoothing_lengths=self.gas.smoothing_lengths,
-            pixel_values=self.gas.metallicities * self.gas.masses,
+            coordinates=self.gas._coordinates,
+            smoothing_lengths=self.gas._smoothing_lengths,
+            pixel_values=self.gas.metallicities * self.gas._masses,
             redshift=self.redshift,
             cosmo=cosmo,
             kernel=kernel,
@@ -1223,9 +1224,9 @@ class Galaxy(BaseGalaxy):
         img = ParticleImage(
             resolution=resolution,
             fov=fov,
-            coordinates=self.stars.coordinates[mask, :],
-            smoothing_lengths=self.stars.smoothing_lengths[mask],
-            pixel_values=self.stars.initial_masses[mask],
+            coordinates=self.stars._coordinates[mask, :],
+            smoothing_lengths=self.stars._smoothing_lengths[mask],
+            pixel_values=self.stars._initial_masses[mask],
             redshift=self.redshift,
             cosmo=cosmo,
             kernel=kernel,


### PR DESCRIPTION
Fixed the issue in the particle imaging documentation. For some reason the units I had added to automatically convert everything to the global system had been removed (I assume in the move). Thus the kpc units of the loaded data were assumed to be Mpc and the images failed completely.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
