### PR TITLE
Fixing the age masking for spectra creation

### DIFF
--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -107,10 +107,10 @@ class StarsComponent:
             fesc_LyA (float)
                 Fraction of Lyman-alpha emission that can escape unimpeded
                 by the ISM/IGM.
-            young (bool, float):
+            young (bool/float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
-            old (bool, float):
+            old (bool/float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
             kwargs
@@ -159,10 +159,10 @@ class StarsComponent:
         Args:
             grid (obj):
                 Spectral grid object.
-            young (bool, float):
+            young (bool/float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
-            old (bool, float):
+            old (bool/float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
             label (string)
@@ -217,10 +217,10 @@ class StarsComponent:
             fesc (float):
                 Fraction of stellar emission that escapeds unattenuated from
                 the birth cloud (defaults to 0.0).
-            young (bool, float):
+            young (bool/float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
-            old (bool, float):
+            old (bool/float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
             label (string)
@@ -274,10 +274,10 @@ class StarsComponent:
             fesc (float):
                 Fraction of stellar emission that escapeds unattenuated from
                 the birth cloud (defaults to 0.0).
-            young (bool, float):
+            young (bool/float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
-            old (bool, float):
+            old (bool/float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
             label (string)
@@ -346,10 +346,10 @@ class StarsComponent:
             fesc_LyA (float)
                 Fraction of Lyman-alpha emission that can escape unimpeded
                 by the ISM/IGM.
-            young (bool, float):
+            young (bool/float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
-            old (bool, float):
+            old (bool/float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
             label (string):
@@ -497,10 +497,10 @@ class StarsComponent:
                 The V-band optical depth.
             dust_curve (object)
                 Instance of a dust_curve from synthesizer.dust.attenuation.
-            young (bool, float):
+            young (bool/float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
-            old (bool, float):
+            old (bool/float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
             label (string)
@@ -1227,21 +1227,21 @@ class StarsComponent:
         spectra generation methods are in the right units (Myr)
 
         Args:
-            young (bool, float):
+            young (bool/float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
-            old (bool, float):
+            old (bool/float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
         """
 
-        if young:
+        if young is not None:
             if isinstance(young, (unyt_quantity)):
                 young = young.to("Myr")
             else:
                 young *= Myr
 
-        if old:
+        if old is not None:
             if isinstance(old, (unyt_quantity)):
                 old = old.to("Myr")
             else:

--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -90,8 +90,8 @@ class StarsComponent:
         grid,
         fesc=0.0,
         fesc_LyA=1.0,
-        young=False,
-        old=False,
+        young=None,
+        old=None,
         **kwargs,
     ):
         """
@@ -147,8 +147,8 @@ class StarsComponent:
     def get_spectra_incident(
         self,
         grid,
-        young=False,
-        old=False,
+        young=None,
+        old=None,
         label="",
         **kwargs,
     ):
@@ -201,8 +201,8 @@ class StarsComponent:
         self,
         grid,
         fesc=0.0,
-        young=False,
-        old=False,
+        young=None,
+        old=None,
         label="",
         **kwargs,
     ):
@@ -259,8 +259,8 @@ class StarsComponent:
         self,
         grid,
         fesc=0.0,
-        young=False,
-        old=False,
+        young=None,
+        old=None,
         label="",
         **kwargs,
     ):
@@ -320,8 +320,8 @@ class StarsComponent:
         grid,
         fesc=0.0,
         fesc_LyA=1.0,
-        young=False,
-        old=False,
+        young=None,
+        old=None,
         label="",
         verbose=False,
         **kwargs,
@@ -480,8 +480,8 @@ class StarsComponent:
         grid,
         tau_v,
         dust_curve=PowerLaw(slope=-1.0),
-        young=False,
-        old=False,
+        young=None,
+        old=None,
         label="",
         **kwargs,
     ):
@@ -706,7 +706,7 @@ class StarsComponent:
                 fesc,
                 fesc_LyA=fesc_LyA,
                 young=young_old_thresh,
-                old=False,
+                old=None,
                 label="young_",
                 **kwargs,
             )
@@ -717,7 +717,7 @@ class StarsComponent:
                 grid,
                 fesc,
                 fesc_LyA=fesc_LyA,
-                young=False,
+                young=None,
                 old=young_old_thresh,
                 label="old_",
                 **kwargs,
@@ -758,8 +758,8 @@ class StarsComponent:
                 grid,
                 fesc,
                 fesc_LyA=fesc_LyA,
-                young=False,
-                old=False,
+                young=None,
+                old=None,
                 **kwargs,
             )
 

--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -6,7 +6,7 @@ and methods common between them.
 """
 import numpy as np
 import matplotlib.pyplot as plt
-from unyt import Myr, unyt_quantity
+from unyt import Myr, Gyr, unyt_quantity
 
 from synthesizer import exceptions
 from synthesizer.dust.attenuation import PowerLaw
@@ -1246,6 +1246,14 @@ class StarsComponent:
                 old = old.to("Myr")
             else:
                 old *= Myr
+
+        # Ensure ages aren't larger than the age of the universe
+        if young is not None and young > 13.8 * Gyr:
+            raise exceptions.InconsistentArguments(
+                "The young threshold exceeds the age of the universe "
+                f"({young})! Either pass the threshold in Myrs or as a"
+                "unyt_quantity with units attached."
+            )
 
         return young, old
 

--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -107,10 +107,10 @@ class StarsComponent:
             fesc_LyA (float)
                 Fraction of Lyman-alpha emission that can escape unimpeded
                 by the ISM/IGM.
-            young (bool/float/unyt_quantity):
+            young (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
-            old (bool/float/unyt_quantity):
+            old (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
             kwargs
@@ -159,10 +159,10 @@ class StarsComponent:
         Args:
             grid (obj):
                 Spectral grid object.
-            young (bool/float/unyt_quantity):
+            young (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
-            old (bool/float/unyt_quantity):
+            old (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
             label (string)
@@ -217,10 +217,10 @@ class StarsComponent:
             fesc (float):
                 Fraction of stellar emission that escapeds unattenuated from
                 the birth cloud (defaults to 0.0).
-            young (bool/float/unyt_quantity):
+            young (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
-            old (bool/float/unyt_quantity):
+            old (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
             label (string)
@@ -274,10 +274,10 @@ class StarsComponent:
             fesc (float):
                 Fraction of stellar emission that escapeds unattenuated from
                 the birth cloud (defaults to 0.0).
-            young (bool/float/unyt_quantity):
+            young (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
-            old (bool/float/unyt_quantity):
+            old (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
             label (string)
@@ -346,10 +346,10 @@ class StarsComponent:
             fesc_LyA (float)
                 Fraction of Lyman-alpha emission that can escape unimpeded
                 by the ISM/IGM.
-            young (bool/float/unyt_quantity):
+            young (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
-            old (bool/float/unyt_quantity):
+            old (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
             label (string):
@@ -497,10 +497,10 @@ class StarsComponent:
                 The V-band optical depth.
             dust_curve (object)
                 Instance of a dust_curve from synthesizer.dust.attenuation.
-            young (bool/float/unyt_quantity):
+            young (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
-            old (bool/float/unyt_quantity):
+            old (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
             label (string)
@@ -1227,10 +1227,10 @@ class StarsComponent:
         spectra generation methods are in the right units (Myr)
 
         Args:
-            young (bool/float/unyt_quantity):
+            young (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
-            old (bool/float/unyt_quantity):
+            old (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
         """

--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -1251,7 +1251,13 @@ class StarsComponent:
         if young is not None and young > 13.8 * Gyr:
             raise exceptions.InconsistentArguments(
                 "The young threshold exceeds the age of the universe "
-                f"({young})! Either pass the threshold in Myrs or as a"
+                f"({young})! Either pass the threshold in Myrs or as a "
+                "unyt_quantity with units attached."
+            )
+        if old is not None and old > 13.8 * Gyr:
+            raise exceptions.InconsistentArguments(
+                "The old threshold exceeds the age of the universe "
+                f"({old})! Either pass the threshold in Myrs or as a "
                 "unyt_quantity with units attached."
             )
 

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -342,7 +342,7 @@ class Stars(StarsComponent):
         # ... and multiply it by the initial mass of stars
         self.sfzh *= self._initial_mass
 
-    def generate_lnu(self, grid, spectra_name, old=False, young=False):
+    def generate_lnu(self, grid, spectra_name, old=False, young=None):
         """
         Calculate rest frame spectra from an SPS Grid.
 

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -357,8 +357,8 @@ class Stars(Particles, StarsComponent):
         grid,
         spectra_name,
         fesc=0.0,
-        young=False,
-        old=False,
+        young=None,
+        old=None,
         verbose=False,
         do_grid_check=False,
         grid_assignment_method="cic",
@@ -464,6 +464,8 @@ class Stars(Particles, StarsComponent):
 
         # Get particle age masks
         mask = self._get_masks(young, old)
+
+        print("Mask sum:", np.sum(mask), "young =", young, "Old =", old)
 
         # Ensure and warn that the masking hasn't removed everything
         if np.sum(mask) == 0:
@@ -571,8 +573,8 @@ class Stars(Particles, StarsComponent):
         grid,
         spectra_name,
         fesc=0.0,
-        young=False,
-        old=False,
+        young=None,
+        old=None,
         verbose=False,
         do_grid_check=False,
         grid_assignment_method="cic",
@@ -1013,8 +1015,8 @@ class Stars(Particles, StarsComponent):
         grid,
         fesc=0.0,
         fesc_LyA=1.0,
-        young=False,
-        old=False,
+        young=None,
+        old=None,
         **kwargs,
     ):
         """
@@ -1067,8 +1069,8 @@ class Stars(Particles, StarsComponent):
     def get_particle_spectra_incident(
         self,
         grid,
-        young=False,
-        old=False,
+        young=None,
+        old=None,
         label="",
         **kwargs,
     ):
@@ -1119,8 +1121,8 @@ class Stars(Particles, StarsComponent):
         self,
         grid,
         fesc=0.0,
-        young=False,
-        old=False,
+        young=None,
+        old=None,
         label="",
         **kwargs,
     ):
@@ -1174,8 +1176,8 @@ class Stars(Particles, StarsComponent):
         self,
         grid,
         fesc=0.0,
-        young=False,
-        old=False,
+        young=None,
+        old=None,
         label="",
         **kwargs,
     ):
@@ -1228,8 +1230,8 @@ class Stars(Particles, StarsComponent):
         grid,
         fesc=0.0,
         fesc_LyA=1.0,
-        young=False,
-        old=False,
+        young=None,
+        old=None,
         label="",
         **kwargs,
     ):

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1032,10 +1032,10 @@ class Stars(Particles, StarsComponent):
             fesc_LyA (float)
                 Fraction of Lyman-alpha emission that can escape unimpeded
                 by the ISM/IGM.
-            young (bool, float):
+            young (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
-            old (bool, float):
+            old (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
             kwargs
@@ -1081,10 +1081,10 @@ class Stars(Particles, StarsComponent):
         Args:
             grid (obj):
                 Spectral grid object.
-            young (bool, float):
+            young (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
-            old (bool, float):
+            old (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
             label (string)
@@ -1137,10 +1137,10 @@ class Stars(Particles, StarsComponent):
             fesc (float):
                 Fraction of stellar emission that escapeds unattenuated from
                 the birth cloud (defaults to 0.0).
-            young (bool, float):
+            young (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
-            old (bool, float):
+            old (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
             label (string)
@@ -1191,10 +1191,10 @@ class Stars(Particles, StarsComponent):
             fesc (float):
                 Fraction of stellar emission that escapeds unattenuated from
                 the birth cloud (defaults to 0.0).
-            young (bool, float):
+            young (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
-            old (bool, float):
+            old (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
             label (string)
@@ -1252,10 +1252,10 @@ class Stars(Particles, StarsComponent):
             fesc_LyA (float)
                 Fraction of Lyman-alpha emission that can escape unimpeded
                 by the ISM/IGM.
-            young (bool, float):
+            young (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for young star particles.
-            old (bool, float):
+            old (float/unyt_quantity):
                 If not False, specifies age in Myr at which to filter
                 for old star particles.
             label (string)


### PR DESCRIPTION
The docs stated the `young` and `old` flags should be passed in years while the code stated it should be passed in Myrs. This PR fixes the docs but also:

- Introduces a check for whether the `young` and `old` flags exceed the age of the universe after being assumed to be in Myrs for safety when passed without units.
- Changes the default `young` and `old` values to `None` since this makes more sense than a boolean which is only ever `False`, a user may think to pass `True` which is undefined behaviour. (The docs stated they were `None` anyway.)
- Modifies the doc strings to state that a `unyt_quantity` can be passed.

The CAMELS test data in the docs doesn't have any young stars in it, so the thresholds have been changed purely for demonstration purposes. A note of this fact has been included in the docs.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
