### PR TITLE
FIx self reference in apply_attenuation

### DIFF
--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -1008,7 +1008,7 @@ class Sed:
                     "Arrays of tau_v values are only applicable for Seds"
                     " containing multiple spectra"
                 )
-            if self._lnu.shape[0] != self.tau_v.size:
+            if self._lnu.shape[0] != tau_v.size:
                 raise exceptions.InconsistentArguments(
                     "tau_v and spectra are incompatible shapes "
                     f"({tau_v.shape}, {self._lnu.shape})"


### PR DESCRIPTION
The `apply_attenuation` method on Sed references a `tau_v` array on Sed, rather than the argument passed to the function, leading to an error.

This patch fixes the reference to the argument

## Issue Type
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x ] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
