### PR TITLE
Removing __slots__ to fix `TypeError: multiple bases have instance lay-out conflict`

### DIFF
--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -28,14 +28,6 @@ class StarsComponent:
 
     """
 
-    # Define slots
-    # __slots__ = [
-    #     "_ages",
-    #     "metallicities",
-    #     "spectra",
-    #     "lines",
-    # ]
-
     # Define quantities
     ages = Quantity()
 

--- a/src/synthesizer/imaging/images.py
+++ b/src/synthesizer/imaging/images.py
@@ -87,30 +87,6 @@ class Image:
             FilterCollection is passed.
     """
 
-    # Define the slots to reduce the memory footprint
-    # TODO: For some reason defining these slots cause a "TypeError: multiple
-    # bases have instance lay-out conflict" error at import. I can't fathom
-    # why! For now left commented out.
-    __slots__ = [
-        "psfs",
-        "filters",
-        "img",
-        "img_psf",
-        "img_noise",
-        "imgs",
-        "imgs_psf",
-        "imgs_noise",
-        "rgb_image",
-        "combined_imgs",
-        "depths",
-        "snrs",
-        "apertures",
-        "weight_map",
-        "noise_arr",
-        "noise_arrs",
-        "weights_maps",
-    ]
-
     def __init__(
         self,
         filters=(),
@@ -327,7 +303,7 @@ class Image:
         else:
             self.psfs /= np.sum(self.psfs)
 
-    def _get_hist_img_single_filter(self):
+    def _get_hist_img_single_filter(self, *args):
         """
         A place holder to be overloaded on child classes for making histogram
         images.
@@ -337,7 +313,7 @@ class Image:
             "class. It is not designed to be called directly."
         )
 
-    def _get_img_single_filter(self):
+    def _get_img_single_filter(self, *args):
         """
         A place holder to be overloaded on child classes for making smoothed
         images.
@@ -1181,7 +1157,7 @@ class Image:
         print(ascii_img)
 
 
-class ParticleImage(ParticleScene, Image):
+class ParticleImage(Image, ParticleScene):
     """
     The Image object used when creating images from particle distributions.
     This can either be used by passing explict arrays of coordinates and values
@@ -1195,9 +1171,6 @@ class ParticleImage(ParticleScene, Image):
             The particles property array ot be softed into pixels. Only used
             if an Sed is not passed.
     """
-
-    # Define the slots to reduce the memory footprint
-    __slots__ = ["pixel_values"]
 
     def __init__(
         self,
@@ -1286,6 +1259,14 @@ class ParticleImage(ParticleScene, Image):
             filters = ()
 
         # Initilise the parent classes
+        Image.__init__(
+            self,
+            filters=filters,
+            psfs=psfs,
+            depths=depths,
+            apertures=apertures,
+            snrs=snrs,
+        )
         ParticleScene.__init__(
             self,
             resolution=resolution,
@@ -1300,14 +1281,6 @@ class ParticleImage(ParticleScene, Image):
             rest_frame=rest_frame,
             kernel=kernel,
             kernel_threshold=kernel_threshold,
-        )
-        Image.__init__(
-            self,
-            filters=filters,
-            psfs=psfs,
-            depths=depths,
-            apertures=apertures,
-            snrs=snrs,
         )
 
         # Set up standalone arrays used when Synthesizer objects are not
@@ -1430,13 +1403,6 @@ class ParametricImage(Scene, Image):
             None and a FilterCollection must be provided with an Sed to
             calculate ans subsequently smooth photometry into an image.
     """
-
-    # Define slots to reduce memory footprint
-    # __slots__ = [
-    #     "morphology",
-    #     "density_grid",
-    #     "smooth_value",
-    # ]
 
     def __init__(
         self,

--- a/src/synthesizer/imaging/images.py
+++ b/src/synthesizer/imaging/images.py
@@ -91,25 +91,25 @@ class Image:
     # TODO: For some reason defining these slots cause a "TypeError: multiple
     # bases have instance lay-out conflict" error at import. I can't fathom
     # why! For now left commented out.
-    # __slots__ = [
-    #     "psfs",
-    #     "filters",
-    #     "img",
-    #     "img_psf",
-    #     "img_noise",
-    #     "imgs",
-    #     "imgs_psf",
-    #     "imgs_noise",
-    #     "rgb_image",
-    #     "combined_imgs",
-    #     "depths",
-    #     "snrs",
-    #     "apertures",
-    #     "weight_map",
-    #     "noise_arr",
-    #     "noise_arrs",
-    #     "weights_maps",
-    # ]
+    __slots__ = [
+        "psfs",
+        "filters",
+        "img",
+        "img_psf",
+        "img_noise",
+        "imgs",
+        "imgs_psf",
+        "imgs_noise",
+        "rgb_image",
+        "combined_imgs",
+        "depths",
+        "snrs",
+        "apertures",
+        "weight_map",
+        "noise_arr",
+        "noise_arrs",
+        "weights_maps",
+    ]
 
     def __init__(
         self,

--- a/src/synthesizer/imaging/scene.py
+++ b/src/synthesizer/imaging/scene.py
@@ -38,6 +38,8 @@ class Scene:
             The Astropy object containing the cosmological model.
         redshift (float)
             The redshift of the observation.
+        rest_frame (bool)
+            Is the scene in the rest or observer frame?
     """
 
     # Define slots to reduce memory overhead of this class and limit the
@@ -51,6 +53,7 @@ class Scene:
         "orig_npix",
         "cosmo",
         "redshift",
+        "rest_frame",
     ]
 
     # Define quantities

--- a/src/synthesizer/imaging/scene.py
+++ b/src/synthesizer/imaging/scene.py
@@ -42,20 +42,6 @@ class Scene:
             Is the scene in the rest or observer frame?
     """
 
-    # Define slots to reduce memory overhead of this class and limit the
-    # possible attributes.
-    __slots__ = [
-        "_resolution",
-        "_fov",
-        "npix",
-        "sed",
-        "_orig_resolution",
-        "orig_npix",
-        "cosmo",
-        "redshift",
-        "rest_frame",
-    ]
-
     # Define quantities
     resolution = Quantity()
     fov = Quantity()
@@ -316,18 +302,6 @@ class ParticleScene(Scene):
             If an incompatible combination of arguments is provided an error is
             raised.
     """
-
-    # Define slots to reduce memory overhead of this class
-    __slots__ = [
-        "_coordinates",
-        "_centre",
-        "pix_pos",
-        "npart",
-        "_smoothing_lengths",
-        "kernel",
-        "kernel_threshold",
-        "kernel_dim",
-    ]
 
     # Define quantities
     coordinates = Quantity()

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -49,7 +49,7 @@ class BlackHoles(Particles):
     """
 
     # Define the allowed attributes
-    __slots__ = [
+    attrs = [
         "_masses",
         "_coordinates",
         "_velocities",
@@ -148,7 +148,7 @@ class BlackHoles(Particles):
         """
 
         # Ensure all arrays are the expected length
-        for key in self.__slots__:
+        for key in self.attrs:
             attr = getattr(self, key)
             if isinstance(attr, np.ndarray):
                 if attr.shape[0] != self.nparticles:

--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -40,7 +40,7 @@ class Galaxy(BaseGalaxy):
 
     """
 
-    __slots__ = [
+    attrs = [
         "lam",
         "stars",
         "gas",
@@ -108,7 +108,7 @@ class Galaxy(BaseGalaxy):
             self.calculate_integrated_gas_properties()
 
         # Ensure all attributes are initialised to None
-        for attr in Galaxy.__slots__:
+        for attr in Galaxy.attrs:
             try:
                 getattr(self, attr)
             except AttributeError:
@@ -463,10 +463,10 @@ class Galaxy(BaseGalaxy):
         """
         Calculate the gamma parameter, controlling the optical depth
         due to dust dependent on the mass and metallicity of star forming
-        gas. 
+        gas.
 
         gamma = gamma_max - (gamma_max - gamma_min) / C
-       
+
         C = 1 + (Z_SF / Z_MW) * (M_SF / M_star) * (1 / beta)
 
         gamma_max and gamma_min set the upper and lower bounds to which gamma
@@ -529,11 +529,9 @@ class Galaxy(BaseGalaxy):
             gamma = gamma_min
         elif stellar_mass == 0.0:
             gamma = gamma_min
-        else: 
-            C = (
-                1 + (sf_gas_metallicity / Z_norm)
-                * (sf_gas_mass / stellar_mass)
-                * (1.0 / beta)
+        else:
+            C = 1 + (sf_gas_metallicity / Z_norm) * (sf_gas_mass / stellar_mass) * (
+                1.0 / beta
             )
             gamma = gamma_max - (gamma_max - gamma_min) / C
 

--- a/src/synthesizer/particle/gas.py
+++ b/src/synthesizer/particle/gas.py
@@ -46,7 +46,7 @@ class Gas(Particles):
     """
 
     # Define the allowed attributes
-    __slots__ = [
+    attrs = [
         "metallicities",
         "star_forming",
         "log10metallicities",
@@ -75,7 +75,7 @@ class Gas(Particles):
         softening_length=None,
         dust_to_metal_ratio=None,
         dust_masses=None,
-        verbose=False
+        verbose=False,
     ):
         """
         Initialise the gas object.
@@ -125,11 +125,15 @@ class Gas(Particles):
         # Set the smoothing lengths for these gas particles
         self.smoothing_lengths = smoothing_lengths
 
-        # 
+        #
         if (dust_to_metal_ratio is None) & (dust_masses is None):
             if verbose:
-                print(("Neither dust mass nor dust to metal ratio "
-                       "provided. Assuming dust to metal ratio = 0.3"))
+                print(
+                    (
+                        "Neither dust mass nor dust to metal ratio "
+                        "provided. Assuming dust to metal ratio = 0.3"
+                    )
+                )
             self.dust_to_metal_ratio = 0.3
             self.calculate_dust_mass()
         elif dust_to_metal_ratio is not None:
@@ -142,11 +146,12 @@ class Gas(Particles):
 
             # TODO: this should be removed when dust masses are
             # properly propagated to LOS calculation
-            self.dust_to_metal_ratio = self.dust_masses /\
-                (self.masses * self.metallicities)
+            self.dust_to_metal_ratio = self.dust_masses / (
+                self.masses * self.metallicities
+            )
 
-            self.dust_to_metal_ratio[self.dust_masses == 0.] = 0.
-            self.dust_to_metal_ratio[self.metallicities == 0.] = 0.
+            self.dust_to_metal_ratio[self.dust_masses == 0.0] = 0.0
+            self.dust_to_metal_ratio[self.metallicities == 0.0] = 0.0
 
         # Check the arguments we've been given
         self._check_gas_args()
@@ -162,7 +167,7 @@ class Gas(Particles):
         """
 
         # Ensure all arrays are the expected length
-        for key in self.__slots__:
+        for key in self.attrs:
             attr = getattr(self, key)
             if isinstance(attr, np.ndarray):
                 if attr.shape[0] != self.nparticles:
@@ -176,5 +181,4 @@ class Gas(Particles):
         Calculate dust mass from a given dust-to-metals ratio
         and gas particle properties (mass and metallicity)
         """
-        self.dust_masses = self.masses *\
-            self.metallicities * self.dust_to_metal_ratio                    
+        self.dust_masses = self.masses * self.metallicities * self.dust_to_metal_ratio

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -35,9 +35,6 @@ class Particles:
             How many particles are there?
     """
 
-    # Define the allowed attributes
-    __slots__ = ["redshift", "nparticles"]
-
     # Define class level Quantity attributes
     coordinates = Quantity()
     velocities = Quantity()

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -80,7 +80,7 @@ class Stars(Particles, StarsComponent):
     """
 
     # Define the allowed attributes
-    __slots__ = [
+    attrs = [
         "nparticles",
         "tau_v",
         "alpha_enhancement",
@@ -238,7 +238,7 @@ class Stars(Particles, StarsComponent):
         """
 
         # Ensure all arrays are the expected length
-        for key in self.__slots__:
+        for key in self.attrs:
             attr = getattr(self, key)
             if isinstance(attr, np.ndarray):
                 if attr.shape[0] != self.nparticles:
@@ -974,7 +974,7 @@ class Stars(Particles, StarsComponent):
             print("Duplicate existing attributes")
 
         # Handle the other propertys that need duplicating
-        for attr in Stars.__slots__:
+        for attr in Stars.attrs:
             # Skip unset attributes
             if getattr(self, attr) is None:
                 continue
@@ -991,7 +991,7 @@ class Stars(Particles, StarsComponent):
             print("Delete old particles")
 
         # Loop over attributes
-        for attr in Stars.__slots__:
+        for attr in Stars.attrs:
             # Skip unset attributes
             if getattr(self, attr) is None:
                 continue


### PR DESCRIPTION
The error in the title is because only one parent class can have slots in multiple inheritance. In reality, the saving from slots was entirely negligible so it's better to remove them entirely.

In certain cases `__slots__` have been replaced by `attrs` to enable looping over all attributes in certain checks and additions. 

Closes #415 

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
