### PR TITLE
Introduced method to integrate particle spectra

### DIFF
--- a/examples/particle/plot_los_spectra.py
+++ b/examples/particle/plot_los_spectra.py
@@ -60,7 +60,7 @@ nstars = 1000
 ngas = 1000
 
 # Generate some random coordinates
-coords = CoordinateGenerator.generate_3D_gaussian(n)
+coords = CoordinateGenerator.generate_3D_gaussian(nstars)
 
 # Calculate the smoothing lengths from radii
 cent = np.mean(coords, axis=0)
@@ -80,7 +80,7 @@ stars = sample_sfhz(
     param_stars.log10metallicities,
     nstars,
     coordinates=coords,
-    current_masses=np.full(n, 10**8.7 / n),
+    current_masses=np.full(nstars, 10**8.7 / nstars),
     smoothing_lengths=rs / 2,
     redshift=1,
 )

--- a/examples/particle/plot_los_spectra.py
+++ b/examples/particle/plot_los_spectra.py
@@ -121,9 +121,9 @@ kernel_data = sph_kernel.get_kernel()
 tau_v = galaxy.calculate_los_tau_v(kappa=0.07, kernel=kernel_data)
 
 # Get the attenuated spectra
-galaxy.stars.particle_spectra[
-    "attenuated"
-] = galaxy.stars.particle_spectra.apply_attenutation(tau_v)
+galaxy.stars.particle_spectra["attenuated"] = galaxy.stars.particle_spectra[
+    "incident"
+].apply_attenutation(tau_v)
 
 # Integrate the particle spectra
 galaxy.integrate_particle_spectra()

--- a/examples/particle/plot_los_spectra.py
+++ b/examples/particle/plot_los_spectra.py
@@ -123,7 +123,7 @@ tau_v = galaxy.calculate_los_tau_v(kappa=0.07, kernel=kernel_data)
 # Get the attenuated spectra
 galaxy.stars.particle_spectra["attenuated"] = galaxy.stars.particle_spectra[
     "incident"
-].apply_attenutation(tau_v)
+].apply_attenuation(tau_v)
 
 # Integrate the particle spectra
 galaxy.integrate_particle_spectra()

--- a/examples/particle/plot_los_spectra.py
+++ b/examples/particle/plot_los_spectra.py
@@ -1,0 +1,132 @@
+"""
+Plot line of sight diagnostics
+==============================
+
+This example shows how to compute line of sight dust surface densities,
+and plots some diagnostics.
+"""
+import time
+import numpy as np
+import matplotlib.pyplot as plt
+from unyt import Myr
+
+from synthesizer.grid import Grid
+from synthesizer.parametric import SFH, ZDist
+from synthesizer.parametric import Stars as ParametricStars
+from synthesizer.particle.stars import sample_sfhz
+from synthesizer.particle.gas import Gas
+from synthesizer.particle.galaxy import Galaxy
+from synthesizer.particle.particles import CoordinateGenerator
+from synthesizer.kernel_functions import kernel
+
+
+plt.rcParams["font.family"] = "DeJavu Serif"
+plt.rcParams["font.serif"] = ["Times New Roman"]
+
+# Set the seed
+np.random.seed(42)
+
+start = time.time()
+
+# Get the location of this script, __file__ is the absolute path of this
+# script, however we just want to directory
+# script_path = os.path.abspath(os.path.dirname(__file__))
+
+# Define the grid
+grid_name = "test_grid"
+grid_dir = "../../tests/test_grid/"
+grid = Grid(grid_name, grid_dir=grid_dir)
+
+# Define the grid (normally this would be defined by an SPS grid)
+log10ages = np.arange(6.0, 10.5, 0.1)
+metallicities = 10 ** np.arange(-5.0, -1.5, 0.1)
+Z_p = {"metallicity": 0.01}
+metal_dist = ZDist.DeltaConstant(**Z_p)
+sfh_p = {"duration": 100 * Myr}
+sfh = SFH.Constant(**sfh_p)  # constant star formation
+
+# Generate the star formation metallicity history
+mass = 10**10
+param_stars = ParametricStars(
+    log10ages,
+    metallicities,
+    sf_hist=sfh,
+    metal_dist=metal_dist,
+    initial_mass=mass,
+)
+
+# How many stars and gas particles?
+nstars = 1000
+ngas = 1000
+
+# Generate some random coordinates
+coords = CoordinateGenerator.generate_3D_gaussian(n)
+
+# Calculate the smoothing lengths from radii
+cent = np.mean(coords, axis=0)
+rs = np.sqrt(
+    (coords[:, 0] - cent[0]) ** 2
+    + (coords[:, 1] - cent[1]) ** 2
+    + (coords[:, 2] - cent[2]) ** 2
+)
+rs[rs < 0.2] = 0.6  # Set a lower bound on the "smoothing length"
+
+# Sample the SFZH, producing a Stars object
+# we will also pass some keyword arguments for attributes
+# we will need for imaging
+stars = sample_sfhz(
+    param_stars.sfzh,
+    param_stars.log10ages,
+    param_stars.log10metallicities,
+    nstars,
+    coordinates=coords,
+    current_masses=np.full(n, 10**8.7 / n),
+    smoothing_lengths=rs / 2,
+    redshift=1,
+)
+
+# Now make the gas
+
+# Generate some random coordinates
+coords = CoordinateGenerator.generate_3D_gaussian(ngas)
+
+# Calculate the smoothing lengths from radii
+cent = np.mean(coords, axis=0)
+rs = np.sqrt(
+    (coords[:, 0] - cent[0]) ** 2
+    + (coords[:, 1] - cent[1]) ** 2
+    + (coords[:, 2] - cent[2]) ** 2
+)
+rs[rs < 0.2] = 0.6  # Set a lower bound on the "smoothing length"
+
+gas = Gas(
+    masses=np.random.uniform(10**6, 10**6.5, ngas),
+    metallicities=np.random.uniform(0.01, 0.05, ngas),
+    coordinates=coords,
+    smoothing_lengths=rs / 4,
+    dust_to_metal_ratio=0.2,
+)
+
+# Create galaxy object
+galaxy = Galaxy("Galaxy", stars=stars, gas=gas, redshift=1)
+
+# Calculate the stellar rest frame SEDs for all particles in erg / s / Hz
+galaxy.stars.get_particle_spectra_incident(grid)
+
+# Get the SPH kernel
+sph_kernel = kernel()
+kernel_data = sph_kernel.get_kernel()
+
+# Calculate the tau_vs
+tau_v = galaxy.calculate_los_tau_v(kappa=0.07, kernel=kernel_data)
+
+# Get the attenuated spectra
+galaxy.stars.particle_spectra[
+    "attenuated"
+] = galaxy.stars.particle_spectra.apply_attenutation(tau_v)
+
+# Integrate the particle spectra
+galaxy.integrate_particle_spectra()
+
+# Plot the Sed
+galaxy.plot_spectra(show=True, combined_spectra=False, stellar_spectra=True)

--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -356,7 +356,7 @@ class Galaxy(BaseGalaxy):
         # Handle stellar spectra
         if self.stars is not None:
             # Loop over stellar particle spectra
-            for key, sed in self.stars.particle_spectra:
+            for key, sed in self.stars.particle_spectra.items():
                 self.stars.spectra[key] = Sed(
                     sed.lam,
                     np.sum(sed._lnu, axis=0),
@@ -365,7 +365,7 @@ class Galaxy(BaseGalaxy):
         # Handle black hole spectra
         if self.black_holes is not None:
             # Loop over stellar particle spectra
-            for key, sed in self.black_holes.particle_spectra:
+            for key, sed in self.black_holes.particle_spectra.items():
                 self.black_holes.spectra[key] = Sed(
                     sed.lam,
                     np.sum(sed._lnu, axis=0),

--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -149,7 +149,7 @@ class Galaxy(BaseGalaxy):
         """
         Load arrays for star properties into a `Stars`  object,
         and attach to this galaxy object
-        
+
         TODO: this should be able to take a pre-existing stars object!
 
         Args:
@@ -347,6 +347,34 @@ class Galaxy(BaseGalaxy):
             np.max(gas_sml),
             force_loop,
         )
+
+    def integrate_particle_spectra(self):
+        """
+        Integrates all particle spectra on any attached components.
+        """
+
+        # Handle stellar spectra
+        if self.stars is not None:
+            # Loop over stellar particle spectra
+            for key, sed in self.stars.particle_spectra:
+                self.stars.spectra[key] = Sed(
+                    sed.lam,
+                    np.sum(sed._lnu, axis=0),
+                )
+
+        # Handle black hole spectra
+        if self.black_holes is not None:
+            # Loop over stellar particle spectra
+            for key, sed in self.black_holes.particle_spectra:
+                self.black_holes.spectra[key] = Sed(
+                    sed.lam,
+                    np.sum(sed._lnu, axis=0),
+                )
+
+        # Handle gas spectra
+        if self.gas is not None:
+            # Nothing to do here... YET
+            pass
 
     def get_line_los():
         """


### PR DESCRIPTION
Introduces `particle.Galaxy.integrate_particle_spectra` which will integrate all `particle_spectra` on all components and store them in the component `spectra` attributes. 

This PR also introduces an example demonstrating this behaviour in `examples/particle/plot_los_spectra`. This example also makes a plot of the attenuated and incident spectra which was absent from the other los example which focuses on accuracy and runtime. 

This PR does not implement this method on the components themselves since most (if not all?) cases where this is needed are at the galaxy level requiring multiple components to calculate the optical depths. However, if people disagree with this assessment they can be easily implemented on the components.

Closes #488 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
