### PR TITLE
wrong weight fraction for lower edge of grid cases

### DIFF
--- a/src/synthesizer/extensions/weights.h
+++ b/src/synthesizer/extensions/weights.h
@@ -113,7 +113,7 @@ void weight_loop_cic(const double **grid_props, const double **part_props,
 
       /* Use the grid edge. */
       part_cell = 0;
-      frac = 1;
+      frac = 0;
 
     } else if (part_val > grid_prop[dims[dim] - 1]) {
 


### PR DESCRIPTION
Fixes a small bug in CIC grid assignment where weights at the lower edge of the grid were assigned a weight fraction of zero. Led to segfaults in some cases where the entire weights grid was empty.

## Issue Type
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
