### PR TITLE
Fixing conversion import in plot_scale_by_luminosity

### DIFF
--- a/examples/parametric/plot_scale_by_luminosity.py
+++ b/examples/parametric/plot_scale_by_luminosity.py
@@ -17,7 +17,7 @@ from synthesizer.grid import Grid
 from synthesizer.filters import Filter
 from synthesizer.parametric import Stars, SFH, ZDist
 from synthesizer import galaxy
-from synthesizer.utils import m_to_fnu, flux_to_luminosity
+from synthesizer.conversions import apparent_mag_to_fnu, flux_to_luminosity
 
 
 # Set up a figure to plot on


### PR DESCRIPTION
I have no idea how this got onto `main` without causing errors... but PRs are failing because of an example trying to import conversions from `utils` which are now in `conversions` (with better naming). 

This PR fixes the import.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
