### PR TITLE
Scaling parametric galaxy mass to achieve luminosity/flux

### DIFF
--- a/examples/parametric/plot_scale_by_luminosity.py
+++ b/examples/parametric/plot_scale_by_luminosity.py
@@ -1,0 +1,169 @@
+""" An example showing how to scale a galaxies mass by luminosity/flux.
+
+Parametric galaxies scale their brightness based on their initial stellar
+mass which is passed at instantiation. This example shows how a galaxy
+can later be scaled in terms of mass to achieve a particular brightness in
+a particular filter.
+"""
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+from astropy.cosmology import Planck18 as cosmo
+from unyt import Myr, Msun, erg, s, Hz, nJy
+
+from synthesizer.grid import Grid
+from synthesizer.filters import Filter
+from synthesizer.parametric import Stars, SFH, ZDist
+from synthesizer import galaxy
+from synthesizer.utils import m_to_fnu, flux_to_luminosity
+
+
+# Set up a figure to plot on
+fig = plt.figure()
+ax_lum = fig.add_subplot(111)
+
+# Set up the flux y axis
+ax_flux = ax_lum.twinx()
+
+# Enforce logscale
+ax_lum.loglog()
+ax_flux.loglog()
+
+# Define the grid
+grid_name = "test_grid"
+grid_dir = "../../tests/test_grid/"
+grid = Grid(grid_name, grid_dir=grid_dir)
+
+# Set up the SFH
+sfh = SFH.Constant(duration=100 * Myr)
+
+# Set up the metallicity distribution
+metal_dist = ZDist.Normal(mean=0.01, sigma=0.005)
+
+# Get the stellar population
+stars = Stars(
+    grid.log10age,
+    grid.metallicity,
+    sf_hist=sfh,
+    metal_dist=metal_dist,
+    initial_mass=10**9 * Msun,
+)
+
+# And make a galaxy containing this stellar population
+redshift = 12
+gal = galaxy(stars=stars, redshift=redshift)
+
+# Generate spectra using pacman model (complex)
+gal.stars.get_spectra_pacman(
+    grid,
+    fesc=0.5,
+    fesc_LyA=0.5,
+    tau_v=0.1,
+)
+
+# Get the observed spectra
+gal.get_observed_spectra(cosmo=cosmo)
+
+# Plot the original spectra
+ax_lum.plot(
+    gal.stars.spectra["attenuated"]._lam,
+    gal.stars.spectra["attenuated"]._lnu,
+    color="m",
+    linestyle="--",
+    alpha=0.7,
+)
+ax_flux.plot(
+    gal.stars.spectra["attenuated"]._obslam,
+    gal.stars.spectra["attenuated"]._fnu,
+    color="m",
+    label=(
+        "Original ($\log_{10}(M_\star / M_\odot)"
+        + f"={np.log10(gal.stars.initial_mass):.2f})$"
+    ),
+    alpha=0.7,
+)
+
+# Define a filter in which we will scale the galaxy
+f = Filter(filter_code="JWST/NIRCam.F150W", new_lam=grid.lam)
+
+# First lets scale by luminosity
+scale_lum = 10**25.0 * erg
+gal.stars.scale_mass_by_luminosity(
+    lum=scale_lum,
+    scale_filter=f,
+    spectra_type="attenuated",
+)
+
+# Plot the luminosity scaled spectra
+ax_lum.plot(
+    gal.stars.spectra["attenuated"]._lam,
+    gal.stars.spectra["attenuated"]._lnu,
+    color="c",
+    linestyle="--",
+    alpha=0.7,
+)
+ax_flux.plot(
+    gal.stars.spectra["attenuated"]._obslam,
+    gal.stars.spectra["attenuated"]._fnu,
+    color="c",
+    label=(
+        "Luminosity scaled ($\log_{10}(M_\star / M_\odot)"
+        + f"={np.log10(gal.stars.initial_mass):.2f})$"
+    ),
+    alpha=0.7,
+)
+
+# And scale by flux
+scale_flux = m_to_fnu(20)
+print(scale_flux)
+gal.stars.scale_mass_by_flux(
+    flux=scale_flux,
+    scale_filter=f,
+    spectra_type="attenuated",
+)
+
+# Plot the luminosity scaled spectra
+ax_lum.plot(
+    gal.stars.spectra["attenuated"]._lam,
+    gal.stars.spectra["attenuated"]._lnu,
+    color="orange",
+    linestyle="--",
+    alpha=0.7,
+)
+ax_flux.plot(
+    gal.stars.spectra["attenuated"]._obslam,
+    gal.stars.spectra["attenuated"]._fnu,
+    color="orange",
+    label=(
+        "Flux scaled ($\log_{10}(M_\star / M_\odot)"
+        + f"={np.log10(gal.stars.initial_mass):.2f})$"
+    ),
+    alpha=0.7,
+)
+
+# Label axes
+x_units = str(gal.stars.spectra["attenuated"].lam.units)
+y_units_lnu = str(gal.stars.spectra["attenuated"].lnu.units)
+y_units_fnu = str(gal.stars.spectra["attenuated"].fnu.units)
+ax_lum.set_xlabel(r"$\lambda/[\mathrm{" + x_units + r"}]$")
+ax_lum.set_ylabel(r"$L_{\nu}/[\mathrm{" + y_units_lnu + r"}]$")
+ax_flux.set_ylabel(r"$F_{\nu}/[\mathrm{" + y_units_fnu + r"}]$")
+
+
+# Make the legend
+legend_handles = [
+    Line2D([0], [0], color="k", linestyle="--"),
+    Line2D([0], [0], color="k", linestyle="-"),
+]
+legend_labels = ["Luminosity", "Flux"]
+ax_flux.legend(loc="upper right")
+ax_lum.legend(handles=legend_handles, labels=legend_labels, loc="upper left")
+
+ax_lum.set_ylim(
+    flux_to_luminosity(10**-4, cosmo, redshift=redshift),
+    flux_to_luminosity(10**12.5, cosmo, redshift=redshift),
+)
+ax_flux.set_ylim(10**-4, 10**12.5)
+ax_lum.set_xlim(10**2, None)
+ax_flux.set_xlim(10**2, None)
+plt.show()

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -641,7 +641,7 @@ class Stars(StarsComponent):
             )
 
         # Calculate the current flux in scale_filter
-        current_flux = scale_filter.appy_filter(sed._fnu)
+        current_flux = scale_filter.appy_filter(sed._fnu, nu=sed._obsnu)
 
         # Calculate the conversion ratio between the requested and current
         # flux

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -27,6 +27,7 @@ from synthesizer.plt import single_histxy, mlabel
 from synthesizer.parametric.sf_hist import Common as SFHCommon
 from synthesizer.parametric.metal_dist import Common as ZDistCommon
 from synthesizer.units import Quantity
+from synthesizer.utils import has_units
 
 
 class Stars(StarsComponent):
@@ -542,6 +543,121 @@ class Stars(StarsComponent):
             raise exceptions.InconsistentAddition("SFZH must be the same shape")
 
         return Stars(self.log10ages, self.metallicities, sfzh=new_sfzh)
+
+    def scale_mass_by_luminosity(self, lum, scale_filter, spectra_type):
+        """
+        Scale the mass of the stellar population to match a luminosity in a
+        specific filter.
+
+        NOTE: This will overwrite the initial mass attribute.
+
+        Args:
+            lum (unyt_quantity)
+                The desried luminosity in scale_filter.
+            scale_filter (Filter)
+                The filter in which lum is measured.
+            spectra_type (str)
+                The spectra key with which to do this scaling, e.g. "incident"
+                or "emergent".
+
+        Raises
+            MissingSpectraType
+                If the requested spectra doesn't exist an error is thrown.
+        """
+
+        # Check we have the spectra
+        if spectra_type not in self.spectra:
+            raise exceptions.MissingSpectraType(
+                f"The requested spectra type ({spectra_type}) does not exist"
+                " in this stellar population. Have you called the "
+                "corresponding spectra method?"
+            )
+
+        # Check we have units
+        if not has_units(lum):
+            raise exceptions.IncorrectUnits("lum must be given with unyt units")
+
+        # Calculate the current luminosity in scale_filter
+        sed = self.spectra[spectra_type]
+        current_lum = scale_filter.appy_filter(sed._lnu)
+
+        # Calculate the conversion ratio between the requested and current
+        # luminosity
+        conversion = lum / current_lum
+
+        # Apply conversion to the masses
+        self.initial_mass *= conversion
+
+        # Apply the conversion to all spectra
+        for key in self.spectra:
+            self.spectra[key]._lnu *= conversion
+            if self.spectra[key]._fnu is not None:
+                self.spectra[key]._fnu *= conversion
+
+        # Apply correction to the SFZH
+        self.sfzh *= conversion
+
+    def scale_mass_by_flux(self, flux, scale_filter, spectra_type):
+        """
+        Scale the mass of the stellar population to match a flux in a
+        specific filter.
+
+        NOTE: This will overwrite the initial mass attribute.
+
+        Args:
+            flux (unyt_quantity)
+                The desried flux in scale_filter.
+            scale_filter (Filter)
+                The filter in which flux is measured.
+            spectra_type (str)
+                The spectra key with which to do this scaling, e.g. "incident"
+                or "emergent".
+
+        Raises
+            MissingSpectraType
+                If the requested spectra doesn't exist an error is thrown.
+        """
+
+        # Check we have the spectra
+        if spectra_type not in self.spectra:
+            raise exceptions.MissingSpectraType(
+                f"The requested spectra type ({spectra_type}) does not exist"
+                " in this stellar population. Have you called the "
+                "corresponding spectra method?"
+            )
+
+        # Check we have units
+        if not has_units(flux):
+            raise exceptions.IncorrectUnits("lum must be given with unyt units")
+
+        # Get the sed object
+        sed = self.spectra[spectra_type]
+
+        # Ensure we have a flux
+        if sed.fnu is None:
+            raise exceptions.MissingSpectraType(
+                "{spectra_type} does not have a flux! Make sure to"
+                " run Sed.get_fnu or Galaxy.get_observed_spectra"
+            )
+
+        # Calculate the current flux in scale_filter
+        current_flux = scale_filter.appy_filter(sed._fnu)
+
+        # Calculate the conversion ratio between the requested and current
+        # flux
+        conversion = flux / current_flux
+
+        # Apply conversion to the masses
+        self.initial_mass *= conversion
+
+        # Apply the conversion to all spectra
+        for key in self.spectra:
+            self.spectra[key]._lnu *= conversion
+            if self.spectra[key]._fnu is not None:
+                self.spectra[key]._fnu *= conversion
+
+        # Apply correction to the SFZH
+        self.sfzh *= conversion
 
     def plot_sfzh(self, show=True):
         """

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -579,7 +579,7 @@ class Stars(StarsComponent):
 
         # Calculate the current luminosity in scale_filter
         sed = self.spectra[spectra_type]
-        current_lum = scale_filter.appy_filter(sed._lnu)
+        current_lum = scale_filter.apply_filter(sed.lnu)
 
         # Calculate the conversion ratio between the requested and current
         # luminosity
@@ -641,7 +641,7 @@ class Stars(StarsComponent):
             )
 
         # Calculate the current flux in scale_filter
-        current_flux = scale_filter.appy_filter(sed._fnu, nu=sed._obsnu)
+        current_flux = scale_filter.apply_filter(sed.fnu, nu=sed.obsnu)
 
         # Calculate the conversion ratio between the requested and current
         # flux

--- a/src/synthesizer/utils.py
+++ b/src/synthesizer/utils.py
@@ -1,7 +1,7 @@
 import h5py
 import numpy as np
 import unyt
-from unyt import c, h, nJy, erg, s, Hz, pc, kb
+from unyt import c, h, nJy, erg, s, Hz, pc, kb, unyt_array, unyt_quantity
 
 
 def write_data_h5py(filename, name, data, overwrite=False):
@@ -14,8 +14,7 @@ def write_data_h5py(filename, name, data, overwrite=False):
                 del h5file[name]
                 h5file[name] = data
             else:
-                raise ValueError("Dataset already exists, "
-                                 + "and `overwrite` not set")
+                raise ValueError("Dataset already exists, " + "and `overwrite` not set")
         else:
             h5file.create_dataset(name, data=data)
 
@@ -190,11 +189,11 @@ def Lnu_to_M(Lnu_):
 def planck(nu, T):
     """
     Planck's law.
-        
+
     Args:
         nu (unyt_array/array-like, float)
             The frequencies at which to calculate the distribution.
-        T  (float/array-like, float)     
+        T  (float/array-like, float)
             The dust temperature. Either a single value or the same size
             as nu.
 
@@ -207,14 +206,13 @@ def planck(nu, T):
 
 
 def rebin_1d(a, i, func=np.sum):
-
     """
     A simple function for rebinning a 1D array using a specificed
     function (e.g. sum or mean).
 
     TODO: add exeption to make sure a is an 1D array and that i is an integer.
-    
-    Args: 
+
+    Args:
         a (ndarray)
             the input 1D array
         i (int)
@@ -224,14 +222,35 @@ def rebin_1d(a, i, func=np.sum):
 
 
     """
-    
+
     n = len(a)
 
     # if array is not the right size truncate it
     if n % i != 0:
-        a = a[:int(i * np.floor(n/i))]
+        a = a[: int(i * np.floor(n / i))]
 
     x = len(a) // i
     b = a.reshape(x, i)
 
     return func(b, axis=1)
+
+
+def has_units(x):
+    """
+    Check whether the passed variable has units, i.e. is a unyt_quanity or
+    unyt_array.
+
+    Args:
+        x (generic variable)
+            The variables to check.
+
+    Returns:
+        bool
+            True if the variable has units, False otherwise.
+    """
+
+    # Do the check
+    if isinstance(x, (unyt_array, unyt_quantity)):
+        return True
+
+    return False


### PR DESCRIPTION
This PR adds two methods (and an example): `scale_mass_by_luminosity` and `scale_mass_by_flux` on `parametric.Stars`.

These allow the user to provide a target luminosity/flux, a `Filter` in which that photometry is defined, and a `spectra_type` to use in the scaling. They then calculate the current luminosity/flux in that filter, calculate a conversion factor between the current and the desired luiminosity/flux and apply this conversion to the `Stars`' `initial_mass`, `sfzh`, and any spectra (both rest frame and observed, if present).

This closes #354 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
