### PR TITLE
Fix and complete sanity check of particle spectra derivation

### DIFF
--- a/examples/particle/plot_compare_grid_assignment.py
+++ b/examples/particle/plot_compare_grid_assignment.py
@@ -1,0 +1,100 @@
+""" Compare SPS grid assignment methods
+
+This example compares a the cloud in cell (CIC) and nearest grid point (NGP)
+grid assignment methods. These methods dictate how mass is assigned to
+spectra in the SPS grids.
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+from unyt import Myr
+
+from synthesizer.grid import Grid
+from synthesizer.parametric import SFH, ZDist
+from synthesizer.parametric import Stars as ParametricStars
+from synthesizer.particle.stars import sample_sfhz
+from synthesizer.particle.galaxy import Galaxy as ParticleGalaxy
+
+
+# Define the grid
+grid_name = "test_grid"
+grid_dir = "../../tests/test_grid/"
+grid = Grid(grid_name, grid_dir=grid_dir)
+
+# Define the SFH and metallicity distribution
+Z_p = {"metallicity": 0.01}
+metal_dist = ZDist.DeltaConstant(**Z_p)
+sfh_p = {"duration": 100 * Myr}
+sfh = SFH.Constant(**sfh_p)
+
+# Define the parametric stars
+sfzh = ParametricStars(
+    grid.log10age,
+    grid.metallicity,
+    sf_hist_func=sfh,
+    metal_dist_func=metal_dist,
+    initial_mass=10**9,
+)
+
+# How many particles?
+nstar = 10**5
+
+# Get the stars object
+stars = sample_sfhz(
+    sfzh.sfzh,
+    sfzh.log10ages,
+    sfzh.log10metallicities,
+    nstar,
+    initial_mass=10**9 / nstar,
+)
+
+# Create galaxy object
+particle_galaxy = ParticleGalaxy(stars=stars)
+
+# Calculate the stars SEDs using both grid assignment schemes
+cic_sed = particle_galaxy.stars.get_spectra_incident(
+    grid,
+    grid_assignment_method="cic",
+)
+ngp_sed = particle_galaxy.stars.get_spectra_incident(
+    grid,
+    grid_assignment_method="ngp",
+)
+
+# Setup the plot
+fig = plt.figure()
+ax = fig.add_subplot(111)
+resi_ax = ax.twinx()
+ax.grid(True)
+
+resi_ax.semilogx(
+    ngp_sed.lam,
+    ngp_sed.lnu / cic_sed.lnu,
+    color="m",
+    linestyle="dotted",
+    label="Residual",
+    alpha=0.6,
+)
+ax.loglog(
+    cic_sed.lam,
+    cic_sed.lnu,
+    label="CIC",
+)
+ax.loglog(
+    ngp_sed.lam,
+    ngp_sed.lnu,
+    label="NGP",
+)
+
+
+resi_ax.set_ylabel("NGP / CIC")
+x_units = str(cic_sed.lam.units)
+y_units = str(cic_sed.lnu.units)
+ax.set_xlabel(r"$\lambda/[\mathrm{" + x_units + r"}]$")
+ax.set_ylabel(r"$L_{\nu}/[\mathrm{" + y_units + r"}]$")
+
+ax.legend()
+resi_ax.legend(loc="upper left")
+ax.set_xlim(10**2.0, 10**5.2)
+ax.set_ylim(10**25.0, 10**30.0)
+plt.show()

--- a/examples/particle/plot_compare_grid_assignment.py
+++ b/examples/particle/plot_compare_grid_assignment.py
@@ -31,8 +31,8 @@ sfh = SFH.Constant(**sfh_p)
 sfzh = ParametricStars(
     grid.log10age,
     grid.metallicity,
-    sf_hist_func=sfh,
-    metal_dist_func=metal_dist,
+    sf_hist=sfh,
+    metal_dist=metal_dist,
     initial_mass=10**9,
 )
 

--- a/examples/particle/plot_compare_parametric_particle.py
+++ b/examples/particle/plot_compare_parametric_particle.py
@@ -14,7 +14,6 @@ from synthesizer.grid import Grid
 from synthesizer.parametric import SFH, ZDist
 from synthesizer.parametric import Stars as ParametricStars
 from synthesizer.particle.stars import sample_sfhz
-from synthesizer.particle.stars import Stars
 from synthesizer.parametric.galaxy import Galaxy as ParametricGalaxy
 from synthesizer.particle.galaxy import Galaxy as ParticleGalaxy
 
@@ -42,7 +41,8 @@ sfzh = ParametricStars(
     grid.log10age,
     grid.metallicity,
     sf_hist_func=sfh,
-    metal_dist_func=metal_dist
+    metal_dist_func=metal_dist,
+    initial_mass=1,
 )
 
 # --------------------------------------------
@@ -59,7 +59,7 @@ plt.plot(
 # --------------------------------------------
 # CREATE PARTICLE SED
 
-for N in [1, 10, 100]: # , 1000]:
+for N in [1, 10, 100, 1000, 10000]:  # , 1000]:
     # --- create stars object
     stars = sample_sfhz(sfzh.sfzh, sfzh.log10ages, sfzh.log10metallicities, N)
     # ensure that the total mass = 1 irrespective of N. This can be also acheived by setting the mass of the star particles in sample_sfhz but this will be easier most of the time.
@@ -80,6 +80,6 @@ for N in [1, 10, 100]: # , 1000]:
 
 plt.legend()
 plt.xlim([2, 5])
-plt.ylim([10, 22])
+plt.ylim([18, 22])
 # plt.savefig(script_path + '/plots/compare_parametric_particle.png', dpi=200, bbox_inches='tight'); plt.close()
 plt.show()

--- a/examples/particle/plot_compare_parametric_particle.py
+++ b/examples/particle/plot_compare_parametric_particle.py
@@ -31,7 +31,10 @@ sfh = SFH.Constant(**sfh_p)
 
 # Define the parametric stars
 sfzh = ParametricStars(
-    grid.log10age, grid.metallicity, sf_hist=sfh, metal_dist=metal_dist
+    grid.log10age,
+    grid.metallicity,
+    sf_hist=sfh,
+    metal_dist=metal_dist,
     initial_mass=1,
 )
 

--- a/examples/particle/plot_compare_parametric_particle.py
+++ b/examples/particle/plot_compare_parametric_particle.py
@@ -48,14 +48,15 @@ plt.plot(
 
 
 # Compute the particle Sed for a range of particle samples
-for N in [1, 10, 100, 1000]:
+for nstar in [1, 10, 100, 1000]:
     # Get the stars object
-    stars = sample_sfhz(sfzh.sfzh, sfzh.log10ages, sfzh.log10metallicities, N)
-
-    # Ensure that the total mass = 1 irrespective of N. This can be also
-    # acheived by setting the mass of the star particles in sample_sfhz
-    # but this will be easier most of the time.
-    stars.renormalise_mass(1.0)
+    stars = sample_sfhz(
+        sfzh.sfzh,
+        sfzh.log10ages,
+        sfzh.log10metallicities,
+        nstar,
+        initial_mass=1 / nstar,
+    )
 
     # Create galaxy object
     particle_galaxy = ParticleGalaxy(stars=stars)
@@ -68,7 +69,7 @@ for N in [1, 10, 100, 1000]:
     plt.plot(
         np.log10(ngp_sed.lam),
         np.log10(ngp_sed.lnu),
-        label=f"particle (N={N})",
+        label=f"particle (N={nstar})",
     )
 
 

--- a/examples/particle/plot_single_star_test.py
+++ b/examples/particle/plot_single_star_test.py
@@ -19,8 +19,8 @@ grid = Grid(grid_name, grid_dir=grid_dir)
 stars = ParametricStars(
     grid.log10age,
     grid.metallicity,
-    instant_sf=1e7,
-    instant_metallicity=0.01,
+    sf_hist=1e7,
+    metal_dist=0.01,
     initial_mass=1,
 )
 

--- a/examples/particle/plot_single_star_test.py
+++ b/examples/particle/plot_single_star_test.py
@@ -2,6 +2,8 @@
 """
 import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib.colors import Normalize
+from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from synthesizer.grid import Grid
 from synthesizer.particle import Stars as ParticleStars
@@ -14,7 +16,7 @@ grid_dir = "../../tests/test_grid/"
 grid = Grid(grid_name, grid_dir=grid_dir)
 
 # Define the parametric stars
-sfzh = ParametricStars(
+stars = ParametricStars(
     grid.log10age,
     grid.metallicity,
     instant_sf=1e7,
@@ -22,18 +24,103 @@ sfzh = ParametricStars(
     initial_mass=1,
 )
 
+# Plot the SFZH
+stars.plot_sfzh()
+
 # Compute the parametric sed
 sed = stars.get_spectra_transmitted(grid)
-plt.plot(np.log10(sed.lam), np.log10(sed.lnu), label="parametric")
 
-
+# Create the particle stars object
 part_stars = ParticleStars(
     initial_masses=np.array([1.0]),
     ages=np.array([1e7]),
     metallicities=np.array([0.01]),
 )
-sed = part_stars.get_spectra_transmitted(grid)
-plt.plot(np.log10(sed.lam), np.log10(sed.lnu), label="particle")
+
+# Calculate the particle SFZH grid (equivalent to grid weights)
+part_sfzh = part_stars.get_sfzh(grid, grid_assignment_method="cic")
+
+# Plot the SFZH
+part_stars.plot_sfzh(grid, grid_assignment_method="cic")
+
+# Create the figure and axes for the comparison
+fig, ax = plt.subplots()
+ax.grid(True)
+
+# Plot the grid points
+x, y = np.meshgrid(grid.log10age, grid.metallicity)
+ax.scatter(
+    x.flatten(),
+    np.log10(y.flatten()),
+    marker=".",
+    color="grey",
+    alpha=0.3,
+)
+
+# Plot the stellar particle properties
+ax.scatter(
+    part_stars.log10ages,
+    part_stars.log10metallicities,
+    marker="*",
+    zorder=10,
+    color="gold",
+)
+
+# Plot the particle SFZH
+plt_part_sfzh = np.full_like(part_sfzh, np.nan)
+plt_part_sfzh[part_sfzh > 0] = part_sfzh[part_sfzh > 0]
+pcm2 = ax.pcolormesh(
+    grid.log10age,
+    np.log10(grid.metallicity),
+    plt_part_sfzh.T,
+    cmap="plasma",
+    norm=Normalize(vmin=np.min(part_sfzh[part_sfzh > 0]), vmax=1.0, clip=True),
+    alpha=0.8,
+)
+
+# Plot the parametric SFZH
+plt_para_sfzh = np.full_like(stars.sfzh, np.nan)
+plt_para_sfzh[stars.sfzh > 0] = stars.sfzh[stars.sfzh > 0]
+pcm1 = ax.pcolormesh(
+    grid.log10age,
+    np.log10(grid.metallicity),
+    plt_para_sfzh.T,
+    cmap="Greys_r",
+    alpha=0.8,
+    norm=Normalize(vmin=np.min(stars.sfzh[stars.sfzh > 0]), vmax=1.0, clip=True),
+)
+
+
+# Create colorbars on the right for each mesh
+divider = make_axes_locatable(ax)
+cax1 = divider.append_axes("right", size="5%", pad=0.1)
+cbar1 = fig.colorbar(pcm1, cax=cax1, label="Parametric SFZH")
+
+# Create colorbars on the top for each mesh
+cax2 = divider.append_axes("top", size="5%", pad=0.1)
+cbar2 = plt.colorbar(
+    pcm2,
+    cax=cax2,
+    orientation="horizontal",
+    label="Particle SFZH",
+    ticklocation="top",
+)
+
+# Label axes
+ax.set_xlabel(r"$\log_{10}(\mathrm{Age}/\mathrm{yr})$")
+ax.set_ylabel(r"$\log_{10}(Z)$")
+
+plt.show()
+
+part_sed = part_stars.get_spectra_transmitted(grid, grid_assignment_method="cic")
+plt.figure(2)
+plt.plot(np.log10(sed.lam), np.log10(sed.lnu), label="parametric")
+plt.plot(
+    np.log10(part_sed.lam),
+    np.log10(part_sed.lnu),
+    label="particle",
+    linestyle="--",
+)
 plt.legend()
 plt.xlim([2, 5])
 plt.ylim([18, 22])

--- a/examples/particle/plot_single_star_test.py
+++ b/examples/particle/plot_single_star_test.py
@@ -1,0 +1,40 @@
+""" A sanity check example for a single star in both parametric and particle
+"""
+import numpy as np
+import matplotlib.pyplot as plt
+
+from synthesizer.grid import Grid
+from synthesizer.particle import Stars as ParticleStars
+from synthesizer.parametric import Stars as ParametricStars
+
+
+# Define the grid
+grid_name = "test_grid"
+grid_dir = "../../tests/test_grid/"
+grid = Grid(grid_name, grid_dir=grid_dir)
+
+# Define the parametric stars
+sfzh = ParametricStars(
+    grid.log10age,
+    grid.metallicity,
+    instant_sf=1e7,
+    instant_metallicity=0.01,
+    initial_mass=1,
+)
+
+# Compute the parametric sed
+sed = stars.get_spectra_transmitted(grid)
+plt.plot(np.log10(sed.lam), np.log10(sed.lnu), label="parametric")
+
+
+part_stars = ParticleStars(
+    initial_masses=np.array([1.0]),
+    ages=np.array([1e7]),
+    metallicities=np.array([0.01]),
+)
+sed = part_stars.get_spectra_transmitted(grid)
+plt.plot(np.log10(sed.lam), np.log10(sed.lnu), label="particle")
+plt.legend()
+plt.xlim([2, 5])
+plt.ylim([18, 22])
+plt.show()

--- a/setup.py
+++ b/setup.py
@@ -121,6 +121,7 @@ class BuildExt(build_ext):
 src_files = {
     "synthesizer.extensions.integrated_spectra": "src/synthesizer/extensions/integrated_spectra.c",
     "synthesizer.extensions.particle_spectra": "src/synthesizer/extensions/particle_spectra.c",
+    "synthesizer.extensions.sfzh": "src/synthesizer/extensions/sfzh.c",
     "synthesizer.extensions.los": "src/synthesizer/extensions/los.c",
     "synthesizer.imaging.extensions.spectral_cube": "src/synthesizer/imaging/extensions/spectral_cube.c",
     "synthesizer.imaging.extensions.image": "src/synthesizer/imaging/extensions/image.c",

--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -100,6 +100,7 @@ class StarsComponent:
         fesc_LyA=1.0,
         young=False,
         old=False,
+        **kwargs,
     ):
         """
         Generate the line contribution spectra. This is only invoked if
@@ -120,6 +121,9 @@ class StarsComponent:
             old (bool, float):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
+            kwargs
+                Any keyword arguments which can be passed to
+                generate_lnu.
 
         Returns:
             numpy.ndarray
@@ -132,7 +136,11 @@ class StarsComponent:
         # Generate contribution of line emission alone and reduce the
         # contribution of Lyman-alpha
         linecont = self.generate_lnu(
-            grid, spectra_name="linecont", old=old, young=young
+            grid,
+            spectra_name="linecont",
+            old=old,
+            young=young,
+            **kwargs,
         )
 
         # Multiply by the Lyamn-continuum escape fraction
@@ -144,7 +152,14 @@ class StarsComponent:
 
         return linecont
 
-    def get_spectra_incident(self, grid, young=False, old=False, label=""):
+    def get_spectra_incident(
+        self,
+        grid,
+        young=False,
+        old=False,
+        label="",
+        **kwargs,
+    ):
         """
         Generate the incident (equivalent to pure stellar for stars) spectra
         using the provided Grid.
@@ -161,6 +176,9 @@ class StarsComponent:
             label (string)
                 A modifier for the spectra dictionary key such that the
                 key is label + "_incident".
+            kwargs
+                Any keyword arguments which can be passed to
+                generate_lnu.
 
         Returns:
             Sed
@@ -171,7 +189,13 @@ class StarsComponent:
         young, old = self.check_young_old_units(young, old)
 
         # Get the incident spectra
-        lnu = self.generate_lnu(grid, "incident", young=young, old=old)
+        lnu = self.generate_lnu(
+            grid,
+            "incident",
+            young=young,
+            old=old,
+            **kwargs,
+        )
 
         # Create the Sed object
         sed = Sed(grid.lam, lnu)
@@ -188,6 +212,7 @@ class StarsComponent:
         young=False,
         old=False,
         label="",
+        **kwargs,
     ):
         """
         Generate the transmitted spectra using the provided Grid. This is the
@@ -209,6 +234,9 @@ class StarsComponent:
             label (string)
                 A modifier for the spectra dictionary key such that the
                 key is label + "_transmitted".
+            kwargs
+                Any keyword arguments which can be passed to
+                generate_lnu.
 
         Returns:
             Sed
@@ -220,7 +248,11 @@ class StarsComponent:
 
         # Get the transmitted spectra
         lnu = (1.0 - fesc) * self.generate_lnu(
-            grid, "transmitted", young=young, old=old
+            grid,
+            "transmitted",
+            young=young,
+            old=old,
+            **kwargs,
         )
 
         # Create the Sed object
@@ -238,6 +270,7 @@ class StarsComponent:
         young=False,
         old=False,
         label="",
+        **kwargs,
     ):
         """
         Generate nebular spectra from a grid object and star particles.
@@ -258,6 +291,9 @@ class StarsComponent:
             label (string)
                 A modifier for the spectra dictionary key such that the
                 key is label + "_nebular".
+            kwargs
+                Any keyword arguments which can be passed to
+                generate_lnu.
 
         Returns:
             Sed
@@ -268,7 +304,13 @@ class StarsComponent:
         young, old = self.check_young_old_units(young, old)
 
         # Get the nebular emission spectra
-        lnu = self.generate_lnu(grid, "nebular", young=young, old=old)
+        lnu = self.generate_lnu(
+            grid,
+            "nebular",
+            young=young,
+            old=old,
+            **kwargs,
+        )
 
         # Apply the escape fraction
         lnu *= 1 - fesc
@@ -290,6 +332,7 @@ class StarsComponent:
         old=False,
         label="",
         verbose=False,
+        **kwargs,
     ):
         """
         Generates the intrinsic spectra, this is the sum of the escaping
@@ -298,9 +341,9 @@ class StarsComponent:
         transmitted through the gas. In addition to returning the intrinsic
         spectra this saves the incident, nebular, and escaped spectra.
 
-        Note, if a grid that has not been post-processed through a 
+        Note, if a grid that has not been post-processed through a
         photoionisation code is provided (i.e. read_lines=False) this will
-        just call `get_spectra_incident`. 
+        just call `get_spectra_incident`.
 
         Args:
             grid (obj):
@@ -322,6 +365,9 @@ class StarsComponent:
                 key is label + "_transmitted".
             verbose (bool):
                 verbose output flag
+            kwargs
+                Any keyword arguments which can be passed to
+                generate_lnu.
 
         Updates:
             incident:
@@ -337,7 +383,7 @@ class StarsComponent:
             Sed
                 An Sed object containing the intrinsic spectra.
         """
-        
+
         # Make sure young and old in Myr, if provided
         young, old = self.check_young_old_units(young, old)
 
@@ -345,20 +391,23 @@ class StarsComponent:
         if grid.read_lines is False:
             if verbose:
                 print(
-                    ("The grid you are using has not been post-processed "
-                     "through a photoionisation code. This method will "
-                     "just return the incident stellar emission. Are "
-                     "you sure this is the method you want to use?")
+                    (
+                        "The grid you are using has not been post-processed "
+                        "through a photoionisation code. This method will "
+                        "just return the incident stellar emission. Are "
+                        "you sure this is the method you want to use?"
+                    )
                 )
 
             spec = self.get_spectra_incident(
                 grid=grid,
                 young=young,
                 old=old,
-                label=label
+                label=label,
+                **kwargs,
             )
 
-            self.spectra[f'{label}intrinsic'] = self.spectra[f'{label}incident']
+            self.spectra[f"{label}intrinsic"] = self.spectra[f"{label}incident"]
             return spec
 
         # The incident emission
@@ -367,6 +416,7 @@ class StarsComponent:
             young=young,
             old=old,
             label=label,
+            **kwargs,
         )
 
         # The emission which escapes the gas
@@ -375,12 +425,22 @@ class StarsComponent:
 
         # The stellar emission which **is** reprocessed by the gas
         transmitted = self.get_spectra_transmitted(
-            grid, fesc, young=young, old=old, label=label
+            grid,
+            fesc,
+            young=young,
+            old=old,
+            label=label,
+            **kwargs,
         )
 
         # The nebular emission
         nebular = self.get_spectra_nebular(
-            grid, fesc, young=young, old=old, label=label
+            grid,
+            fesc,
+            young=young,
+            old=old,
+            label=label,
+            **kwargs,
         )
 
         # If the Lyman-alpha escape fraction is <1.0 suppress it.
@@ -390,11 +450,16 @@ class StarsComponent:
                 grid,
                 fesc=fesc,
                 fesc_LyA=fesc_LyA,
+                **kwargs,
             )
 
             # Get the nebular continuum emission
             nebular_continuum = self.generate_lnu(
-                grid, "nebular_continuum", young=young, old=old
+                grid,
+                "nebular_continuum",
+                young=young,
+                old=old,
+                **kwargs,
             )
             nebular_continuum *= 1 - fesc
 
@@ -412,9 +477,9 @@ class StarsComponent:
             intrinsic = reprocessed
 
         if fesc > 0:
-            self.spectra[f'{label}escaped'] = escaped
-        self.spectra[f'{label}reprocessed'] = reprocessed
-        self.spectra[f'{label}intrinsic'] = intrinsic
+            self.spectra[f"{label}escaped"] = escaped
+        self.spectra[f"{label}reprocessed"] = reprocessed
+        self.spectra[f"{label}intrinsic"] = intrinsic
 
         return reprocessed
 
@@ -426,6 +491,7 @@ class StarsComponent:
         young=False,
         old=False,
         label="",
+        **kwargs,
     ):
         """
         Calculates dust attenuated spectra assuming a simple screen.
@@ -448,6 +514,9 @@ class StarsComponent:
             label (string)
                 A modifier for the spectra dictionary key such that the
                 key is label + "_transmitted".
+            kwargs
+                Any keyword arguments which can be passed to
+                generate_lnu.
 
         Returns:
             Sed
@@ -472,6 +541,7 @@ class StarsComponent:
             young=young,
             old=old,
             label=label,
+            **kwargs,
         )
 
         # Apply the dust screen
@@ -494,6 +564,7 @@ class StarsComponent:
         fesc=0.0,
         fesc_LyA=1.0,
         label="",
+        **kwargs,
     ):
         """
         Calculates dust attenuated spectra assuming the PACMAN dust/fesc model
@@ -527,6 +598,9 @@ class StarsComponent:
             label (string)
                 A modifier for the spectra dictionary key such that the
                 key is label + "_transmitted".
+            kwargs
+                Any keyword arguments which can be passed to
+                generate_lnu.
 
         Raises:
             InconsistentArguments:
@@ -590,9 +664,9 @@ class StarsComponent:
 
         # If grid has photoinoisation outputs, use the reprocessed outputs
         if grid.read_lines:
-            reprocessed_name = 'reprocessed'
+            reprocessed_name = "reprocessed"
         else:  # otherwise just use the intrinsic stellar spectra
-            reprocessed_name = 'intrinsic'
+            reprocessed_name = "intrinsic"
 
         # Generate intrinsic spectra for young and old particles
         # separately before summing them if we have been given
@@ -627,6 +701,7 @@ class StarsComponent:
                 young=young_old_thresh,
                 old=False,
                 label="young_",
+                **kwargs,
             )
 
             # Generate the old gas reprocessed spectra
@@ -638,6 +713,7 @@ class StarsComponent:
                 young=False,
                 old=young_old_thresh,
                 label="old_",
+                **kwargs,
             )
 
             # Combine young and old spectra
@@ -672,7 +748,12 @@ class StarsComponent:
             #   - reprocessed = transmitted + nebular
             #   - intrinsic = transmitted + reprocessed
             self.get_spectra_reprocessed(
-                grid, fesc, fesc_LyA=fesc_LyA, young=False, old=False
+                grid,
+                fesc,
+                fesc_LyA=fesc_LyA,
+                young=False,
+                old=False,
+                **kwargs,
             )
 
         if np.isscalar(tau_v):
@@ -708,10 +789,9 @@ class StarsComponent:
 
             # Calculate attenuated spectra of young stars
             dust_curve.slope = alpha[1]  # use the BC slope
-            young_attenuated = self.spectra[f"young_{reprocessed_name}"].\
-                    apply_attenuation(
-                    tau_v[1], dust_curve=dust_curve
-                )
+            young_attenuated = self.spectra[
+                f"young_{reprocessed_name}"
+            ].apply_attenuation(tau_v[1], dust_curve=dust_curve)
 
             dust_curve.slope = alpha[0]  # use the ISM slope
             young_attenuated = young_attenuated.apply_attenuation(
@@ -720,10 +800,9 @@ class StarsComponent:
             self.spectra["young_attenuated"] = young_attenuated
 
             # Calculate attenuated spectra of old stars
-            old_attenuated = self.spectra[f"old_{reprocessed_name}"].\
-                    apply_attenuation(
-                    tau_v[0], dust_curve=dust_curve
-                )
+            old_attenuated = self.spectra[f"old_{reprocessed_name}"].apply_attenuation(
+                tau_v[0], dust_curve=dust_curve
+            )
             self.spectra["old_attenuated"] = old_attenuated
 
             # Get the combined attenuated spectra
@@ -766,6 +845,7 @@ class StarsComponent:
         alpha_ISM=None,
         alpha_BC=None,
         young_old_thresh=7.0,
+        **kwargs,
     ):
         """
         Calculates dust attenuated spectra assuming the Charlot & Fall (2000)
@@ -789,6 +869,9 @@ class StarsComponent:
             young_old_thresh (float)
                 The threshold in log10(age/yr) for young/old stellar
                 populations.
+            kwargs
+                Any keyword arguments which can be passed to
+                generate_lnu.
 
         Returns:
             Sed
@@ -803,6 +886,7 @@ class StarsComponent:
             tau_v=[tau_v_ISM, tau_v_BC],
             alpha=[alpha_ISM, alpha_BC],
             young_old_thresh=young_old_thresh,
+            **kwargs,
         )
 
     def get_line_intrinsic(self, grid, line_ids, fesc=0.0):
@@ -1029,7 +1113,7 @@ class StarsComponent:
         ylimits=(),
         xlimits=(),
         figsize=(3.5, 5),
-        **kwargs
+        **kwargs,
     ):
         """
         Plots either specific spectra (specified via spectra_to_plot) or all
@@ -1078,5 +1162,5 @@ class StarsComponent:
             xlimits=xlimits,
             figsize=figsize,
             draw_legend=isinstance(spectra, dict),
-            **kwargs
+            **kwargs,
         )

--- a/src/synthesizer/extensions/integrated_spectra.c
+++ b/src/synthesizer/extensions/integrated_spectra.c
@@ -114,7 +114,7 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
     const double mass = part_mass[p];
 
     /* Finally, compute the weights for this particle. */
-    weight_loop_CIC(grid_props, part_props, mass, grid_weights, dims, ndim, p);
+    weight_loop_cic(grid_props, part_props, mass, grid_weights, dims, ndim, p);
 
   } /* Loop over particles. */
 

--- a/src/synthesizer/extensions/integrated_spectra.c
+++ b/src/synthesizer/extensions/integrated_spectra.c
@@ -9,9 +9,9 @@
 
 /* Python includes */
 #include <Python.h>
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/ndarrayobject.h>
 #include <numpy/ndarraytypes.h>
-#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 
 /* Local includes */
 #include "weights.h"
@@ -65,10 +65,6 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
 
   /* Extract a pointer to the particle masses. */
   const double *part_mass = PyArray_DATA(np_part_mass);
-
-  /* Compute the number of weights we need. Adding on a buffer for
-   * accurate casting*/
-  const int nweights = pow(2, ndim) + 0.1;
 
   /* Allocate a single array for grid properties*/
   int nprops = 0;

--- a/src/synthesizer/extensions/integrated_spectra.c
+++ b/src/synthesizer/extensions/integrated_spectra.c
@@ -14,6 +14,7 @@
 #include <numpy/ndarraytypes.h>
 
 /* Local includes */
+#include "macros.h"
 #include "weights.h"
 
 /**

--- a/src/synthesizer/extensions/integrated_spectra.c
+++ b/src/synthesizer/extensions/integrated_spectra.c
@@ -124,8 +124,10 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
       weight_loop_ngp(grid_props, part_props, mass, grid_weights, dims, ndim,
                       p);
     } else {
-      printf("Unrecognised gird assignment method (%s)! Falling back on CIC\n",
-             method);
+      if (p == 0)
+        printf(
+            "Unrecognised gird assignment method (%s)! Falling back on CIC\n",
+            method);
       weight_loop_cic(grid_props, part_props, mass, grid_weights, dims, ndim,
                       p);
     }

--- a/src/synthesizer/extensions/integrated_spectra.c
+++ b/src/synthesizer/extensions/integrated_spectra.c
@@ -124,6 +124,7 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
       weight_loop_ngp(grid_props, part_props, mass, grid_weights, dims, ndim,
                       p);
     } else {
+      /* Only print this warning once! */
       if (p == 0)
         printf(
             "Unrecognised gird assignment method (%s)! Falling back on CIC\n",

--- a/src/synthesizer/extensions/integrated_spectra.c
+++ b/src/synthesizer/extensions/integrated_spectra.c
@@ -120,11 +120,11 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
     if (strcmp(method, "cic") == 0) {
       weight_loop_cic(grid_props, part_props, mass, grid_weights, dims, ndim,
                       p);
-    } else if (strcmp(method, "ngp")) {
+    } else if (strcmp(method, "ngp") == 0) {
       weight_loop_ngp(grid_props, part_props, mass, grid_weights, dims, ndim,
                       p);
     } else {
-      printf("Unrecognised gird assignment method (%s)! Falling back on CIC",
+      printf("Unrecognised gird assignment method (%s)! Falling back on CIC\n",
              method);
       weight_loop_cic(grid_props, part_props, mass, grid_weights, dims, ndim,
                       p);

--- a/src/synthesizer/extensions/macros.h
+++ b/src/synthesizer/extensions/macros.h
@@ -1,0 +1,8 @@
+/******************************************************************************
+ * A C module containing macros for use in C extensions.
+ *****************************************************************************/
+
+/* Define a macro to handle that bzero is non-standard. */
+#ifndef bzero
+#define bzero(b, len) (memset((b), '\0', (len)), (void)0)
+#endif

--- a/src/synthesizer/extensions/particle_spectra.c
+++ b/src/synthesizer/extensions/particle_spectra.c
@@ -319,7 +319,7 @@ PyObject *compute_particle_seds(PyObject *self, PyObject *args) {
       spectra_loop_ngp(grid_props, part_props, mass, grid_spectra, dims, ndim,
                        spectra, nlam, fesc, p);
     } else {
-      printf("Unrecognised gird assignment method (%s)! Falling back on CIC",
+      printf("Unrecognised gird assignment method (%s)! Falling back on CIC\n",
              method);
       spectra_loop_cic(grid_props, part_props, mass, grid_spectra, dims, ndim,
                        spectra, nlam, fesc, p);

--- a/src/synthesizer/extensions/particle_spectra.c
+++ b/src/synthesizer/extensions/particle_spectra.c
@@ -40,13 +40,8 @@ void spectra_loop_cic(const double **grid_props, const double **part_props,
                       const int nlam, const double fesc, const int p) {
 
   /* Setup the index and mass fraction arrays. */
-  int frac_indices[(int)pow(2, (double)ndim)][ndim];
-  double fracs[(int)pow(2, (double)ndim)];
-
-  /* Set up the fractions. */
-  for (int icell = 0; icell < (int)pow(2, (double)ndim); icell++) {
-    fracs[icell] = 1;
-  }
+  int part_indices[ndim];
+  double axis_fracs[ndim];
 
   /* Loop over dimensions finding the mass weightings and indicies. */
   for (int dim = 0; dim < ndim; dim++) {
@@ -78,52 +73,62 @@ void spectra_loop_cic(const double **grid_props, const double **part_props,
 
       /* Find the grid index corresponding to this particle property. */
       part_cell =
-          binary_search(/*low*/ 1, /*high*/ dims[dim] - 1, grid_prop, part_val);
+          binary_search(/*low*/ 0, /*high*/ dims[dim] - 1, grid_prop, part_val);
 
-      /* Make sure we have the cell containing the particle. */
-      if (grid_prop[part_cell] < part_val) {
-        part_cell += 1;
-      }
-
-      /* Calculate the fraction. Note, here we do the cell containing the
-       * particle, the cell below is calculated from this fraction. */
-      frac = (part_val - grid_prop[part_cell - 1]) /
+      /* Calculate the fraction. Note, here we do the "low" cell, the cell
+       * above is calculated from this fraction. */
+      frac = (grid_prop[part_cell] - part_val) /
              (grid_prop[part_cell] - grid_prop[part_cell - 1]);
     }
 
-    /* Set the fractions. */
-    fracs[dim * 2 + 1] *= frac;
-    fracs[dim * 2] *= 1 - frac;
+    /* Set the fraction for this dimension. */
+    axis_fracs[dim] = (1 - frac);
 
-    /* Set these indices. */
-    for (int jdim = 0; jdim < ndim; jdim++) {
-      frac_indices[jdim * 2][dim] = part_cell - 1;
-      frac_indices[jdim * 2 + 1][dim] = part_cell;
-    }
+    /* Set this index. */
+    part_indices[dim] = part_cell;
   }
 
-  /* Normalise the fractions. */
-  double sum = 0;
-  for (int icell = 0; icell < (int)pow(2, (double)ndim); icell++) {
-    sum += fracs[icell];
-  }
-  for (int icell = 0; icell < (int)pow(2, (double)ndim); icell++) {
-    fracs[icell] /= sum;
+  /* To combine fractions we will need an array of dimensions for the subset.
+   * These are always two in size, one for the low and one for high grid
+   * point. */
+  int sub_dims[ndim];
+  for (int idim = 0; idim < ndim; idim++) {
+    sub_dims[idim] = 2;
   }
 
   /* Now loop over this collection of cells collecting and setting their
    * weights. */
   for (int icell = 0; icell < (int)pow(2, (double)ndim); icell++) {
 
+    /* Set up some index arrays we'll need. */
+    int subset_ind[ndim];
+    int frac_ind[ndim];
+
+    /* Get the multi-dimensional version of icell. */
+    get_indices_from_flat(icell, ndim, sub_dims, subset_ind);
+
+    /* Multiply all contributing fractions and get the fractions index
+     * in the grid. */
+    double frac = 1;
+    for (int idim = 0; idim < ndim; idim++) {
+      if (subset_ind[idim] == 0) {
+        frac *= (1 - axis_fracs[idim]);
+        frac_ind[idim] = part_indices[idim] - 1;
+      } else {
+        frac *= axis_fracs[idim];
+        frac_ind[idim] = part_indices[idim];
+      }
+    }
+
     /* Early skip for cells contributing a 0 fraction. */
-    if (fracs[icell] <= 0)
+    if (frac <= 0)
       continue;
 
     /* We have a contribution, get the flattened index into the grid array. */
-    const int grid_ind = get_flat_index(frac_indices[icell], dims, ndim);
+    const int grid_ind = get_flat_index(frac_ind, dims, ndim);
 
     /* Define the weight. */
-    double weight = mass * fracs[icell];
+    double weight = mass * frac;
 
     /* Get the spectra ind. */
     int unraveled_ind[ndim + 1];

--- a/src/synthesizer/extensions/particle_spectra.c
+++ b/src/synthesizer/extensions/particle_spectra.c
@@ -80,6 +80,11 @@ void spectra_loop_cic(const double **grid_props, const double **part_props,
       part_cell =
           binary_search(/*low*/ 1, /*high*/ dims[dim] - 1, grid_prop, part_val);
 
+      /* Make sure we have the cell containing the particle. */
+      if (grid_prop[part_cell] < part_val) {
+        part_cell += 1;
+      }
+
       /* Calculate the fraction. Note, here we do the cell containing the
        * particle, the cell below is calculated from this fraction. */
       frac = (part_val - grid_prop[part_cell - 1]) /

--- a/src/synthesizer/extensions/particle_spectra.c
+++ b/src/synthesizer/extensions/particle_spectra.c
@@ -2,146 +2,19 @@
  * C extension to calculate SEDs for star particles.
  * Calculates weights on an arbitrary dimensional grid given the mass.
  *****************************************************************************/
+/* C includes */
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 
+/* Python includes */
 #include <Python.h>
-
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
-
 #include <numpy/ndarrayobject.h>
 #include <numpy/ndarraytypes.h>
 
-/* Define a macro to handle that bzero is non-standard. */
-#define bzero(b, len) (memset((b), '\0', (len)), (void)0)
-
-/**
- * @brief Compute an ndimensional index from a flat index.
- *
- * @param flat_ind: The flattened index to unravel.
- * @param ndim: The number of dimensions for the unraveled index.
- * @param dims: The size of each dimension.
- * @param indices: The output N-dimensional indices.
- */
-void get_indices_from_flat(int flat_ind, int ndim, const int *dims,
-                           int *indices) {
-
-  /* Loop over indices calculating each one. */
-  for (int i = 0; i < ndim; i++) {
-    indices[i] = flat_ind % dims[i];
-    flat_ind /= dims[i];
-  }
-}
-
-/**
- * @brief Compute a flat grid index based on the grid dimensions.
- *
- * @param multi_index: An array of N-dimensional indices.
- * @param dims: The length of each dimension.
- * @param ndim: The number of dimensions.
- */
-int get_flat_index(const int *multi_index, const int *dims, const int ndims) {
-  int index = 0, stride = 1;
-  for (int i = ndims - 1; i >= 0; i--) {
-    index += stride * multi_index[i];
-    stride *= dims[i];
-  }
-
-  return index;
-}
-
-/**
- * @brief Performs a binary search for the index of an array corresponding to
- * a value.
- *
- * @param low: The initial low index (probably beginning of array).
- * @param high: The initial high index (probably size of array).
- * @param arr: The array to search in.
- * @param val: The value to search for.
- */
-int binary_search(int low, int high, const double *arr, const double val) {
-
-  /* While we don't have a pair of adjacent indices. */
-  int diff = high - low;
-  while (diff > 1) {
-
-    /* Define the midpoint. */
-    int mid = low + floor(diff / 2);
-
-    /* Where is the midpoint relative to the value? */
-    if (arr[mid] < val) {
-      low = mid;
-    } else {
-      high = mid;
-    }
-
-    /* Compute the new range. */
-    diff = high - low;
-  }
-  return low;
-}
-
-/**
- * @brief Calculates the mass fractions in each right most grid cell along
- *        each dimension.
- *
- * @param grid_props: An array of the properties along each grid axis.
- * @param part_props: An array of the particle properties, in the same property
- *                    order as grid props.
- * @param p: Index of the current particle.
- * @param ndim: The number of grid dimensions.
- * @param dims: The length of each grid dimension.
- * @param npart: The number of particles in total.
- * @param frac_indices: The array for storing N-dimensional grid indicies.
- * @param fracs: The array for storing the mass fractions. NOTE: The left most
- *               grid cell's mass fraction is simply (1 - frac[dim])
- */
-void frac_loop(const double **grid_props, const double **part_props, int p,
-               const int ndim, const int *dims, const int npart,
-               int *frac_indices, double *fracs) {
-
-  /* Loop over dimensions. */
-  for (int dim = 0; dim < ndim; dim++) {
-
-    /* Get this array of grid properties */
-    const double *grid_prop = grid_props[dim];
-
-    /* Get this particle property. */
-    const double part_val = part_props[dim][p];
-
-    /**************************************************************************
-     * Get the cells corresponding to this particle and compute the fraction.
-     *************************************************************************/
-
-    /* Define the starting indices. */
-    int low = 0, high = dims[dim] - 1;
-
-    /* Here we need to handle if we are outside the range of values. If so
-     * there's no point in searching and we return the edge nearest to the
-     * value. */
-    if (part_val <= grid_prop[low]) {
-      low = 0;
-      fracs[dim] = 0;
-    } else if (part_val > grid_prop[high]) {
-      low = dims[dim];
-      fracs[dim] = 0;
-    } else {
-
-      /* Find the grid index corresponding to this particle property. */
-      low = binary_search(low, high, grid_prop, part_val);
-      high = low + 1;
-
-      /* Calculate the fraction. Note, this represents the mass fraction in
-       * the high cell. */
-      fracs[dim] =
-          (part_val - grid_prop[low]) / (grid_prop[high] - grid_prop[low]);
-    }
-
-    /* Set these indices. */
-    frac_indices[dim] = low;
-  }
-}
+/* Local includes */
+#include "weights.h"
 
 /**
  * @brief This calculates the grid weights in each grid cell.
@@ -149,15 +22,11 @@ void frac_loop(const double **grid_props, const double **part_props, int p,
  * To do this for an N-dimensional array this is done recursively one dimension
  * at a time.
  *
+ * @param grid_props: An array of the properties along each grid axis.
+ * @param part_props: An array of the particle properties, in the same property
+ *                    order as grid props.
  * @param mass: The mass of the current particle.
- * @param sub_indices: The indices in the 2**ndim subset of grid points being
- *                     computed in the current recursion (entries are 0 or 1).
- * @param frac_indices: The array for storing N-dimensional grid indicies.
- * @param low_indices: The index of the bottom corner grid point.
  * @param grid_spectra: The grid of SPS spectra.
- * @param fracs: The array for storing the mass fractions. NOTE: The left most
- *               grid cell's mass fraction is simply (1 - frac[dim])
- * @param dim: The current dimension in the recursion.
  * @param dims: The length of each grid dimension.
  * @param ndim: The number of grid dimensions.
  * @param spectra: The array of particle spectra.
@@ -165,38 +34,82 @@ void frac_loop(const double **grid_props, const double **part_props, int p,
  * @param fesc: The escape fraction.
  * @param p: The index of the current particle.
  */
-void recursive_spectra_loop(const double mass, short int *sub_indices,
-                            int *frac_indices, int *low_indices,
-                            const double *grid_spectra, double *fracs, int dim,
-                            const int *dims, const int ndim, double *spectra,
-                            const int nlam, const double fesc, const int p) {
+void spectra_loop_CIC(const double **grid_props, const double **part_props,
+                      const double mass, const double *grid_spectra,
+                      const int *dims, const int ndim, double *spectra,
+                      const int nlam, const double fesc, const int p) {
 
-  /* Are we done yet? */
-  if (dim >= ndim) {
+  /* Setup the index and mass fraction arrays. */
+  int frac_indices[(int)pow(2, (double)ndim)][ndim];
+  double fracs[(int)pow(2, (double)ndim)];
 
-    /* Get the flattened index into the grid array. */
-    const int grid_ind = get_flat_index(frac_indices, dims, ndim);
+  /* Set up the fractions. */
+  for (int icell = 0; icell < (int)pow(2, (double)ndim); icell++) {
+    fracs[icell] = 1;
+  }
 
-    /* Check whether we need a weight in this cell. */
-    for (int i = 0; i < ndim; i++) {
-      if ((sub_indices[i] == 1 && fracs[i] == 0 && frac_indices[i] == 0) ||
-          (sub_indices[i] == 1 && fracs[i] == 0 &&
-           frac_indices[i] == dims[i])) {
-        return;
-      }
+  /* Loop over dimensions finding the mass weightings and indicies. */
+  for (int dim = 0; dim < ndim; dim++) {
+
+    /* Get this array of grid properties for this dimension */
+    const double *grid_prop = grid_props[dim];
+
+    /* Get this particle property. */
+    const double part_val = part_props[dim][p];
+
+    /* Here we need to handle if we are outside the range of values. If so
+     * there's no point in searching and we return the edge nearest to the
+     * value. */
+    int part_cell;
+    double frac;
+    if (part_val <= grid_prop[0]) {
+
+      /* Use the grid edge. */
+      part_cell = 0;
+      frac = 1;
+
+    } else if (part_val > grid_prop[dims[dim] - 1]) {
+
+      /* Use the grid edge. */
+      part_cell = dims[dim] - 1;
+      frac = 1;
+
+    } else {
+
+      /* Find the grid index corresponding to this particle property. */
+      part_cell =
+          binary_search(/*low*/ 1, /*high*/ dims[dim] - 1, grid_prop, part_val);
+
+      /* Calculate the fraction. Note, here we do the cell containing the
+       * particle, the cell below is calculated from this fraction. */
+      frac = (part_val - grid_prop[part_cell - 1]) /
+             (grid_prop[part_cell] - grid_prop[part_cell - 1]);
     }
 
-    /* Compute the weight. */
-    double weight = mass;
-    for (int i = 0; i < ndim; i++) {
+    /* Set the fractions. */
+    fracs[dim * 2 + 1] *= frac;
+    fracs[dim * 2] *= 1 - frac;
 
-      /* Account for the fractional contribution in this grid cell. */
-      if (sub_indices[i]) {
-        weight *= fracs[i];
-      } else {
-        weight *= (1 - fracs[i]);
-      }
+    /* Set these indices. */
+    for (int jdim = 0; jdim < ndim; jdim++) {
+      frac_indices[jdim * 2][dim] = part_cell - 1;
+      frac_indices[jdim * 2 + 1][dim] = part_cell;
     }
+  }
+
+  /* Now loop over this collection of cells collecting and setting their
+   * weights. */
+  for (int icell = 0; icell < (int)pow(2, (double)ndim); icell++) {
+
+    /* Early skip for cells contributing a 0 fraction. */
+    if (fracs[icell] <= 0)
+      continue;
+
+    /* We have a contribution, get the flattened index into the grid array. */
+    const int grid_ind = get_flat_index(frac_indices[icell], dims, ndim);
+
+    /* Define the weight. */
+    double weight = mass * fracs[icell];
 
     /* Get the spectra ind. */
     int unraveled_ind[ndim + 1];
@@ -211,24 +124,6 @@ void recursive_spectra_loop(const double mass, short int *sub_indices,
       spectra[p * nlam + ilam] +=
           grid_spectra[spectra_ind + ilam] * (1 - fesc) * weight;
     }
-
-    /* We're done! */
-    return;
-  }
-
-  /* Loop over this dimension */
-  for (int i = 0; i < ndim; i++) {
-
-    /* Where are we in the sub_array? */
-    sub_indices[dim] = i;
-
-    /* Where are we in the grid array? */
-    frac_indices[dim] = low_indices[dim] + i;
-
-    /* Recurse... */
-    recursive_spectra_loop(mass, sub_indices, frac_indices, low_indices,
-                           grid_spectra, fracs, dim + 1, dims, ndim, spectra,
-                           nlam, fesc, p);
   }
 }
 
@@ -281,9 +176,6 @@ PyObject *compute_particle_seds(PyObject *self, PyObject *args) {
   /* Extract a pointer to the particle masses. */
   const double *part_mass = PyArray_DATA(np_part_mass);
 
-  /* Compute the number of weights we need. */
-  const int nweights = pow(2, ndim) + 0.1;
-
   /* Allocate a single array for grid properties*/
   int nprops = 0;
   for (int dim = 0; dim < ndim; dim++)
@@ -324,44 +216,15 @@ PyObject *compute_particle_seds(PyObject *self, PyObject *args) {
     part_props[idim] = part_arr;
   }
 
-  /* Set up arrays to store grid indices for the weights, mass fractions
-   * and indices.
-   * NOTE: the wavelength index on frac_indices is always 0. */
-  double fracs[ndim];
-  int frac_indices[ndim];
-  int low_indices[ndim];
-  short int sub_indices[ndim];
-
   /* Loop over particles. */
   for (int p = 0; p < npart; p++) {
-
-    /* Reset arrays. */
-    for (int ind = 0; ind < ndim; ind++) {
-      fracs[ind] = 0;
-      sub_indices[ind] = 0;
-    }
-    for (int ind = 0; ind < ndim; ind++) {
-      frac_indices[ind] = 0;
-      low_indices[ind] = 0;
-    }
 
     /* Get this particle's mass. */
     const double mass = part_mass[p];
 
-    /* Compute grid indices and the mass faction in each grid cell. */
-    frac_loop(grid_props, part_props, p, ndim, dims, npart, frac_indices,
-              fracs);
-
-    /* Make a copy of the indices of the fraction to keep track of the initial
-     * indices during recursion. */
-    for (int ind = 0; ind < ndim; ind++) {
-      low_indices[ind] = frac_indices[ind];
-    }
-
     /* Finally, compute the weights for this particle. */
-    recursive_spectra_loop(mass, sub_indices, frac_indices, low_indices,
-                           grid_spectra, fracs, /*dim*/ 0, dims, ndim, spectra,
-                           nlam, fesc, p);
+    spectra_loop_CIC(grid_props, part_props, mass, grid_spectra, dims, ndim,
+                     spectra, nlam, fesc, p);
   }
 
   /* Clean up memory! */

--- a/src/synthesizer/extensions/particle_spectra.c
+++ b/src/synthesizer/extensions/particle_spectra.c
@@ -14,6 +14,7 @@
 #include <numpy/ndarraytypes.h>
 
 /* Local includes */
+#include "macros.h"
 #include "weights.h"
 
 /**

--- a/src/synthesizer/extensions/particle_spectra.c
+++ b/src/synthesizer/extensions/particle_spectra.c
@@ -246,7 +246,7 @@ PyObject *compute_particle_seds(PyObject *self, PyObject *args) {
   const PyArrayObject *np_part_mass, *np_ndims;
   const char *method;
 
-  if (!PyArg_ParseTuple(args, "OOOOdOiii", &np_grid_spectra, &grid_tuple,
+  if (!PyArg_ParseTuple(args, "OOOOdOiiis", &np_grid_spectra, &grid_tuple,
                         &part_tuple, &np_part_mass, &fesc, &np_ndims, &ndim,
                         &npart, &nlam, &method))
     return NULL;

--- a/src/synthesizer/extensions/particle_spectra.c
+++ b/src/synthesizer/extensions/particle_spectra.c
@@ -315,7 +315,7 @@ PyObject *compute_particle_seds(PyObject *self, PyObject *args) {
     if (strcmp(method, "cic") == 0) {
       spectra_loop_cic(grid_props, part_props, mass, grid_spectra, dims, ndim,
                        spectra, nlam, fesc, p);
-    } else if (strcmp(method, "ngp")) {
+    } else if (strcmp(method, "ngp") == 0) {
       spectra_loop_ngp(grid_props, part_props, mass, grid_spectra, dims, ndim,
                        spectra, nlam, fesc, p);
     } else {

--- a/src/synthesizer/extensions/particle_spectra.c
+++ b/src/synthesizer/extensions/particle_spectra.c
@@ -319,8 +319,11 @@ PyObject *compute_particle_seds(PyObject *self, PyObject *args) {
       spectra_loop_ngp(grid_props, part_props, mass, grid_spectra, dims, ndim,
                        spectra, nlam, fesc, p);
     } else {
-      printf("Unrecognised gird assignment method (%s)! Falling back on CIC\n",
-             method);
+      /* Only print this warning once */
+      if (p == 0)
+        printf(
+            "Unrecognised gird assignment method (%s)! Falling back on CIC\n",
+            method);
       spectra_loop_cic(grid_props, part_props, mass, grid_spectra, dims, ndim,
                        spectra, nlam, fesc, p);
     }

--- a/src/synthesizer/extensions/particle_spectra.c
+++ b/src/synthesizer/extensions/particle_spectra.c
@@ -97,6 +97,15 @@ void spectra_loop_cic(const double **grid_props, const double **part_props,
     }
   }
 
+  /* Normalise the fractions. */
+  double sum = 0;
+  for (int icell = 0; icell < (int)pow(2, (double)ndim); icell++) {
+    sum += fracs[icell];
+  }
+  for (int icell = 0; icell < (int)pow(2, (double)ndim); icell++) {
+    fracs[icell] /= sum;
+  }
+
   /* Now loop over this collection of cells collecting and setting their
    * weights. */
   for (int icell = 0; icell < (int)pow(2, (double)ndim); icell++) {

--- a/src/synthesizer/extensions/particle_spectra.c
+++ b/src/synthesizer/extensions/particle_spectra.c
@@ -35,7 +35,7 @@
  * @param fesc: The escape fraction.
  * @param p: The index of the current particle.
  */
-void spectra_loop_CIC(const double **grid_props, const double **part_props,
+void spectra_loop_cic(const double **grid_props, const double **part_props,
                       const double mass, const double *grid_spectra,
                       const int *dims, const int ndim, double *spectra,
                       const int nlam, const double fesc, const int p) {
@@ -224,7 +224,7 @@ PyObject *compute_particle_seds(PyObject *self, PyObject *args) {
     const double mass = part_mass[p];
 
     /* Finally, compute the weights for this particle. */
-    spectra_loop_CIC(grid_props, part_props, mass, grid_spectra, dims, ndim,
+    spectra_loop_cic(grid_props, part_props, mass, grid_spectra, dims, ndim,
                      spectra, nlam, fesc, p);
   }
 

--- a/src/synthesizer/extensions/sfzh.c
+++ b/src/synthesizer/extensions/sfzh.c
@@ -1,0 +1,160 @@
+/******************************************************************************
+ * C extension to calculate integrated SEDs for a galaxy's star particles.
+ * Calculates weights on an arbitrary dimensional grid given the mass.
+ *****************************************************************************/
+/* C includes */
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Python includes */
+#include <Python.h>
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#include <numpy/ndarrayobject.h>
+#include <numpy/ndarraytypes.h>
+
+/* Local includes */
+#include "macros.h"
+#include "weights.h"
+
+/**
+ * @brief Computes an integrated SED for a collection of particles.
+ *
+ * @param np_grid_spectra: The SPS spectra array.
+ * o
+ * @param grid_tuple: The tuple containing arrays of grid axis properties.
+ * @param part_tuple: The tuple of particle property arrays (in the same order
+ *                    as grid_tuple).
+ * @param np_part_mass: The particle mass array.
+ * @param fesc: The escape fraction.
+ * @param np_ndims: The size of each grid axis.
+ * @param ndim: The number of grid axes.
+ * @param npart: The number of particles.
+ * @param nlam: The number of wavelength elements.
+ */
+PyObject *compute_sfzh(PyObject *self, PyObject *args) {
+
+  const int ndim, npart;
+  const PyObject *grid_tuple, *part_tuple;
+  const PyArrayObject *np_part_mass, *np_ndims;
+  const char *method;
+
+  if (!PyArg_ParseTuple(args, "OOOOiis", &grid_tuple, &part_tuple,
+                        &np_part_mass, &np_ndims, &ndim, &npart, &method))
+    return NULL;
+
+  /* Quick check to make sure our inputs are valid. */
+  if (ndim == 0)
+    return NULL;
+  if (npart == 0)
+    return NULL;
+
+  /* Extract a pointer to the grid dims */
+  const int *dims = PyArray_DATA(np_ndims);
+
+  /* Extract a pointer to the particle masses. */
+  const double *part_mass = PyArray_DATA(np_part_mass);
+
+  /* Allocate a single array for grid properties*/
+  int nprops = 0;
+  for (int dim = 0; dim < ndim; dim++)
+    nprops += dims[dim];
+  const double **grid_props = malloc(nprops * sizeof(double *));
+
+  /* How many grid elements are there? (excluding wavelength axis)*/
+  int grid_size = 1;
+  for (int dim = 0; dim < ndim; dim++)
+    grid_size *= dims[dim];
+
+  /* Allocate an array to hold the grid weights. */
+  double *sfzh = malloc(grid_size * sizeof(double));
+  bzero(sfzh, grid_size * sizeof(double));
+
+  /* Unpack the grid property arrays into a single contiguous array. */
+  for (int idim = 0; idim < ndim; idim++) {
+
+    /* Extract the data from the numpy array. */
+    const PyArrayObject *np_grid_arr = PyTuple_GetItem(grid_tuple, idim);
+    const double *grid_arr = PyArray_DATA(np_grid_arr);
+
+    /* Assign this data to the property array. */
+    grid_props[idim] = grid_arr;
+  }
+
+  /* Allocate a single array for particle properties. */
+  const double **part_props = malloc(npart * ndim * sizeof(double *));
+
+  /* Unpack the particle property arrays into a single contiguous array. */
+  for (int idim = 0; idim < ndim; idim++) {
+
+    /* Extract the data from the numpy array. */
+    const PyArrayObject *np_part_arr = PyTuple_GetItem(part_tuple, idim);
+    const double *part_arr = PyArray_DATA(np_part_arr);
+
+    /* Assign this data to the property array. */
+    part_props[idim] = part_arr;
+  }
+
+  /* Loop over particles. */
+  for (int p = 0; p < npart; p++) {
+
+    /* Get this particle's mass. */
+    const double mass = part_mass[p];
+
+    /* Finally, compute the weights for this particle using the
+     * requested method. */
+    if (strcmp(method, "cic") == 0) {
+      weight_loop_cic(grid_props, part_props, mass, sfzh, dims, ndim, p);
+    } else if (strcmp(method, "ngp") == 0) {
+      weight_loop_ngp(grid_props, part_props, mass, sfzh, dims, ndim, p);
+    } else {
+      /* Only print this warning once! */
+      if (p == 0)
+        printf(
+            "Unrecognised gird assignment method (%s)! Falling back on CIC\n",
+            method);
+      weight_loop_cic(grid_props, part_props, mass, sfzh, dims, ndim, p);
+    }
+
+  } /* Loop over particles. */
+
+  /* Clean up memory! */
+  free(part_props);
+  free(grid_props);
+
+  /* Reconstruct the python array to return. */
+  npy_intp np_dims[ndim];
+  for (int idim = 0; idim < ndim; idim++) {
+    np_dims[idim] = dims[idim];
+  }
+
+  PyArrayObject *out_sfzh = (PyArrayObject *)PyArray_SimpleNewFromData(
+      ndim, np_dims, NPY_FLOAT64, sfzh);
+
+  return Py_BuildValue("N", out_sfzh);
+}
+
+/* Below is all the gubbins needed to make the module importable in Python. */
+static PyMethodDef SFZHMethods[] = {{"compute_sfzh", compute_sfzh, METH_VARARGS,
+                                     "Method for calculating the SFZH."},
+                                    {NULL, NULL, 0, NULL}};
+
+/* Make this importable. */
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "make_sfzh",                             /* m_name */
+    "A module to calculating particle SFZH", /* m_doc */
+    -1,                                      /* m_size */
+    SFZHMethods,                             /* m_methods */
+    NULL,                                    /* m_reload */
+    NULL,                                    /* m_traverse */
+    NULL,                                    /* m_clear */
+    NULL,                                    /* m_free */
+};
+
+PyMODINIT_FUNC PyInit_sfzh(void) {
+  PyObject *m = PyModule_Create(&moduledef);
+  import_array();
+  return m;
+}

--- a/src/synthesizer/extensions/weights.h
+++ b/src/synthesizer/extensions/weights.h
@@ -131,7 +131,7 @@ void weight_loop_cic(const double **grid_props, const double **part_props,
 
       /* Calculate the fraction. Note, here we do the cell containing the
        * particle, the cell below is calculated from this fraction. */
-      frac = (part_val - grid_prop[part_cell - 1]) /
+      frac = (part_val - grid_prop[part_cell]) /
              (grid_prop[part_cell] - grid_prop[part_cell - 1]);
     }
 
@@ -144,6 +144,15 @@ void weight_loop_cic(const double **grid_props, const double **part_props,
       frac_indices[jdim * 2][dim] = part_cell - 1;
       frac_indices[jdim * 2 + 1][dim] = part_cell;
     }
+  }
+
+  /* Normalise the fractions. */
+  double sum = 0;
+  for (int icell = 0; icell < (int)pow(2, (double)ndim); icell++) {
+    sum += fracs[icell];
+  }
+  for (int icell = 0; icell < (int)pow(2, (double)ndim); icell++) {
+    fracs[icell] /= sum;
   }
 
   /* Now loop over this collection of cells collecting and setting their

--- a/src/synthesizer/extensions/weights.h
+++ b/src/synthesizer/extensions/weights.h
@@ -180,7 +180,7 @@ void weight_loop_ngp(const double **grid_props, const double **part_props,
                      const int ndim, const int p) {
 
   /* Setup the index array. */
-  int part_indices[ndim][ndim];
+  int part_indices[ndim];
 
   /* Loop over dimensions finding the indicies. */
   for (int dim = 0; dim < ndim; dim++) {
@@ -212,21 +212,13 @@ void weight_loop_ngp(const double **grid_props, const double **part_props,
           binary_search(/*low*/ 1, /*high*/ dims[dim] - 1, grid_prop, part_val);
     }
 
-    /* Set these indices. */
-    for (int jdim = 0; jdim < ndim; jdim++) {
-      part_indices[jdim * 2][dim] = part_cell - 1;
-      part_indices[jdim * 2 + 1][dim] = part_cell;
-    }
+    /* Set the index. */
+    part_indices[dim] = part_cell;
   }
 
-  /* Now loop over this collection of cells collecting and setting their
-   * weights. */
-  for (int icell = 0; icell < (int)pow(2, (double)ndim); icell++) {
+  /* Get the weight's index. */
+  const int weight_ind = get_flat_index(part_indices, dims, ndim);
 
-    /* We have a contribution, get the flattened index into the grid array. */
-    const int weight_ind = get_flat_index(part_indices[icell], dims, ndim);
-
-    /* Add the weight. */
-    weights[weight_ind] += mass;
-  }
+  /* Add the weight. */
+  weights[weight_ind] += mass;
 }

--- a/src/synthesizer/extensions/weights.h
+++ b/src/synthesizer/extensions/weights.h
@@ -1,0 +1,167 @@
+/******************************************************************************
+ * A C module containing all the weights functions common to all particle
+ * spectra extensions.
+ *****************************************************************************/
+#include <math.h>
+
+/* Define a macro to handle that bzero is non-standard. */
+#define bzero(b, len) (memset((b), '\0', (len)), (void)0)
+
+/**
+ * @brief Compute an ndimensional index from a flat index.
+ *
+ * @param flat_ind: The flattened index to unravel.
+ * @param ndim: The number of dimensions for the unraveled index.
+ * @param dims: The size of each dimension.
+ * @param indices: The output N-dimensional indices.
+ */
+void get_indices_from_flat(int flat_ind, int ndim, const int *dims,
+                           int *indices) {
+
+  /* Loop over indices calculating each one. */
+  for (int i = 0; i < ndim; i++) {
+    indices[i] = flat_ind % dims[i];
+    flat_ind /= dims[i];
+  }
+}
+
+/**
+ * @brief Compute a flat grid index based on the grid dimensions.
+ *
+ * @param multi_index: An array of N-dimensional indices.
+ * @param dims: The length of each dimension.
+ * @param ndim: The number of dimensions.
+ */
+int get_flat_index(const int *multi_index, const int *dims, const int ndims) {
+  int index = 0, stride = 1;
+  for (int i = ndims - 1; i >= 0; i--) {
+    index += stride * multi_index[i];
+    stride *= dims[i];
+  }
+
+  return index;
+}
+
+/**
+ * @brief Performs a binary search for the index of an array corresponding to
+ * a value.
+ *
+ * @param low: The initial low index (probably beginning of array).
+ * @param high: The initial high index (probably size of array).
+ * @param arr: The array to search in.
+ * @param val: The value to search for.
+ */
+int binary_search(int low, int high, const double *arr, const double val) {
+
+  /* While we don't have a pair of adjacent indices. */
+  int diff = high - low;
+  while (diff > 1) {
+
+    /* Define the midpoint. */
+    int mid = low + floor(diff / 2);
+
+    /* Where is the midpoint relative to the value? */
+    if (val > arr[mid]) {
+      low = mid;
+    } else {
+      high = mid;
+    }
+
+    /* Compute the new range. */
+    diff = high - low;
+  }
+  return low;
+}
+
+/**
+ * @brief This calculates the grid weights in each grid cell.
+ *
+ * To do this for an N-dimensional array this is done recursively one dimension
+ * at a time.
+ *
+ * @param grid_props: An array of the properties along each grid axis.
+ * @param part_props: An array of the particle properties, in the same property
+ *                    order as grid props.
+ * @param mass: The mass of the current particle.
+ * @param weights: The weight of each grid point.
+ * @param dims: The length of each grid dimension.
+ * @param ndim: The number of grid dimensions.
+ * @param p: Index of the current particle.
+ */
+void weight_loop_CIC(const double **grid_props, const double **part_props,
+                     const double mass, double *weights, const int *dims,
+                     const int ndim, const int p) {
+
+  /* Setup the index and mass fraction arrays. */
+  int frac_indices[(int)pow(2, (double)ndim)][ndim];
+  double fracs[(int)pow(2, (double)ndim)];
+
+  /* Set up the fractions. */
+  for (int icell = 0; icell < (int)pow(2, (double)ndim); icell++) {
+    fracs[icell] = 1;
+  }
+
+  /* Loop over dimensions finding the mass weightings and indicies. */
+  for (int dim = 0; dim < ndim; dim++) {
+
+    /* Get this array of grid properties for this dimension */
+    const double *grid_prop = grid_props[dim];
+
+    /* Get this particle property. */
+    const double part_val = part_props[dim][p];
+
+    /* Here we need to handle if we are outside the range of values. If so
+     * there's no point in searching and we return the edge nearest to the
+     * value. */
+    int part_cell;
+    double frac;
+    if (part_val <= grid_prop[0]) {
+
+      /* Use the grid edge. */
+      part_cell = 0;
+      frac = 1;
+
+    } else if (part_val > grid_prop[dims[dim] - 1]) {
+
+      /* Use the grid edge. */
+      part_cell = dims[dim] - 1;
+      frac = 1;
+
+    } else {
+
+      /* Find the grid index corresponding to this particle property. */
+      part_cell =
+          binary_search(/*low*/ 1, /*high*/ dims[dim] - 1, grid_prop, part_val);
+
+      /* Calculate the fraction. Note, here we do the cell containing the
+       * particle, the cell below is calculated from this fraction. */
+      frac = (part_val - grid_prop[part_cell - 1]) /
+             (grid_prop[part_cell] - grid_prop[part_cell - 1]);
+    }
+
+    /* Set the fractions. */
+    fracs[dim * 2 + 1] *= frac;
+    fracs[dim * 2] *= 1 - frac;
+
+    /* Set these indices. */
+    for (int jdim = 0; jdim < ndim; jdim++) {
+      frac_indices[jdim * 2][dim] = part_cell - 1;
+      frac_indices[jdim * 2 + 1][dim] = part_cell;
+    }
+  }
+
+  /* Now loop over this collection of cells collecting and setting their
+   * weights. */
+  for (int icell = 0; icell < (int)pow(2, (double)ndim); icell++) {
+
+    /* Early skip for cells contributing a 0 fraction. */
+    if (fracs[icell] <= 0)
+      continue;
+
+    /* We have a contribution, get the flattened index into the grid array. */
+    const int weight_ind = get_flat_index(frac_indices[icell], dims, ndim);
+
+    /* Add the weight. */
+    weights[weight_ind] += mass * fracs[icell];
+  }
+}

--- a/src/synthesizer/extensions/weights.h
+++ b/src/synthesizer/extensions/weights.h
@@ -86,7 +86,7 @@ int binary_search(int low, int high, const double *arr, const double val) {
  * @param ndim: The number of grid dimensions.
  * @param p: Index of the current particle.
  */
-void weight_loop_CIC(const double **grid_props, const double **part_props,
+void weight_loop_cic(const double **grid_props, const double **part_props,
                      const double mass, double *weights, const int *dims,
                      const int ndim, const int p) {
 

--- a/src/synthesizer/extensions/weights.h
+++ b/src/synthesizer/extensions/weights.h
@@ -2,10 +2,8 @@
  * A C module containing all the weights functions common to all particle
  * spectra extensions.
  *****************************************************************************/
+/* C includes */
 #include <math.h>
-
-/* Define a macro to handle that bzero is non-standard. */
-#define bzero(b, len) (memset((b), '\0', (len)), (void)0)
 
 /**
  * @brief Compute an ndimensional index from a flat index.

--- a/src/synthesizer/extensions/weights.h
+++ b/src/synthesizer/extensions/weights.h
@@ -68,7 +68,13 @@ int binary_search(int low, int high, const double *arr, const double val) {
     /* Compute the new range. */
     diff = high - low;
   }
-  return low;
+
+  /* Return the nearest grid point. */
+  if ((val - arr[low]) < (arr[high] - val)) {
+    return high;
+  } else {
+    return low;
+  }
 }
 
 /**
@@ -127,7 +133,12 @@ void weight_loop_cic(const double **grid_props, const double **part_props,
 
       /* Find the grid index corresponding to this particle property. */
       part_cell =
-          binary_search(/*low*/ 1, /*high*/ dims[dim] - 1, grid_prop, part_val);
+          binary_search(/*low*/ 0, /*high*/ dims[dim] - 1, grid_prop, part_val);
+
+      /* Make sure we have the cell containing the particle. */
+      if (grid_prop[part_cell] < part_val) {
+        part_cell += 1;
+      }
 
       /* Calculate the fraction. Note, here we do the cell containing the
        * particle, the cell below is calculated from this fraction. */
@@ -218,7 +229,7 @@ void weight_loop_ngp(const double **grid_props, const double **part_props,
 
       /* Find the grid index corresponding to this particle property. */
       part_cell =
-          binary_search(/*low*/ 1, /*high*/ dims[dim] - 1, grid_prop, part_val);
+          binary_search(/*low*/ 0, /*high*/ dims[dim] - 1, grid_prop, part_val);
     }
 
     /* Set the index. */

--- a/src/synthesizer/extensions/weights.h
+++ b/src/synthesizer/extensions/weights.h
@@ -146,6 +146,7 @@ void weight_loop_cic(const double **grid_props, const double **part_props,
   for (int idim = 0; idim < ndim; idim++) {
     sub_dims[idim] = 2;
   }
+
   /* Now loop over this collection of cells collecting and setting their
    * weights. */
   for (int icell = 0; icell < (int)pow(2, (double)ndim); icell++) {

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -92,18 +92,18 @@ class Stars(StarsComponent):
     initial_mass = Quantity()
 
     def __init__(
-            self,
-            log10ages,
-            metallicities,
-            initial_mass=1.0,
-            morphology=None,
-            sfzh=None,
-            sf_hist=None,
-            metal_dist=None,
-            sf_hist_func=None,
-            metal_dist_func=None,
-            instant_sf=None,
-            instant_metallicity=None,
+        self,
+        log10ages,
+        metallicities,
+        initial_mass=1.0,
+        morphology=None,
+        sfzh=None,
+        sf_hist=None,
+        metal_dist=None,
+        sf_hist_func=None,
+        metal_dist_func=None,
+        instant_sf=None,
+        instant_metallicity=None,
     ):
         """
         Initialise the parametric stellar population.
@@ -153,7 +153,7 @@ class Stars(StarsComponent):
         """
 
         # Instantiate the parent
-        StarsComponent.__init__(self, 10 ** log10ages, metallicities)
+        StarsComponent.__init__(self, 10**log10ages, metallicities)
 
         # Set the age grid properties
         self.log10ages = log10ages
@@ -185,7 +185,6 @@ class Stars(StarsComponent):
         # If we have been handed an explict SFZH grid we can ignore all the
         # calculation methods
         if sfzh is not None:
-
             # Store the SFZH grid
             self.sfzh = sfzh
 
@@ -196,7 +195,6 @@ class Stars(StarsComponent):
             self.metal_dist = np.sum(self.sfzh, axis=0)
 
         else:
-
             # Set up the array ready for the calculation
             self.sfzh = np.zeros((len(log10ages), len(metallicities)))
 
@@ -212,9 +210,7 @@ class Stars(StarsComponent):
             # Regular linearly
             self.metallicity_grid_type = "Z"
 
-        elif len(set(
-                self.log10metallicities[:-1] - self.log10metallicities[1:]
-        )) == 1:
+        elif len(set(self.log10metallicities[:-1] - self.log10metallicities[1:])) == 1:
             # Regular in logspace
             self.metallicity_grid_type = "log10Z"
 
@@ -244,7 +240,6 @@ class Stars(StarsComponent):
 
         # Handle the instantaneous SFH case
         if instant_sf is not None:
-
             # Create SFH array
             self.sf_hist = np.zeros(self.ages.size)
 
@@ -260,7 +255,6 @@ class Stars(StarsComponent):
 
         # Handle the instantaneous ZH case
         if instant_metallicity is not None:
-
             # Create SFH array
             self.metal_dist = np.zeros(self.metallicities.size)
 
@@ -270,7 +264,6 @@ class Stars(StarsComponent):
 
         # Calculate SFH from function if necessary
         if self.sf_hist_func is not None and self.sf_hist is None:
-
             # Set up SFH array
             self.sf_hist = np.zeros(self.ages.size)
 
@@ -284,7 +277,6 @@ class Stars(StarsComponent):
 
         # Calculate SFH from function if necessary
         if self.metal_dist_func is not None and self.metal_dist is None:
-
             # Set up SFH array
             self.metal_dist = np.zeros(self.metallicities.size)
 
@@ -368,9 +360,7 @@ class Stars(StarsComponent):
         sfzh = np.expand_dims(self.sfzh, axis=2)
 
         # Account for the SFZH mask in the non-zero indices
-        non_zero_inds = (
-            non_zero_inds[0][sfzh_mask], non_zero_inds[1][sfzh_mask]
-        )
+        non_zero_inds = (non_zero_inds[0][sfzh_mask], non_zero_inds[1][sfzh_mask])
 
         # Compute the spectra
         spectra = np.sum(
@@ -408,7 +398,6 @@ class Stars(StarsComponent):
 
         # If the line_id is a str denoting a single line
         if isinstance(line_id, str):
-
             # Get the grid information we need
             grid_line = grid.lines[line_id]
             wavelength = grid_line["wavelength"]
@@ -419,9 +408,7 @@ class Stars(StarsComponent):
             )
 
             # Continuum at line wavelength, erg/s/Hz
-            continuum = np.sum(
-                grid_line["continuum"] * self.sfzh, axis=(0, 1)
-            )
+            continuum = np.sum(grid_line["continuum"] * self.sfzh, axis=(0, 1))
 
             # NOTE: this is currently incorrect and should be made of the
             # separated nebular and stellar continuum emission
@@ -436,7 +423,6 @@ class Stars(StarsComponent):
 
         # Else if the line is list or tuple denoting a doublet (or higher)
         elif isinstance(line_id, (list, tuple)):
-
             # Set up containers for the line information
             luminosity = []
             continuum = []
@@ -452,16 +438,12 @@ class Stars(StarsComponent):
                 # Line luminosity erg/s
                 luminosity.append(
                     (1 - fesc)
-                    * np.sum(
-                        grid_line["luminosity"] * self.sfzh, axis=(0, 1)
-                    )
+                    * np.sum(grid_line["luminosity"] * self.sfzh, axis=(0, 1))
                 )
 
                 # Continuum at line wavelength, erg/s/Hz
                 continuum.append(
-                    np.sum(
-                        grid_line["continuum"] * self.sfzh, axis=(0, 1)
-                    )
+                    np.sum(grid_line["continuum"] * self.sfzh, axis=(0, 1))
                 )
 
         else:
@@ -520,8 +502,9 @@ class Stars(StarsComponent):
                 The other instance of Stars to add to this one.
         """
 
-        if (np.all(self.log10ages == other_stars.log10ages) and
-            np.all(self.metallicities == other_stars.metallicities)):
+        if np.all(self.log10ages == other_stars.log10ages) and np.all(
+            self.metallicities == other_stars.metallicities
+        ):
             new_sfzh = self.sfzh + other_stars.sfzh
 
         else:


### PR DESCRIPTION
This PR addresses the issues observed when comparing parametric and particle derived spectra. 

The code surrounding this process was somewhat convoluted due to the parts that needed to handle arbitrary dimensions. This complexity had lots of scope to introduce mistakes and one had been introduced in the assignment of grid indices. The cause of this issue was a logical expression which should have been `>=` but was just `>`. 

This PR has not only fixed the code and simplified it dramatically it:
- Removes the recursive method in favour of a clearer iterative method that still works for arbitrarily many directions.
- Closes #278, by the introduction of a `grid_assignment_method` argument which can either take `"cic"/"CIC"` to use the old "interpolation" like method, or `"ngp"/"NGP"` to use a new nearest grid point method.
- Introduces `**kwargs` in all spectra method arguments to enable the passing of keywords to `generate_lnu`/`generate_particle_lnu`. This addresses an issue where most spectra methods couldn't turn off the grid bounds check.
- Introduces methods (and C extensions) to calculate a binned SFZH (i.e. the grid weights) for particle based `Stars` objects, analogous to the parametric SFZH. This makes sanity checks easier since both the parametric and particle `Stars` objects can now be compared on common ground.
- Adds an example test comparing a single particle SFZH and an instantaneous SFZH.
- Introduces an example comparing the grid assignment methods.

In the process of checking this works I checked:
- Single stars match between the particle and parametric methods.
- A single star particle when sampling exactly on a grid point behaves as expected.
- A single star particle when sampling between grid points behaves as expected, with the correct assignment of mass to grid points.
- The two assignment schemes give comparable results.

Here is a comparison of single star SFZH histories with the fixed code (CIC):

![Fixed_CIC](https://github.com/flaresimulations/synthesizer/assets/40025495/b2c57470-de6e-47f4-bc39-43e30629e684)

Here is a comparison of single star SFZH histories with the fixed code (NGP):

![Fixed_NGP](https://github.com/flaresimulations/synthesizer/assets/40025495/15661a39-9e03-4488-9095-de733bf16d51)

And here are the spectra (exactly overlaid on each other):

![sucess](https://github.com/flaresimulations/synthesizer/assets/40025495/301bb7e6-865c-4801-af63-250acdda0446)

Finally here is the comparison between assignment methods:

![grid_comp](https://github.com/flaresimulations/synthesizer/assets/40025495/14e62707-f81c-4fda-a0ce-afcd8c99e66d)

All of these plots can be produced by the examples.

## Issue Type
<!-- delete options below as required -->
- Bug
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
