### PR TITLE
Improve the out of grid bounds error

### DIFF
--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -417,7 +417,7 @@ class Stars(Particles, StarsComponent):
             ].size
 
             # How many particles lie above the grid limits?
-            n_above_age = self.log10ages[self.log10ages < grid.log10age[-1]].size
+            n_above_age = self.log10ages[self.log10ages > grid.log10age[-1]].size
             n_above_metal = self.metallicities[
                 self.metallicities > grid.metallicity[-1]
             ].size
@@ -450,16 +450,16 @@ class Stars(Particles, StarsComponent):
                 )
                 print(f"Of these:")
                 print(
-                    f"{n_below_age / self.nparticles:.2f}% have log10(ages/yr) > {grid.log10age[0]}"
+                    f"  {n_below_age / self.nparticles * 100:.2f}% have log10(ages/yr) > {grid.log10age[0]}"
                 )
                 print(
-                    f"{n_below_metal / self.nparticles:.2f}% have metallicities  < {grid.metallicity[0]}"
+                    f"  {n_below_metal / self.nparticles * 100:.2f}% have metallicities < {grid.metallicity[0]}"
                 )
                 print(
-                    f"{n_above_age / self.nparticles:.2f}% have log10(ages/yr) > {grid.log10age[-1]}"
+                    f"  {n_above_age / self.nparticles * 100:.2f}% have log10(ages/yr) > {grid.log10age[-1]}"
                 )
                 print(
-                    f"{n_above_metal / self.nparticles:.2f}% have metallicities  > {grid.metallicity[-1]}"
+                    f"  {n_above_metal / self.nparticles * 100:.2f}% have metallicities > {grid.metallicity[-1]}"
                 )
 
         # Get particle age masks
@@ -631,7 +631,7 @@ class Stars(Particles, StarsComponent):
             ].size
 
             # How many particles lie above the grid limits?
-            n_above_age = self.log10ages[self.log10ages < grid.log10age[-1]].size
+            n_above_age = self.log10ages[self.log10ages > grid.log10age[-1]].size
             n_above_metal = self.metallicities[
                 self.metallicities > grid.metallicity[-1]
             ].size
@@ -664,16 +664,16 @@ class Stars(Particles, StarsComponent):
                 )
                 print(f"Of these:")
                 print(
-                    f"{n_below_age / self.nparticles:.2f}% have log10(ages/yr) < {grid.log10age[0]}"
+                    f"  {n_below_age / self.nparticles * 100:.2f}% have log10(ages/yr) < {grid.log10age[0]}"
                 )
                 print(
-                    f"{n_below_metal / self.nparticles:.2f}% have metallicities  < {grid.metallicity[0]}"
+                    f"  {n_below_metal / self.nparticles * 100:.2f}% have metallicities < {grid.metallicity[0]}"
                 )
                 print(
-                    f"{n_above_age / self.nparticles:.2f}% have log10(ages/yr) > {grid.log10age[-1]}"
+                    f"  {n_above_age / self.nparticles * 100:.2f}% have log10(ages/yr) > {grid.log10age[-1]}"
                 )
                 print(
-                    f"{n_above_metal / self.nparticles:.2f}% have metallicities  > {grid.metallicity[-1]}"
+                    f"  {n_above_metal / self.nparticles * 100:.2f}% have metallicities > {grid.metallicity[-1]}"
                 )
 
         # Get particle age masks

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -360,7 +360,7 @@ class Stars(Particles, StarsComponent):
         young=False,
         old=False,
         verbose=False,
-        do_grid_check=True,
+        do_grid_check=False,
         grid_assignment_method="cic",
     ):
         """
@@ -574,7 +574,7 @@ class Stars(Particles, StarsComponent):
         young=False,
         old=False,
         verbose=False,
-        do_grid_check=True,
+        do_grid_check=False,
         grid_assignment_method="cic",
     ):
         """

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -410,6 +410,18 @@ class Stars(Particles, StarsComponent):
 
         # Are we checking the particles are consistent with the grid?
         if do_grid_check:
+            # How many particles lie below the grid limits?
+            n_below_age = self.log10ages[self.log10ages < grid.log10age[0]].size
+            n_below_metal = self.metallicities[
+                self.metallicities < grid.metallicity[0]
+            ].size
+
+            # How many particles lie above the grid limits?
+            n_above_age = self.log10ages[self.log10ages < grid.log10age[-1]].size
+            n_above_metal = self.metallicities[
+                self.metallicities > grid.metallicity[-1]
+            ].size
+
             # Check the fraction of particles outside of the grid (these will be
             # pinned to the edge of the grid) by finding those inside
             age_inside_mask = np.logical_and(
@@ -432,7 +444,23 @@ class Stars(Particles, StarsComponent):
 
             # Tell the user if there are particles outside the grid
             if ratio_out > 0:
-                print(f"{ratio_out * 100:.2f}% of particles lie outside the grid!")
+                print(
+                    f"{ratio_out * 100:.2f}% of particles lie outside the grid! "
+                    "These will be pinned at the grid limits."
+                )
+                print(f"Of these:")
+                print(
+                    f"{n_below_age / self.nparticles:.2f}% have log10(ages/yr)  < {grid.log10age[0]}"
+                )
+                print(
+                    f"{n_below_metal / self.nparticles:.2f}% have metallicities < {grid.metallicity[0]}"
+                )
+                print(
+                    f"{n_above_age / self.nparticles:.2f}% have log10(ages/yr)  > {grid.log10age[-1]}"
+                )
+                print(
+                    f"{n_above_metal / self.nparticles:.2f}% have metallicities > {grid.metallicity[-1]}"
+                )
 
         # Get particle age masks
         mask = self._get_masks(young, old)
@@ -596,6 +624,18 @@ class Stars(Particles, StarsComponent):
 
         # Are we checking the particles are consistent with the grid?
         if do_grid_check:
+            # How many particles lie below the grid limits?
+            n_below_age = self.log10ages[self.log10ages < grid.log10age[0]].size
+            n_below_metal = self.metallicities[
+                self.metallicities < grid.metallicity[0]
+            ].size
+
+            # How many particles lie above the grid limits?
+            n_above_age = self.log10ages[self.log10ages < grid.log10age[-1]].size
+            n_above_metal = self.metallicities[
+                self.metallicities > grid.metallicity[-1]
+            ].size
+
             # Check the fraction of particles outside of the grid (these will be
             # pinned to the edge of the grid) by finding those inside
             age_inside_mask = np.logical_and(
@@ -618,7 +658,23 @@ class Stars(Particles, StarsComponent):
 
             # Tell the user if there are particles outside the grid
             if ratio_out > 0:
-                print(f"{ratio_out * 100:.2f}% of particles lie outside the grid!")
+                print(
+                    f"{ratio_out * 100:.2f}% of particles lie outside the grid! "
+                    "These will be pinned at the grid limits."
+                )
+                print(f"Of these:")
+                print(
+                    f"{n_below_age / self.nparticles:.2f}% have log10(ages/yr)  < {grid.log10age[0]}"
+                )
+                print(
+                    f"{n_below_metal / self.nparticles:.2f}% have metallicities < {grid.metallicity[0]}"
+                )
+                print(
+                    f"{n_above_age / self.nparticles:.2f}% have log10(ages/yr)  > {grid.log10age[-1]}"
+                )
+                print(
+                    f"{n_above_metal / self.nparticles:.2f}% have metallicities > {grid.metallicity[-1]}"
+                )
 
         # Get particle age masks
         mask = self._get_masks(young, old)

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -450,16 +450,16 @@ class Stars(Particles, StarsComponent):
                 )
                 print(f"Of these:")
                 print(
-                    f"{n_below_age / self.nparticles:.2f}% have log10(ages/yr)  < {grid.log10age[0]}"
+                    f"{n_below_age / self.nparticles:.2f}% have log10(ages/yr) > {grid.log10age[0]}"
                 )
                 print(
-                    f"{n_below_metal / self.nparticles:.2f}% have metallicities < {grid.metallicity[0]}"
+                    f"{n_below_metal / self.nparticles:.2f}% have metallicities  < {grid.metallicity[0]}"
                 )
                 print(
-                    f"{n_above_age / self.nparticles:.2f}% have log10(ages/yr)  > {grid.log10age[-1]}"
+                    f"{n_above_age / self.nparticles:.2f}% have log10(ages/yr) > {grid.log10age[-1]}"
                 )
                 print(
-                    f"{n_above_metal / self.nparticles:.2f}% have metallicities > {grid.metallicity[-1]}"
+                    f"{n_above_metal / self.nparticles:.2f}% have metallicities  > {grid.metallicity[-1]}"
                 )
 
         # Get particle age masks
@@ -664,16 +664,16 @@ class Stars(Particles, StarsComponent):
                 )
                 print(f"Of these:")
                 print(
-                    f"{n_below_age / self.nparticles:.2f}% have log10(ages/yr)  < {grid.log10age[0]}"
+                    f"{n_below_age / self.nparticles:.2f}% have log10(ages/yr) < {grid.log10age[0]}"
                 )
                 print(
-                    f"{n_below_metal / self.nparticles:.2f}% have metallicities < {grid.metallicity[0]}"
+                    f"{n_below_metal / self.nparticles:.2f}% have metallicities  < {grid.metallicity[0]}"
                 )
                 print(
-                    f"{n_above_age / self.nparticles:.2f}% have log10(ages/yr)  > {grid.log10age[-1]}"
+                    f"{n_above_age / self.nparticles:.2f}% have log10(ages/yr) > {grid.log10age[-1]}"
                 )
                 print(
-                    f"{n_above_metal / self.nparticles:.2f}% have metallicities > {grid.metallicity[-1]}"
+                    f"{n_above_metal / self.nparticles:.2f}% have metallicities  > {grid.metallicity[-1]}"
                 )
 
         # Get particle age masks


### PR DESCRIPTION
This PR:

- Makes the grid bounds error `False` by default so it has to be actively turned on when debugging.
- Adds a report of the percentage of points above or below the limits.
- Closes #440 

For now, this is specific to age and metallicity but can be easily generalised in the future when needed.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
