### PR TITLE
Convert a `Grid` to an `Sed`

### DIFF
--- a/docs/source/grids/grids_example.ipynb
+++ b/docs/source/grids/grids_example.ipynb
@@ -217,6 +217,28 @@
    "source": [
     "Note that this will overwrite the spectra and wavelengths read from the file. To get them back a separate `Grid` can be instatiated without the modified wavelength array."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Converting a `Grid` into an `Sed`\n",
+    "\n",
+    "Any of the spectra arrays stored within a `Grid` can be returned as `Sed` objects (see the `Sed` [docs](../sed.ipynb)). This enables all of the analysis methods provide on an Sed to be used on the whole spectra grid. To do this we simply call `get_sed` with the spectra type we want to extract and then use any of the included methods."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the sed object\n",
+    "sed = grid.get_sed(spectra_type=\"incident\")\n",
+    "\n",
+    "# Measure the balmer break for all spectra in the grid (limiting the output)\n",
+    "sed.measure_balmer_break()[5:10, 5:10]"
+   ]
   }
  ],
  "metadata": {

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -178,7 +178,7 @@ class Grid:
             otherwise, this is a list of the requested lines.
         read_spectra (bool/list)
             Flag for whether to read spectra.
-        spectra (array-like, float)
+        spectra (dict, array-like, float)
             The spectra array from the grid. This is an N-dimensional
             grid where N is the number of axes of the SPS grid. The final
             dimension is always wavelength.
@@ -395,18 +395,17 @@ class Grid:
 
         # Loop over spectra to interpolate
         for spectra_type in self.available_spectra:
-
             # Are we doing the look up in one go, or looping?
             if loop_grid:
                 new_spectra = [None] * len(self.spectra[spectra_type])
-                
+
                 # Loop over first axis of spectra array
                 for i, _spec in enumerate(self.spectra[spectra_type]):
                     new_spectra[i] = spectres(new_lam, self._lam, _spec)
-               
-                del self.spectra[spectra_type] 
+
+                del self.spectra[spectra_type]
                 new_spectra = np.asarray(new_spectra)
-            else:    
+            else:
                 # Evaluate the function at the desired wavelengths
                 new_spectra = spectres(new_lam, self._lam, self.spectra[spectra_type])
 
@@ -741,3 +740,19 @@ class Grid:
 
         # Return tuple of wavelengths and delta lambda
         return self.lam, delta_lambda
+
+    def get_sed(self, spectra_type):
+        """
+        Get the spectra grid as an Sed object enabling grid wide
+        use of Sed methods for flux, photometry, indices, ionising photons
+        etc.
+
+        Args:
+            spectra_type (string)
+                The key of the spectra grid to extract as an Sed object.
+
+        Returns:
+            Sed
+                The spectra grid as an Sed object.
+        """
+        return Sed(self.lam, self.spectra[spectra_type])


### PR DESCRIPTION
This PR implements `Grid.get_sed` to convert a particular spectra grid to a `Sed` object enabling all of the Sed methods to be used on a whole `Grid`. This is demonstrated in the `Grid` docs. 

Closes #333 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
