### PR TITLE
Enabling per particle escape fractions

### DIFF
--- a/src/synthesizer/extensions/integrated_spectra.c
+++ b/src/synthesizer/extensions/integrated_spectra.c
@@ -158,7 +158,7 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
     for (int ilam = 0; ilam < nlam; ilam++) {
 
       /* Add the contribution to this wavelength. */
-      /* fesc is already included in the weight. */
+      /* fesc is already included in the weight */
       spectra[ilam] += grid_spectra[spectra_ind + ilam] * weight;
     }
   }

--- a/src/synthesizer/extensions/integrated_spectra.c
+++ b/src/synthesizer/extensions/integrated_spectra.c
@@ -37,14 +37,14 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
 
   const int ndim;
   const int npart, nlam;
-  const double fesc;
   const PyObject *grid_tuple, *part_tuple;
   const PyArrayObject *np_grid_spectra;
+  const PyArrayObject *np_fesc;
   const PyArrayObject *np_part_mass, *np_ndims;
   const char *method;
 
-  if (!PyArg_ParseTuple(args, "OOOOdOiiis", &np_grid_spectra, &grid_tuple,
-                        &part_tuple, &np_part_mass, &fesc, &np_ndims, &ndim,
+  if (!PyArg_ParseTuple(args, "OOOOOOiiis", &np_grid_spectra, &grid_tuple,
+                        &part_tuple, &np_part_mass, &np_fesc, &np_ndims, &ndim,
                         &npart, &nlam, &method))
     return NULL;
 
@@ -68,6 +68,9 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
 
   /* Extract a pointer to the particle masses. */
   const double *part_mass = PyArray_DATA(np_part_mass);
+
+  /* Extract a pointer to the fesc array. */
+  const double *fesc = PyArray_DATA(np_fesc);
 
   /* Allocate a single array for grid properties*/
   int nprops = 0;
@@ -118,19 +121,19 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
     /* Finally, compute the weights for this particle using the
      * requested method. */
     if (strcmp(method, "cic") == 0) {
-      weight_loop_cic(grid_props, part_props, mass, grid_weights, dims, ndim,
-                      p);
+      weight_loop_cic(grid_props, part_props, mass, grid_weights, dims, ndim, p,
+                      fesc[p]);
     } else if (strcmp(method, "ngp") == 0) {
-      weight_loop_ngp(grid_props, part_props, mass, grid_weights, dims, ndim,
-                      p);
+      weight_loop_ngp(grid_props, part_props, mass, grid_weights, dims, ndim, p,
+                      fesc[p]);
     } else {
       /* Only print this warning once! */
       if (p == 0)
         printf(
             "Unrecognised gird assignment method (%s)! Falling back on CIC\n",
             method);
-      weight_loop_cic(grid_props, part_props, mass, grid_weights, dims, ndim,
-                      p);
+      weight_loop_cic(grid_props, part_props, mass, grid_weights, dims, ndim, p,
+                      fesc[p]);
     }
 
   } /* Loop over particles. */

--- a/src/synthesizer/extensions/integrated_spectra.c
+++ b/src/synthesizer/extensions/integrated_spectra.c
@@ -158,7 +158,8 @@ PyObject *compute_integrated_sed(PyObject *self, PyObject *args) {
     for (int ilam = 0; ilam < nlam; ilam++) {
 
       /* Add the contribution to this wavelength. */
-      spectra[ilam] += grid_spectra[spectra_ind + ilam] * (1 - fesc) * weight;
+      /* fesc is already included in the weight. */
+      spectra[ilam] += grid_spectra[spectra_ind + ilam] * weight;
     }
   }
 

--- a/src/synthesizer/extensions/particle_spectra.c
+++ b/src/synthesizer/extensions/particle_spectra.c
@@ -240,14 +240,14 @@ PyObject *compute_particle_seds(PyObject *self, PyObject *args) {
 
   const int ndim;
   const int npart, nlam;
-  const double fesc;
   const PyObject *grid_tuple, *part_tuple;
   const PyArrayObject *np_grid_spectra;
+  const PyArrayObject *np_fesc;
   const PyArrayObject *np_part_mass, *np_ndims;
   const char *method;
 
-  if (!PyArg_ParseTuple(args, "OOOOdOiiis", &np_grid_spectra, &grid_tuple,
-                        &part_tuple, &np_part_mass, &fesc, &np_ndims, &ndim,
+  if (!PyArg_ParseTuple(args, "OOOOOOiiis", &np_grid_spectra, &grid_tuple,
+                        &part_tuple, &np_part_mass, &np_fesc, &np_ndims, &ndim,
                         &npart, &nlam, &method))
     return NULL;
 
@@ -271,6 +271,9 @@ PyObject *compute_particle_seds(PyObject *self, PyObject *args) {
 
   /* Extract a pointer to the particle masses. */
   const double *part_mass = PyArray_DATA(np_part_mass);
+
+  /* Extract a pointer to the fesc array. */
+  const double *fesc = PyArray_DATA(np_fesc);
 
   /* Allocate a single array for grid properties*/
   int nprops = 0;
@@ -322,10 +325,10 @@ PyObject *compute_particle_seds(PyObject *self, PyObject *args) {
      * requested method. */
     if (strcmp(method, "cic") == 0) {
       spectra_loop_cic(grid_props, part_props, mass, grid_spectra, dims, ndim,
-                       spectra, nlam, fesc, p);
+                       spectra, nlam, fesc[p], p);
     } else if (strcmp(method, "ngp") == 0) {
       spectra_loop_ngp(grid_props, part_props, mass, grid_spectra, dims, ndim,
-                       spectra, nlam, fesc, p);
+                       spectra, nlam, fesc[p], p);
     } else {
       /* Only print this warning once */
       if (p == 0)
@@ -333,7 +336,7 @@ PyObject *compute_particle_seds(PyObject *self, PyObject *args) {
             "Unrecognised gird assignment method (%s)! Falling back on CIC\n",
             method);
       spectra_loop_cic(grid_props, part_props, mass, grid_spectra, dims, ndim,
-                       spectra, nlam, fesc, p);
+                       spectra, nlam, fesc[p], p);
     }
   }
 

--- a/src/synthesizer/extensions/sfzh.c
+++ b/src/synthesizer/extensions/sfzh.c
@@ -105,16 +105,16 @@ PyObject *compute_sfzh(PyObject *self, PyObject *args) {
     /* Finally, compute the weights for this particle using the
      * requested method. */
     if (strcmp(method, "cic") == 0) {
-      weight_loop_cic(grid_props, part_props, mass, sfzh, dims, ndim, p);
+      weight_loop_cic(grid_props, part_props, mass, sfzh, dims, ndim, p, 0);
     } else if (strcmp(method, "ngp") == 0) {
-      weight_loop_ngp(grid_props, part_props, mass, sfzh, dims, ndim, p);
+      weight_loop_ngp(grid_props, part_props, mass, sfzh, dims, ndim, p, 0);
     } else {
       /* Only print this warning once! */
       if (p == 0)
         printf(
             "Unrecognised gird assignment method (%s)! Falling back on CIC\n",
             method);
-      weight_loop_cic(grid_props, part_props, mass, sfzh, dims, ndim, p);
+      weight_loop_cic(grid_props, part_props, mass, sfzh, dims, ndim, p, 0);
     }
 
   } /* Loop over particles. */

--- a/src/synthesizer/extensions/weights.h
+++ b/src/synthesizer/extensions/weights.h
@@ -88,7 +88,7 @@ int binary_search(int low, int high, const double *arr, const double val) {
  */
 void weight_loop_cic(const double **grid_props, const double **part_props,
                      const double mass, double *weights, const int *dims,
-                     const int ndim, const int p) {
+                     const int ndim, const int p, const double fesc) {
 
   /* Setup the index and mass fraction arrays. */
   int part_indices[ndim];
@@ -179,7 +179,7 @@ void weight_loop_cic(const double **grid_props, const double **part_props,
     const int weight_ind = get_flat_index(frac_ind, dims, ndim);
 
     /* Add the weight. */
-    weights[weight_ind] += (mass * frac);
+    weights[weight_ind] += (mass * frac * (1 - fesc));
   }
 }
 
@@ -198,7 +198,7 @@ void weight_loop_cic(const double **grid_props, const double **part_props,
  */
 void weight_loop_ngp(const double **grid_props, const double **part_props,
                      const double mass, double *weights, const int *dims,
-                     const int ndim, const int p) {
+                     const int ndim, const int p, const double fesc) {
 
   /* Setup the index array. */
   int part_indices[ndim];
@@ -246,5 +246,5 @@ void weight_loop_ngp(const double **grid_props, const double **part_props,
   const int weight_ind = get_flat_index(part_indices, dims, ndim);
 
   /* Add the weight. */
-  weights[weight_ind] += mass;
+  weights[weight_ind] += (mass * (1 - fesc));
 }

--- a/src/synthesizer/extensions/weights.h
+++ b/src/synthesizer/extensions/weights.h
@@ -85,6 +85,7 @@ int binary_search(int low, int high, const double *arr, const double val) {
  * @param dims: The length of each grid dimension.
  * @param ndim: The number of grid dimensions.
  * @param p: Index of the current particle.
+ * @param fesc: The escape fraction.
  */
 void weight_loop_cic(const double **grid_props, const double **part_props,
                      const double mass, double *weights, const int *dims,
@@ -195,6 +196,7 @@ void weight_loop_cic(const double **grid_props, const double **part_props,
  * @param dims: The length of each grid dimension.
  * @param ndim: The number of grid dimensions.
  * @param p: Index of the current particle.
+ * @param fesc: The escape fraction.
  */
 void weight_loop_ngp(const double **grid_props, const double **part_props,
                      const double mass, double *weights, const int *dims,

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -343,7 +343,7 @@ class Stars(Particles, StarsComponent):
 
         # If fesc isn't an array make it one
         if not isinstance(fesc, np.ndarray):
-            fesc = np.ascontiguousarray(np.full(npart, fesc, dtype=np.float32))
+            fesc = np.ascontiguousarray(np.full(npart, fesc))
 
         # Convert inputs to tuples
         grid_props = tuple(grid_props)

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -318,7 +318,10 @@ class Stars(Particles, StarsComponent):
             np.ascontiguousarray(self.log10ages[mask], dtype=np.float64),
             np.ascontiguousarray(self.metallicities[mask], dtype=np.float64),
         ]
-        part_mass = np.ascontiguousarray(self._initial_masses[mask], dtype=np.float64)
+        part_mass = np.ascontiguousarray(
+            self._initial_masses[mask],
+            dtype=np.float64,
+        )
 
         # Make sure we set the number of particles to the size of the mask
         npart = np.int32(np.sum(mask))
@@ -327,13 +330,20 @@ class Stars(Particles, StarsComponent):
         nlam = np.int32(grid.spectra[spectra_type].shape[-1])
 
         # Slice the spectral grids and pad them with copies of the edges.
-        grid_spectra = np.ascontiguousarray(grid.spectra[spectra_type], np.float64)
+        grid_spectra = np.ascontiguousarray(
+            grid.spectra[spectra_type],
+            np.float64,
+        )
 
         # Get the grid dimensions after slicing what we need
         grid_dims = np.zeros(len(grid_props) + 1, dtype=np.int32)
         for ind, g in enumerate(grid_props):
             grid_dims[ind] = len(g)
         grid_dims[ind + 1] = nlam
+
+        # If fesc isn't an array make it one
+        if not isinstance(fesc, np.ndarray):
+            fesc = np.ascontiguousarray(np.full(npart, fesc, dtype=np.float32))
 
         # Convert inputs to tuples
         grid_props = tuple(grid_props)
@@ -372,9 +382,10 @@ class Stars(Particles, StarsComponent):
                 The spectral grid object.
             spectra_name (string)
                 The name of the target spectra inside the grid file.
-            fesc (float)
+            fesc (float/array-like, float)
                 Fraction of stellar emission that escapes unattenuated from
-                the birth cloud (defaults to 0.0).
+                the birth cloud. Can either be a single value
+                or an value per star (defaults to 0.0).
             young (bool/float)
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
@@ -501,9 +512,10 @@ class Stars(Particles, StarsComponent):
                 A list of line_ids or a str denoting a single line.
                 Doublets can be specified as a nested list or using a
                 comma (e.g. 'OIII4363,OIII4959').
-            fesc (float):
-                The Lyman continuum escaped fraction, the fraction of
-                ionising photons that entirely escaped.
+            fesc (float/array-like, float)
+                Fraction of stellar emission that escapes unattenuated from
+                the birth cloud. Can either be a single value
+                or an value per star (defaults to 0.0).
 
         Returns:
             Line
@@ -586,9 +598,10 @@ class Stars(Particles, StarsComponent):
                 The spectral grid object.
             spectra_name (string)
                 The name of the target spectra inside the grid file.
-            fesc (float)
+            fesc (float/array-like, float)
                 Fraction of stellar emission that escapes unattenuated from
-                the birth cloud (defaults to 0.0).
+                the birth cloud. Can either be a single value
+                or an value per star (defaults to 0.0).
             young (bool/float)
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
@@ -718,9 +731,10 @@ class Stars(Particles, StarsComponent):
                 A list of line_ids or a str denoting a single line.
                 Doublets can be specified as a nested list or using a
                 comma (e.g. 'OIII4363,OIII4959').
-            fesc (float):
-                The Lyman continuum escaped fraction, the fraction of
-                ionising photons that entirely escaped.
+            fesc (float/array-like, float)
+                Fraction of stellar emission that escapes unattenuated from
+                the birth cloud. Can either be a single value
+                or an value per star (defaults to 0.0).
 
         Returns:
             Line
@@ -1024,12 +1038,10 @@ class Stars(Particles, StarsComponent):
         Args:
             grid (obj):
                 Spectral grid object.
-            fesc (float):
-                Fraction of stellar emission that escapeds unattenuated from
-                the birth cloud (defaults to 0.0).
-            fesc_LyA (float)
-                Fraction of Lyman-alpha emission that can escape unimpeded
-                by the ISM/IGM.
+            fesc (float/array-like, float)
+                Fraction of stellar emission that escapes unattenuated from
+                the birth cloud. Can either be a single value
+                or an value per star (defaults to 0.0).
             young (bool, float):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
@@ -1132,9 +1144,10 @@ class Stars(Particles, StarsComponent):
         Args:
             grid (obj):
                 Spectral grid object.
-            fesc (float):
-                Fraction of stellar emission that escapeds unattenuated from
-                the birth cloud (defaults to 0.0).
+            fesc (float/array-like, float)
+                Fraction of stellar emission that escapes unattenuated from
+                the birth cloud. Can either be a single value
+                or an value per star (defaults to 0.0).
             young (bool, float):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
@@ -1186,9 +1199,10 @@ class Stars(Particles, StarsComponent):
         Args:
             grid (obj):
                 Spectral grid object.
-            fesc (float):
-                Fraction of stellar emission that escapeds unattenuated from
-                the birth cloud (defaults to 0.0).
+            fesc (float/array-like, float)
+                Fraction of stellar emission that escapes unattenuated from
+                the birth cloud. Can either be a single value
+                or an value per star (defaults to 0.0).
             young (bool, float):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
@@ -1244,9 +1258,10 @@ class Stars(Particles, StarsComponent):
         Args:
             grid (obj):
                 Spectral grid object.
-            fesc (float):
-                Fraction of stellar emission that escapeds unattenuated from
-                the birth cloud (defaults to 0.0).
+            fesc (float/array-like, float)
+                Fraction of stellar emission that escapes unattenuated from
+                the birth cloud. Can either be a single value
+                or an value per star (defaults to 0.0).
             fesc_LyA (float)
                 Fraction of Lyman-alpha emission that can escape unimpeded
                 by the ISM/IGM.


### PR DESCRIPTION
Although not a common use case it would be nice to be able to give star particles particle specific escape fractions (i.e. based on age or metallicity). This PR enables this as a possibility.

- `fesc` can be a single value. If it is an array full of that value is made to pass to the C extension. This is short lived enough and only 32 bit so has a minimal effect on footprint.
- `fesc` can also be passed as any array.
- Since the integrated spectra extension limits lam loops by calculating the weight grid first and then applying it to spectra the escape fraction is combined into the weights, this is all hidden in the backend but this approach is the only way to maintain this optimisation and enable the `fesc` array. It works but is worth noting.
- Closes #124 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
