### PR TITLE
Not including particles on the grid edges in grid checks

### DIFF
--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -383,8 +383,8 @@ class Stars(Particles, StarsComponent):
             # Check the fraction of particles outside of the grid (these will be
             # pinned to the edge of the grid) by finding those inside
             age_inside_mask = np.logical_and(
-                self.log10ages < grid.log10age[-1],
-                self.log10ages > grid.log10age[0],
+                self.log10ages <= grid.log10age[-1],
+                self.log10ages >= grid.log10age[0],
             )
             met_inside_mask = np.logical_and(
                 self.metallicities < grid.metallicity[-1],
@@ -559,8 +559,8 @@ class Stars(Particles, StarsComponent):
             # Check the fraction of particles outside of the grid (these will be
             # pinned to the edge of the grid) by finding those inside
             age_inside_mask = np.logical_and(
-                self.log10ages < grid.log10age[-1],
-                self.log10ages > grid.log10age[0],
+                self.log10ages <= grid.log10age[-1],
+                self.log10ages >= grid.log10age[0],
             )
             met_inside_mask = np.logical_and(
                 self.metallicities < grid.metallicity[-1],


### PR DESCRIPTION
Changed the logic to be greater than/less than or equal to.

Closes #432. 

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
