### PR TITLE
Fixed the limits on plots in cosmo_examples.ipynb

### DIFF
--- a/docs/source/cosmo/cosmo_example.ipynb
+++ b/docs/source/cosmo/cosmo_example.ipynb
@@ -242,8 +242,6 @@
    "source": [
     "spec = g.stars.get_spectra_nebular(grid)\n",
     "fig, ax = g.stars.plot_spectra()\n",
-    "ax.set_ylim(25,)\n",
-    "ax.set_xlim(2, 4.2)\n",
     "plt.show()"
    ]
   },
@@ -265,8 +263,6 @@
    "source": [
     "spec = g.stars.get_spectra_reprocessed(grid, fesc=0.1)\n",
     "fig, ax = g.stars.plot_spectra()\n",
-    "ax.set_ylim(25,)\n",
-    "ax.set_xlim(2, 4.2)\n",
     "plt.show()"
    ]
   },
@@ -289,8 +285,6 @@
    "source": [
     "spec = g.stars.get_spectra_screen(grid, tau_v=0.33)\n",
     "fig, ax = g.stars.plot_spectra(spectra_to_plot=['intrinsic', 'emergent'])\n",
-    "ax.set_ylim(25,)\n",
-    "ax.set_xlim(2, 4.2)\n",
     "plt.show()"
    ]
   },
@@ -311,8 +305,6 @@
    "source": [
     "spec = g.stars.get_spectra_CharlotFall(grid, tau_v_ISM=0.33, tau_v_BC=0.67)\n",
     "fig, ax = g.stars.plot_spectra(spectra_to_plot=['intrinsic', 'emergent'])\n",
-    "ax.set_ylim(25,)\n",
-    "ax.set_xlim(2, 4.2)\n",
     "plt.show()"
    ]
   },


### PR DESCRIPTION
Hardcoded limits were causing blank plots in the cosmo docs. These have been removed.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
