### PR TITLE
Remove dust_attenutation dependency and set astropy version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,10 +78,10 @@ classifiers = [  # Optional
 # Dependancies
 dependencies = [
   "nbmake",
-  "astropy",
+  "astropy == 5.3.4",
   "h5py",
   "mpmath",
-  "numpy>=1.23",
+  "numpy >= 1.23",
   "packaging",
   "pyerfa",
   "pyparsing",
@@ -89,7 +89,6 @@ dependencies = [
   "scipy",
   "unyt",
   "cmasher",
-  "dust_attenuation@git+https://github.com/karllark/dust_attenuation.git@v0.5.dev",
   "dust_extinction",
   "nbsphinx",
   "matplotlib",


### PR DESCRIPTION
DWISOTT. Also sets the astropy version to ensure workflows don't fail (this is also set elsewhere). 

Issue raised on `dust_extinction` related to astropy version issue: https://github.com/karllark/dust_extinction/issues/197

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
