### PR TITLE
Fix FLARES load

### DIFF
--- a/docs/source/imaging/particle_imaging.ipynb
+++ b/docs/source/imaging/particle_imaging.ipynb
@@ -33,7 +33,7 @@
     "from synthesizer.grid import Grid\n",
     "from synthesizer.filters import FilterCollection as Filters\n",
     "from synthesizer.load_data.load_camels import load_CAMELS_IllustrisTNG\n",
-    "from synthesizer.kernel_functions import kernel"
+    "from synthesizer.kernel_functions import Kernel"
    ]
   },
   {
@@ -251,7 +251,7 @@
    "outputs": [],
    "source": [
     "# Get the SPH kernel\n",
-    "sph_kernel = kernel()\n",
+    "sph_kernel = Kernel()\n",
     "kernel_data = sph_kernel.get_kernel()\n",
     "\n",
     "img_start = time.time()\n",

--- a/examples/cosmo/test_los_spectra.py
+++ b/examples/cosmo/test_los_spectra.py
@@ -6,7 +6,7 @@ Test the calculation of tau_v along the line of sight
 to each star particle
 """
 from synthesizer.load_data import load_CAMELS_IllustrisTNG
-from synthesizer.kernel_functions import kernel
+from synthesizer.kernel_functions import Kernel
 
 gals = load_CAMELS_IllustrisTNG(
     "../../tests/data/",
@@ -15,7 +15,7 @@ gals = load_CAMELS_IllustrisTNG(
     fof_dir="../../tests/data/",
 )
 
-kern = kernel()
-kern.get_kernel()
+kernel = Kernel()
+kernel.get_kernel()
 
-gals[0].calculate_los_tau_v(kappa=0.3, kernel=kern.get_kernel())
+gals[0].calculate_los_tau_v(kappa=0.3, kernel=kernel.get_kernel())

--- a/examples/particle/plot_los_spectra.py
+++ b/examples/particle/plot_los_spectra.py
@@ -17,7 +17,7 @@ from synthesizer.particle.stars import sample_sfhz
 from synthesizer.particle.gas import Gas
 from synthesizer.particle.galaxy import Galaxy
 from synthesizer.particle.particles import CoordinateGenerator
-from synthesizer.kernel_functions import kernel
+from synthesizer.kernel_functions import Kernel
 
 
 plt.rcParams["font.family"] = "DeJavu Serif"
@@ -114,11 +114,11 @@ galaxy = Galaxy("Galaxy", stars=stars, gas=gas, redshift=1)
 galaxy.stars.get_particle_spectra_incident(grid)
 
 # Get the SPH kernel
-sph_kernel = kernel()
+sph_kernel = Kernel()
 kernel_data = sph_kernel.get_kernel()
 
 # Calculate the tau_vs
-tau_v = galaxy.calculate_los_tau_v(kappa=0.07, kernel=kernel_data)
+tau_v = galaxy.calculate_los_tau_v(kappa=0.07, kernel=kernel_data, force_loop=True)
 
 # Get the attenuated spectra
 galaxy.stars.particle_spectra["attenuated"] = galaxy.stars.particle_spectra[

--- a/examples/particle/plot_los_spectra.py
+++ b/examples/particle/plot_los_spectra.py
@@ -118,7 +118,9 @@ sph_kernel = Kernel()
 kernel_data = sph_kernel.get_kernel()
 
 # Calculate the tau_vs
-tau_v = galaxy.calculate_los_tau_v(kappa=0.07, kernel=kernel_data, force_loop=True)
+tau_v = galaxy.calculate_los_tau_v(
+    kappa=0.07, kernel=kernel_data, force_loop=True
+)
 
 # Get the attenuated spectra
 galaxy.stars.particle_spectra["attenuated"] = galaxy.stars.particle_spectra[

--- a/src/synthesizer/extensions/los.c
+++ b/src/synthesizer/extensions/los.c
@@ -84,28 +84,22 @@ void low_mass_los_loop(const double *star_pos, const double *gas_pos, const doub
       double x = gas_x - star_x;
       double y = gas_y - star_y;
 
-      /* Early skip if the star doesn't fall in the gas particles kernel. */
-      if (abs(x) > (threshold * sml) || abs(y) > (threshold * sml))
-        continue;
-
-      /* Convert separation to distance. */
-      double rsqu = x * x + y * y;
-
       /* Calculate the impact parameter. */
-      double sml_squ = gas_sml[igas] * gas_sml[igas];
-      double q = rsqu / sml_squ;
+      double b = sqrt(x * x + y * y);
 
-      /* Skip gas particles outside the kernel. */
-      if (q > threshold) continue;
+      /* Early skip if the star's line of sight doesn't fall in the gas particles kernel. */
+      if (b > (threshold * sml))
+        continue;
+      
+      /* Find fraction of smoothing length. */
+      double q = b / sml;
 
       /* Get the value of the kernel at q. */
       int index = kdim * q;
       double kvalue = kernel[index];
 
       /* Finally, compute the metal surface density itself. */
-      los_dustsds[istar] += dtm * mass * met / sml_squ * kvalue;
-      
-      
+      los_dustsds[istar] += dtm * mass * met / (sml * sml) * kvalue;
     }
   }
   

--- a/src/synthesizer/extensions/los.c
+++ b/src/synthesizer/extensions/los.c
@@ -402,26 +402,22 @@ double calculate_los_recursive(struct cell *c,
       double x = gas_x - star_x;
       double y = gas_y - star_y;
 
-      /* Early skip if the star doesn't fall in the gas particles kernel. */
-      if (abs(x) > (threshold * sml) || abs(y) > (threshold * sml))
-        continue;
-
-      /* Convert separation to distance. */
-      double rsqu = x * x + y * y;
-
       /* Calculate the impact parameter. */
-      double sml_squ = gas_sml[igas] * gas_sml[igas];
-      double q = rsqu / sml_squ;
+      double b = sqrt(x * x + y * y);
 
-      /* Skip gas particles outside the kernel. */
-      if (q > threshold) continue;
+      /* Early skip if the star's line of sight doesn't fall in the gas particles kernel. */
+      if (b > (threshold * sml))
+        continue;
+      
+      /* Find fraction of smoothing length. */
+      double q = b / sml;
 
       /* Get the value of the kernel at q. */
       int index = kdim * q;
       double kvalue = kernel[index];
 
       /* Finally, compute the metal surface density itself. */
-      los_dustsds += dtm * mass * met / sml_squ * kvalue;
+      los_dustsds += dtm * mass * met / (sml * sml) * kvalue;
       
     }
   }

--- a/src/synthesizer/kernel_functions.py
+++ b/src/synthesizer/kernel_functions.py
@@ -75,7 +75,9 @@ class Kernel:
 
         kernel = self.get_kernel()
         header = np.array([{"kernel": self.name, "bins": self.binsize}])
-        np.savez("kernel_{}.npz".format(self.name), header=header, kernel=kernel)
+        np.savez(
+            "kernel_{}.npz".format(self.name), header=header, kernel=kernel
+        )
 
         print(header)
 
@@ -119,7 +121,9 @@ def cubic(r):
 def quintic(r):
     if r < 0.333333333:
         return 27.0 * (
-            6.4457752 * r * r * r * r * (1.0 - r) - 1.4323945 * r * r + 0.17507044
+            6.4457752 * r * r * r * r * (1.0 - r)
+            - 1.4323945 * r * r
+            + 0.17507044
         )
     elif r < 0.666666667:
         return 27.0 * (

--- a/src/synthesizer/kernel_functions.py
+++ b/src/synthesizer/kernel_functions.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy import integrate
 
 
-class kernel:
+class Kernel:
 
     """
     Line of sight distance along a particle, l = 2*sqrt(h^2 + b^2),
@@ -75,9 +75,7 @@ class kernel:
 
         kernel = self.get_kernel()
         header = np.array([{"kernel": self.name, "bins": self.binsize}])
-        np.savez(
-            "kernel_{}.npz".format(self.name), header=header, kernel=kernel
-        )
+        np.savez("kernel_{}.npz".format(self.name), header=header, kernel=kernel)
 
         print(header)
 
@@ -121,9 +119,7 @@ def cubic(r):
 def quintic(r):
     if r < 0.333333333:
         return 27.0 * (
-            6.4457752 * r * r * r * r * (1.0 - r)
-            - 1.4323945 * r * r
-            + 0.17507044
+            6.4457752 * r * r * r * r * (1.0 - r) - 1.4323945 * r * r + 0.17507044
         )
     elif r < 0.666666667:
         return 27.0 * (

--- a/src/synthesizer/load_data/load_camels.py
+++ b/src/synthesizer/load_data/load_camels.py
@@ -142,8 +142,13 @@ def load_CAMELS_IllustrisTNG(
     """
 
     with h5py.File(f"{_dir}/{snap_name}", "r") as hf:
+        scale_factor = hf["Header"].attrs["Time"]
+        redshift = 1.0 / scale_factor - 1
+        Om0 = hf["Header"].attrs["Omega0"]
+        h = hf["Header"].attrs["HubbleParam"]
+
         form_time = hf["PartType4/GFM_StellarFormationTime"][:]
-        coods = hf["PartType4/Coordinates"][:]
+        coods = hf["PartType4/Coordinates"][:] * scale_factor  # Mpc (physical)
         masses = hf["PartType4/Masses"][:]
         imasses = hf["PartType4/GFM_InitialMass"][:]
         _metals = hf["PartType4/GFM_Metals"][:]
@@ -153,13 +158,10 @@ def load_CAMELS_IllustrisTNG(
         g_sfr = hf["PartType0/StarFormationRate"][:]
         g_masses = hf["PartType0/Masses"][:]
         g_metals = hf["PartType0/GFM_Metallicity"][:]
-        g_coods = hf["PartType0/Coordinates"][:]
+        g_coods = (
+            hf["PartType0/Coordinates"][:] * scale_factor
+        )  # Mpc (physical)
         g_hsml = hf["PartType0/SubfindHsml"][:]
-
-        scale_factor = hf["Header"].attrs["Time"]
-        redshift = 1.0 / scale_factor - 1
-        Om0 = hf["Header"].attrs["Omega0"]
-        h = hf["Header"].attrs["HubbleParam"]
 
     if fof_dir:
         _dir = fof_dir  # replace if symlinks for fof files are broken
@@ -267,8 +269,13 @@ def load_CAMELS_Astrid(
     """
 
     with h5py.File(f"{_dir}/{snap_name}", "r") as hf:
+        redshift = hf["Header"].attrs["Redshift"]
+        scale_factor = hf["Header"].attrs["Time"][0]
+        Om0 = hf["Header"].attrs["Omega0"][0]
+        h = hf["Header"].attrs["HubbleParam"][0]
+
         form_time = hf["PartType4/GFM_StellarFormationTime"][:]
-        coods = hf["PartType4/Coordinates"][:]
+        coods = hf["PartType4/Coordinates"][:] * scale_factor  # Mpc (physical)
         masses = hf["PartType4/Masses"][:]
 
         # TODO: update with correct scaling
@@ -280,13 +287,10 @@ def load_CAMELS_Astrid(
         g_sfr = hf["PartType0/StarFormationRate"][:]
         g_masses = hf["PartType0/Masses"][:]
         g_metals = hf["PartType0/GFM_Metallicity"][:]
-        g_coods = hf["PartType0/Coordinates"][:]
+        g_coods = (
+            hf["PartType0/Coordinates"][:] * scale_factor
+        )  # Mpc (physical)
         g_hsml = hf["PartType0/SmoothingLength"][:]
-
-        redshift = hf["Header"].attrs["Redshift"]
-        scale_factor = hf["Header"].attrs["Time"][0]
-        Om0 = hf["Header"].attrs["Omega0"][0]
-        h = hf["Header"].attrs["HubbleParam"][0]
 
     masses = (masses * 1e10) / h
     g_masses = (g_masses * 1e10) / h
@@ -356,8 +360,13 @@ def load_CAMELS_Simba(
     """
 
     with h5py.File(f"{_dir}/{snap_name}", "r") as hf:
+        redshift = hf["Header"].attrs["Redshift"]
+        scale_factor = hf["Header"].attrs["Time"]
+        Om0 = hf["Header"].attrs["Omega0"]
+        h = hf["Header"].attrs["HubbleParam"]
+
         form_time = hf["PartType4/StellarFormationTime"][:]
-        coods = hf["PartType4/Coordinates"][:]
+        coods = hf["PartType4/Coordinates"][:] * scale_factor  # Mpc (physical)
         masses = hf["PartType4/Masses"][:]
         imasses = (
             np.ones(len(masses)) * 0.00155
@@ -367,13 +376,10 @@ def load_CAMELS_Simba(
         g_sfr = hf["PartType0/StarFormationRate"][:]
         g_masses = hf["PartType0/Masses"][:]
         g_metals = hf["PartType0/Metallicity"][:][:, 0]
-        g_coods = hf["PartType0/Coordinates"][:]
+        g_coods = (
+            hf["PartType0/Coordinates"][:] * scale_factor
+        )  # Mpc (physical)
         g_hsml = hf["PartType0/SmoothingLength"][:]
-
-        redshift = hf["Header"].attrs["Redshift"]
-        scale_factor = hf["Header"].attrs["Time"]
-        Om0 = hf["Header"].attrs["Omega0"]
-        h = hf["Header"].attrs["HubbleParam"]
 
     masses = (masses * 1e10) / h
     g_masses = (g_masses * 1e10) / h

--- a/src/synthesizer/load_data/load_flares.py
+++ b/src/synthesizer/load_data/load_flares.py
@@ -32,7 +32,9 @@ def load_FLARES(master_file, region, tag):
         glens = hf[f"{region}/{tag}/Galaxy/G_Length"][:]
 
         ages = hf[f"{region}/{tag}/Particle/S_Age"][:]  # Gyr
-        coods = hf[f"{region}/{tag}/Particle/S_Coordinates"][:].T  # Mpc
+        coods = (
+            hf[f"{region}/{tag}/Particle/S_Coordinates"][:].T * scale_factor
+        )  # Mpc (physical)
         masses = hf[f"{region}/{tag}/Particle/S_Mass"][:]  # 1e10 Msol
         imasses = hf[f"{region}/{tag}/Particle/S_MassInitial"][:]  # 1e10 Msol
 
@@ -43,8 +45,12 @@ def load_FLARES(master_file, region, tag):
         g_sfr = hf[f"{region}/{tag}/Particle/G_SFR"][:]  # Msol / yr
         g_masses = hf[f"{region}/{tag}/Particle/G_Mass"][:]  # 1e10 Msol
         g_metals = hf[f"{region}/{tag}/Particle/G_Z_smooth"][:]
-        g_coods = hf[f"{region}/{tag}/Particle/G_Coordinates"][:].T  # Mpc
-        g_hsml = hf[f"{region}/{tag}/Particle/G_sml"][:] / scale_factor  # Mpc
+        g_coods = (
+            hf[f"{region}/{tag}/Particle/G_Coordinates"][:].T * scale_factor
+        )  # Mpc (physical)
+        g_hsml = hf[f"{region}/{tag}/Particle/G_sml"][
+            :
+        ]  # Mpc (physical)
 
     # Convert units
     ages = ages * 1e9  # yr
@@ -58,7 +64,7 @@ def load_FLARES(master_file, region, tag):
     galaxies = [None] * len(begin)
     for i, (b, e) in enumerate(zip(begin, end)):
         # Create the individual galaxy objects
-        galaxies[i] = Galaxy()
+        galaxies[i] = Galaxy(redshift=zed)
 
         galaxies[i].load_stars(
             imasses[b:e] * Msun,

--- a/src/synthesizer/load_data/load_flares.py
+++ b/src/synthesizer/load_data/load_flares.py
@@ -1,12 +1,13 @@
+import numpy as np
 import h5py
 
-from unyt import Msun, kpc, yr
+from unyt import Msun, Mpc, yr
 
 from ..particle.galaxy import Galaxy
 from synthesizer.load_data.utils import get_len
 
 
-def load_FLARES(f, region, tag):
+def load_FLARES(master_file, region, tag):
     """
     Load FLARES galaxies from a FLARES master file
 
@@ -23,36 +24,70 @@ def load_FLARES(f, region, tag):
             `ParticleGalaxy` object containing stars
     """
 
-    with h5py.File(f, "r") as hf:
-        lens = hf[f"{region}/{tag}/Galaxy/S_Length"][:]
+    zed = float(tag[5:].replace("p", "."))
+    scale_factor = 1.0 / (1.0 + zed)
+
+    with h5py.File(master_file, "r") as hf:
+        slens = hf[f"{region}/{tag}/Galaxy/S_Length"][:]
+        glens = hf[f"{region}/{tag}/Galaxy/G_Length"][:]
+
         ages = hf[f"{region}/{tag}/Particle/S_Age"][:]  # Gyr
-        coods = hf[f"{region}/{tag}/Particle/S_Coordinates"][:].T
-        mass = hf[f"{region}/{tag}/Particle/S_Mass"][:]  # 1e10 Msol
-        imass = hf[f"{region}/{tag}/Particle/S_MassInitial"][:]  # 1e10 Msol
-        # metals = hf[f'{region}/{tag}/Particle/S_Z'][:]
+        coods = hf[f"{region}/{tag}/Particle/S_Coordinates"][:].T  # Mpc
+        masses = hf[f"{region}/{tag}/Particle/S_Mass"][:]  # 1e10 Msol
+        imasses = hf[f"{region}/{tag}/Particle/S_MassInitial"][:]  # 1e10 Msol
+
         metals = hf[f"{region}/{tag}/Particle/S_Z_smooth"][:]
         s_oxygen = hf[f"{region}/{tag}/Particle/S_Abundance_Oxygen"][:]
         s_hydrogen = hf[f"{region}/{tag}/Particle/S_Abundance_Hydrogen"][:]
-        # ids = hf[f'{region}/{tag}/Particle/S_ID'][:]
-        # index = hf[f'{region}/{tag}/Particle/S_Index'][:]
-        # hf[f'{pre}/S_Vel']
 
+        g_sfr = hf[f"{region}/{tag}/Particle/G_SFR"][:]  # Msol / yr
+        g_masses = hf[f"{region}/{tag}/Particle/G_Mass"][:]  # 1e10 Msol
+        g_metals = hf[f"{region}/{tag}/Particle/G_Z_smooth"][:]
+        g_coods = hf[f"{region}/{tag}/Particle/G_Coordinates"][:].T  # Mpc
+        g_hsml = hf[f"{region}/{tag}/Particle/G_sml"][:] / scale_factor  # Mpc
+
+    # Convert units
     ages = ages * 1e9  # yr
-    mass = mass * 1e10  # Msol
-    imass = imass * 1e10  # Msol
+    masses = masses * 1e10  # Msol
+    imasses = imasses * 1e10  # Msol
+    g_masses = g_masses * 1e10  # Msol
 
-    begin, end = get_len(lens)
+    # Get the star particle begin / end indices
+    begin, end = get_len(slens)
 
     galaxies = [None] * len(begin)
     for i, (b, e) in enumerate(zip(begin, end)):
+        # Create the individual galaxy objects
         galaxies[i] = Galaxy()
+
         galaxies[i].load_stars(
-            mass[b:e] * Msun,
+            imasses[b:e] * Msun,
             ages[b:e] * yr,
             metals[b:e],
             s_oxygen=s_oxygen[b:e],
             s_hydrogen=s_hydrogen[b:e],
-            coordinates=coods[b:e, :] * kpc,
+            coordinates=coods[b:e, :] * Mpc,
+            current_masses=masses[b:e] * Msun,
+        )
+
+    # Get the gas particle begin / end indices
+    begin, end = get_len(glens)
+
+    for i, (b, e) in enumerate(zip(begin, end)):
+        # Use gas particle SFR for star forming mask
+        sf_mask = g_sfr[b:e] > 0
+        galaxies[i].sf_gas_mass = np.sum(g_masses[b:e][sf_mask]) * Msun
+
+        galaxies[i].sf_gas_metallicity = (
+            np.sum(g_masses[b:e][sf_mask] * g_metals[b:e][sf_mask])
+            / galaxies[i].sf_gas_mass.value
+        )
+
+        galaxies[i].load_gas(
+            coordinates=g_coods[b:e] * Mpc,
+            masses=g_masses[b:e] * Msun,
+            metals=g_metals[b:e],
+            smoothing_lengths=g_hsml[b:e] * Mpc,
         )
 
     return galaxies

--- a/src/synthesizer/load_data/load_simba.py
+++ b/src/synthesizer/load_data/load_simba.py
@@ -42,8 +42,12 @@ def load_Simba(
     """
 
     with h5py.File(f"{directory}/{snap_name}", "r") as hf:
+        scale_factor = hf["Header"].attrs["Time"]
+        Om0 = hf["Header"].attrs["Omega0"]
+        h = hf["Header"].attrs["HubbleParam"]
+
         form_time = hf["PartType4/StellarFormationTime"][:]
-        coods = hf["PartType4/Coordinates"][:]
+        coods = hf["PartType4/Coordinates"][:] * scale_factor  # Mpc (physical)
         masses = hf["PartType4/Masses"][:]
 
         imasses = np.ones(len(masses)) * 0.00155
@@ -55,14 +59,12 @@ def load_Simba(
         g_h2fraction = hf["PartType0/FractionH2"][:]
         g_masses = hf["PartType0/Masses"][:]
         g_metals = hf["PartType0/Metallicity"][:][:, 0]
-        g_coods = hf["PartType0/Coordinates"][:]
-        g_hsml = hf["PartType0/SmoothingLength"][:]
+        g_coods = (
+            hf["PartType0/Coordinates"][:] * scale_factor
+        )  # Mpc (physical)
+        g_hsml = hf["PartType0/SmoothingLength"][:]  # Mpc
 
         g_dustmass = hf["PartType0/Dust_Masses"][:]
-
-        scale_factor = hf["Header"].attrs["Time"]
-        Om0 = hf["Header"].attrs["Omega0"]
-        h = hf["Header"].attrs["HubbleParam"]
 
     # convert units
     masses = (masses * 1e10) / h

--- a/src/synthesizer/load_data/load_simba.py
+++ b/src/synthesizer/load_data/load_simba.py
@@ -121,7 +121,7 @@ def load_Simba(
         # Alternative to setting star_forming property on
         # each gas particle
         h2_masses = g_masses[b:e] * g_h2fraction[b:e]
-        galaxies[i].sf_gas_mass = np.sum(h2_masses)
+        galaxies[i].sf_gas_mass = np.sum(h2_masses) * Msun
         galaxies[i].sf_gas_metallicity = (
             np.sum(h2_masses * g_metals[b:e]) / galaxies[i].sf_gas_mass
         )

--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -142,9 +142,7 @@ class Galaxy(BaseGalaxy):
 
                 # mass weighted gas phase metallicity
                 self.sf_gas_metallicity = (
-                    np.sum(
-                        self.gas.masses[mask] * self.gas.metallicities[mask]
-                    )
+                    np.sum(self.gas.masses[mask] * self.gas.metallicities[mask])
                     / self.sf_gas_mass
                 )
 
@@ -295,9 +293,7 @@ class Galaxy(BaseGalaxy):
                 "Star object is missing coordinates!"
             )
         if self.gas.coordinates is None:
-            raise exceptions.InconsistentArguments(
-                "Gas object is missing coordinates!"
-            )
+            raise exceptions.InconsistentArguments("Gas object is missing coordinates!")
         if self.gas.smoothing_lengths is None:
             raise exceptions.InconsistentArguments(
                 "Gas object is missing smoothing lengths!"
@@ -307,9 +303,7 @@ class Galaxy(BaseGalaxy):
                 "Gas object is missing metallicities!"
             )
         if self.gas.masses is None:
-            raise exceptions.InconsistentArguments(
-                "Gas object is missing masses!"
-            )
+            raise exceptions.InconsistentArguments("Gas object is missing masses!")
         if self.gas.dust_to_metal_ratio is None:
             raise exceptions.InconsistentArguments(
                 "Gas object is missing DTMs (dust_to_metal_ratio)!"
@@ -327,12 +321,8 @@ class Galaxy(BaseGalaxy):
 
         # Set up the gas inputs to the C function.
         gas_pos = np.ascontiguousarray(self.gas._coordinates, dtype=np.float64)
-        gas_sml = np.ascontiguousarray(
-            self.gas._smoothing_lengths, dtype=np.float64
-        )
-        gas_met = np.ascontiguousarray(
-            self.gas.metallicities, dtype=np.float64
-        )
+        gas_sml = np.ascontiguousarray(self.gas._smoothing_lengths, dtype=np.float64)
+        gas_met = np.ascontiguousarray(self.gas.metallicities, dtype=np.float64)
         gas_mass = np.ascontiguousarray(self.gas._masses, dtype=np.float64)
         if isinstance(self.gas.dust_to_metal_ratio, float):
             gas_dtm = np.ascontiguousarray(
@@ -468,6 +458,10 @@ class Galaxy(BaseGalaxy):
             threshold (float)
                 The threshold above which the SPH kernel is 0. This is normally
                 at a value of the impact parameter of q = r / h = 1.
+            force_loop (bool)
+                By default (False) the C function will only loop over nearby
+                gas particles to search for contributions to the LOS surface
+                density. This forces the loop over *all* gas particles.
         """
 
         from ..extensions.los import compute_dust_surface_dens
@@ -480,7 +474,9 @@ class Galaxy(BaseGalaxy):
         args = self._prepare_los_args(kernel, mask, threshold, force_loop)
 
         # Compute the dust surface densities
-        los_dustsds = compute_dust_surface_dens(*args)
+        los_dustsds = compute_dust_surface_dens(*args)  # Msun / Mpc**2
+
+        los_dustsds /= (1e6) ** 2  # Msun / pc**2
 
         # Finalise the calculation
         tau_v = kappa * los_dustsds
@@ -560,22 +556,22 @@ class Galaxy(BaseGalaxy):
             if self.sf_gas_mass is None:
                 raise ValueError("No sf_gas_mass provided")
             else:
-                sf_gas_mass = self.sf_gas_mass  # Msun
+                sf_gas_mass = self.sf_gas_mass.value  # Msun
 
         if stellar_mass is None:
             if self.stellar_mass is None:
                 raise ValueError("No stellar_mass provided")
             else:
-                stellar_mass = self.stellar_mass  # Msun
+                stellar_mass = self.stellar_mass.value  # Msun
 
         if sf_gas_mass == 0.0:
             gamma = gamma_min
         elif stellar_mass == 0.0:
             gamma = gamma_min
         else:
-            C = 1 + (sf_gas_metallicity / Z_norm) * (
-                sf_gas_mass / stellar_mass
-            ) * (1.0 / beta)
+            C = 1 + (sf_gas_metallicity / Z_norm) * (sf_gas_mass / stellar_mass) * (
+                1.0 / beta
+            )
             gamma = gamma_max - (gamma_max - gamma_min) / C
 
         return gamma
@@ -782,14 +778,9 @@ class Galaxy(BaseGalaxy):
         # Combine images
         if stellar_spectra_type is not None and blackhole_spectra_type is None:
             img = stellar_img
-        elif (
-            stellar_spectra_type is not None
-            and blackhole_spectra_type is not None
-        ):
+        elif stellar_spectra_type is not None and blackhole_spectra_type is not None:
             img = stellar_img + blackhole_img
-        elif (
-            stellar_spectra_type is None and blackhole_spectra_type is not None
-        ):
+        elif stellar_spectra_type is None and blackhole_spectra_type is not None:
             img = blackhole_img
         else:
             img = stellar_img  # pixel_value case
@@ -852,8 +843,7 @@ class Galaxy(BaseGalaxy):
 
         else:
             raise exceptions.UnknownImageType(
-                "Unknown img_type %s. (Options are 'hist' or "
-                "'smoothed')" % img_type
+                "Unknown img_type %s. (Options are 'hist' or " "'smoothed')" % img_type
             )
 
         return img
@@ -915,8 +905,7 @@ class Galaxy(BaseGalaxy):
 
         else:
             raise exceptions.UnknownImageType(
-                "Unknown img_type %s. (Options are 'hist' or "
-                "'smoothed')" % img_type
+                "Unknown img_type %s. (Options are 'hist' or " "'smoothed')" % img_type
             )
 
         return img
@@ -980,8 +969,7 @@ class Galaxy(BaseGalaxy):
 
         else:
             raise exceptions.UnknownImageType(
-                "Unknown img_type %s. (Options are 'hist' or "
-                "'smoothed')" % img_type
+                "Unknown img_type %s. (Options are 'hist' or " "'smoothed')" % img_type
             )
 
         # Set up the initial mass image
@@ -1070,8 +1058,7 @@ class Galaxy(BaseGalaxy):
 
         else:
             raise exceptions.UnknownImageType(
-                f"Unknown img_type {img_type}. "
-                "(Options are 'hist' or 'smoothed')"
+                f"Unknown img_type {img_type}. " "(Options are 'hist' or 'smoothed')"
             )
 
         # Make the mass image
@@ -1145,8 +1132,7 @@ class Galaxy(BaseGalaxy):
 
         else:
             raise exceptions.UnknownImageType(
-                f"Unknown img_type {img_type}. "
-                "(Options are 'hist' or 'smoothed')"
+                f"Unknown img_type {img_type}. " "(Options are 'hist' or 'smoothed')"
             )
 
         # Make the mass image
@@ -1216,8 +1202,7 @@ class Galaxy(BaseGalaxy):
 
         else:
             raise exceptions.UnknownImageType(
-                f"Unknown img_type {img_type}. "
-                "(Options are 'hist' or 'smoothed')"
+                f"Unknown img_type {img_type}. " "(Options are 'hist' or 'smoothed')"
             )
 
         return img
@@ -1281,8 +1266,7 @@ class Galaxy(BaseGalaxy):
 
         else:
             raise exceptions.UnknownImageType(
-                f"Unknown img_type {img_type}. "
-                "(Options are 'hist' or 'smoothed')"
+                f"Unknown img_type {img_type}. " "(Options are 'hist' or 'smoothed')"
             )
 
         return img
@@ -1365,8 +1349,7 @@ class Galaxy(BaseGalaxy):
 
         else:
             raise exceptions.UnknownImageType(
-                "Unknown img_type %s. (Options are 'hist' or "
-                "'smoothed')" % img_type
+                "Unknown img_type %s. (Options are 'hist' or " "'smoothed')" % img_type
             )
 
         # Convert the initial mass map to SFR

--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -599,7 +599,9 @@ class Galaxy(BaseGalaxy):
         return gamma
 
     def dust_to_metal_vijayan19(
-        self, stellar_mass_weighted_age=None, ism_metallicity=None
+        self,
+        stellar_mass_weighted_age=None,
+        ism_metallicity=None
     ):
         """
         Fitting function for the dust-to-metals ratio based on
@@ -608,13 +610,20 @@ class Galaxy(BaseGalaxy):
         Vijayan+19: https://arxiv.org/abs/1904.02196
 
         Args:
-            Formula uses Age in Gyr while the supplied Age is in Myr
+            stellar_mass_weighted_age (float)
+                Mass weighted age of stars in Myr. Defaults to None,
+                and uses value provided on this galaxy object (in Gyr)
+                ism_metallicity (float)
+                Mass weighted gas-phase metallicity. Defaults to None,
+                and uses value provided on this galaxy object
+                (dimensionless)
         """
 
         if stellar_mass_weighted_age is None:
             if self.stellar_mass_weighted_age is None:
                 raise ValueError("No stellar_mass_weighted_age provided")
             else:
+                # Formula uses Age in Gyr while the supplied Age is in Myr
                 stellar_mass_weighted_age = (
                     self.stellar_mass_weighted_age.value / 1e6
                 )  # Myr
@@ -625,6 +634,7 @@ class Galaxy(BaseGalaxy):
             else:
                 ism_metallicity = self.mass_weighted_gas_metallicity
 
+        # Fixed parameters from Vijayan+21
         D0, D1, alpha, beta, gamma = 0.008, 0.329, 0.017, -1.337, 2.122
         tau = 5e-5 / (D0 * ism_metallicity)
         dtm = D0 + (D1 - D0) * (

--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -123,6 +123,12 @@ class Galaxy(BaseGalaxy):
         if self.stars.current_masses is not None:
             self.stellar_mass = np.sum(self.stars.current_masses)
 
+            if self.stars.ages is not None:
+                self.stellar_mass_weighted_age = (
+                    np.sum(self.stars.ages * self.stars.current_masses)
+                    / self.stellar_mass
+                )
+
     def calculate_integrated_gas_properties(self):
         """
         Calculate integrated gas properties
@@ -131,6 +137,12 @@ class Galaxy(BaseGalaxy):
         # Define integrated properties of this galaxy
         if self.gas.masses is not None:
             self.gas_mass = np.sum(self.gas.masses)
+
+            # mass weighted gas phase metallicity
+            self.mass_weighted_gas_metallicity = (
+                np.sum(self.gas.masses * self.gas.metallicities)
+                / self.gas_mass
+            )
 
         if self.gas.star_forming is not None:
             mask = self.gas.star_forming
@@ -585,6 +597,51 @@ class Galaxy(BaseGalaxy):
             gamma = gamma_max - (gamma_max - gamma_min) / C
 
         return gamma
+
+    def dust_to_metal_vijayan19(
+        self, stellar_mass_weighted_age=None, ism_metallicity=None
+    ):
+        """
+        Fitting function for the dust-to-metals ratio based on
+        galaxy properties, from L-GALAXIES dust modeling.
+
+        Vijayan+19: https://arxiv.org/abs/1904.02196
+
+        Args:
+            Formula uses Age in Gyr while the supplied Age is in Myr
+        """
+
+        if stellar_mass_weighted_age is None:
+            if self.stellar_mass_weighted_age is None:
+                raise ValueError("No stellar_mass_weighted_age provided")
+            else:
+                stellar_mass_weighted_age = (
+                    self.stellar_mass_weighted_age.value / 1e6
+                )  # Myr
+
+        if ism_metallicity is None:
+            if self.mass_weighted_gas_metallicity is None:
+                raise ValueError("No mass_weighted_gas_metallicity provided")
+            else:
+                ism_metallicity = self.mass_weighted_gas_metallicity
+
+        D0, D1, alpha, beta, gamma = 0.008, 0.329, 0.017, -1.337, 2.122
+        tau = 5e-5 / (D0 * ism_metallicity)
+        dtm = D0 + (D1 - D0) * (
+            1.0
+            - np.exp(
+                -alpha
+                * (ism_metallicity**beta)
+                * ((stellar_mass_weighted_age / (1e3 * tau)) ** gamma)
+            )
+        )
+        if np.isnan(dtm) or np.isinf(dtm):
+            dtm = 0.0
+
+        # Save under gas properties
+        self.gas.dust_to_metal_ratio = dtm
+
+        return dtm
 
     def make_images(
         self,

--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -142,7 +142,9 @@ class Galaxy(BaseGalaxy):
 
                 # mass weighted gas phase metallicity
                 self.sf_gas_metallicity = (
-                    np.sum(self.gas.masses[mask] * self.gas.metallicities[mask])
+                    np.sum(
+                        self.gas.masses[mask] * self.gas.metallicities[mask]
+                    )
                     / self.sf_gas_mass
                 )
 
@@ -293,7 +295,9 @@ class Galaxy(BaseGalaxy):
                 "Star object is missing coordinates!"
             )
         if self.gas.coordinates is None:
-            raise exceptions.InconsistentArguments("Gas object is missing coordinates!")
+            raise exceptions.InconsistentArguments(
+                "Gas object is missing coordinates!"
+            )
         if self.gas.smoothing_lengths is None:
             raise exceptions.InconsistentArguments(
                 "Gas object is missing smoothing lengths!"
@@ -303,7 +307,9 @@ class Galaxy(BaseGalaxy):
                 "Gas object is missing metallicities!"
             )
         if self.gas.masses is None:
-            raise exceptions.InconsistentArguments("Gas object is missing masses!")
+            raise exceptions.InconsistentArguments(
+                "Gas object is missing masses!"
+            )
         if self.gas.dust_to_metal_ratio is None:
             raise exceptions.InconsistentArguments(
                 "Gas object is missing DTMs (dust_to_metal_ratio)!"
@@ -321,8 +327,12 @@ class Galaxy(BaseGalaxy):
 
         # Set up the gas inputs to the C function.
         gas_pos = np.ascontiguousarray(self.gas._coordinates, dtype=np.float64)
-        gas_sml = np.ascontiguousarray(self.gas._smoothing_lengths, dtype=np.float64)
-        gas_met = np.ascontiguousarray(self.gas.metallicities, dtype=np.float64)
+        gas_sml = np.ascontiguousarray(
+            self.gas._smoothing_lengths, dtype=np.float64
+        )
+        gas_met = np.ascontiguousarray(
+            self.gas.metallicities, dtype=np.float64
+        )
         gas_mass = np.ascontiguousarray(self.gas._masses, dtype=np.float64)
         if isinstance(self.gas.dust_to_metal_ratio, float):
             gas_dtm = np.ascontiguousarray(
@@ -569,9 +579,9 @@ class Galaxy(BaseGalaxy):
         elif stellar_mass == 0.0:
             gamma = gamma_min
         else:
-            C = 1 + (sf_gas_metallicity / Z_norm) * (sf_gas_mass / stellar_mass) * (
-                1.0 / beta
-            )
+            C = 1 + (sf_gas_metallicity / Z_norm) * (
+                sf_gas_mass / stellar_mass
+            ) * (1.0 / beta)
             gamma = gamma_max - (gamma_max - gamma_min) / C
 
         return gamma
@@ -778,9 +788,14 @@ class Galaxy(BaseGalaxy):
         # Combine images
         if stellar_spectra_type is not None and blackhole_spectra_type is None:
             img = stellar_img
-        elif stellar_spectra_type is not None and blackhole_spectra_type is not None:
+        elif (
+            stellar_spectra_type is not None
+            and blackhole_spectra_type is not None
+        ):
             img = stellar_img + blackhole_img
-        elif stellar_spectra_type is None and blackhole_spectra_type is not None:
+        elif (
+            stellar_spectra_type is None and blackhole_spectra_type is not None
+        ):
             img = blackhole_img
         else:
             img = stellar_img  # pixel_value case
@@ -843,7 +858,8 @@ class Galaxy(BaseGalaxy):
 
         else:
             raise exceptions.UnknownImageType(
-                "Unknown img_type %s. (Options are 'hist' or " "'smoothed')" % img_type
+                "Unknown img_type %s. (Options are 'hist' or "
+                "'smoothed')" % img_type
             )
 
         return img
@@ -905,7 +921,8 @@ class Galaxy(BaseGalaxy):
 
         else:
             raise exceptions.UnknownImageType(
-                "Unknown img_type %s. (Options are 'hist' or " "'smoothed')" % img_type
+                "Unknown img_type %s. (Options are 'hist' or "
+                "'smoothed')" % img_type
             )
 
         return img
@@ -969,7 +986,8 @@ class Galaxy(BaseGalaxy):
 
         else:
             raise exceptions.UnknownImageType(
-                "Unknown img_type %s. (Options are 'hist' or " "'smoothed')" % img_type
+                "Unknown img_type %s. (Options are 'hist' or "
+                "'smoothed')" % img_type
             )
 
         # Set up the initial mass image
@@ -1058,7 +1076,8 @@ class Galaxy(BaseGalaxy):
 
         else:
             raise exceptions.UnknownImageType(
-                f"Unknown img_type {img_type}. " "(Options are 'hist' or 'smoothed')"
+                f"Unknown img_type {img_type}. "
+                "(Options are 'hist' or 'smoothed')"
             )
 
         # Make the mass image
@@ -1132,7 +1151,8 @@ class Galaxy(BaseGalaxy):
 
         else:
             raise exceptions.UnknownImageType(
-                f"Unknown img_type {img_type}. " "(Options are 'hist' or 'smoothed')"
+                f"Unknown img_type {img_type}. "
+                "(Options are 'hist' or 'smoothed')"
             )
 
         # Make the mass image
@@ -1202,7 +1222,8 @@ class Galaxy(BaseGalaxy):
 
         else:
             raise exceptions.UnknownImageType(
-                f"Unknown img_type {img_type}. " "(Options are 'hist' or 'smoothed')"
+                f"Unknown img_type {img_type}. "
+                "(Options are 'hist' or 'smoothed')"
             )
 
         return img
@@ -1266,7 +1287,8 @@ class Galaxy(BaseGalaxy):
 
         else:
             raise exceptions.UnknownImageType(
-                f"Unknown img_type {img_type}. " "(Options are 'hist' or 'smoothed')"
+                f"Unknown img_type {img_type}. "
+                "(Options are 'hist' or 'smoothed')"
             )
 
         return img
@@ -1349,7 +1371,8 @@ class Galaxy(BaseGalaxy):
 
         else:
             raise exceptions.UnknownImageType(
-                "Unknown img_type %s. (Options are 'hist' or " "'smoothed')" % img_type
+                "Unknown img_type %s. (Options are 'hist' or "
+                "'smoothed')" % img_type
             )
 
         # Convert the initial mass map to SFR

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -721,7 +721,7 @@ class Stars(Particles, StarsComponent):
             if verbose:
                 print("Age mask has filtered out all particles")
 
-            return np.zeros(len(grid.lam))
+            return np.zeros((self.nstars, len(grid.lam)))
 
         from ..extensions.particle_spectra import compute_particle_seds
 

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -232,13 +232,17 @@ class Sed:
         # could instead check the first and last entry and the shape.
         # In rare instances this could fail though.
         if not np.array_equal(self._lam, second_sed._lam):
-            raise exceptions.InconsistentAddition("Wavelength grids must be identical")
+            raise exceptions.InconsistentAddition(
+                "Wavelength grids must be identical"
+            )
 
         # Ensure the lnu arrays are compatible
         # This check is redudant for Sed.lnu.shape = (nlam, ) spectra but will
         # not erroneously error. Nor is it expensive.
         if self._lnu.shape[0] != second_sed._lnu.shape[0]:
-            raise exceptions.InconsistentAddition("SEDs must have same dimensions")
+            raise exceptions.InconsistentAddition(
+                "SEDs must have same dimensions"
+            )
 
         # They're compatible, add them
         return Sed(self._lam, lnu=self._lnu + second_sed._lnu)
@@ -450,7 +454,8 @@ class Sed:
         """
 
         return (
-            self._get_lnu_at_nu(nu.to(self.nu.units).value, kind=kind) * self.lnu.units
+            self._get_lnu_at_nu(nu.to(self.nu.units).value, kind=kind)
+            * self.lnu.units
         )
 
     def _get_lnu_at_lam(self, lam, kind=False, ind=None):
@@ -596,14 +601,18 @@ class Sed:
             # base units.
             lims = (c / np.array(window)).to(self.nu.units).value
             luminosity = (
-                integrate.quad(self._get_lnu_at_nu, *lims)[0] * self.lnu.units * Hz
+                integrate.quad(self._get_lnu_at_nu, *lims)[0]
+                * self.lnu.units
+                * Hz
             )
 
         elif method == "trapz":
             # Define a pseudo transmission function
             transmission = (self.lam > window[0]) & (self.lam < window[1])
             transmission = transmission.astype(float)
-            luminosity = np.trapz(self.lnu[::-1] * transmission[::-1], x=self.nu[::-1])
+            luminosity = np.trapz(
+                self.lnu[::-1] * transmission[::-1], x=self.nu[::-1]
+            )
         else:
             raise exceptions.UnrecognisedOption(
                 f"Unrecognised integration method ({method}). "
@@ -666,7 +675,9 @@ class Sed:
                 Lnu = (
                     np.array(
                         [
-                            np.trapz(_lnu[::-1] * transmission[::-1] / nu, x=nu)
+                            np.trapz(
+                                _lnu[::-1] * transmission[::-1] / nu, x=nu
+                            )
                             / np.trapz(transmission[::-1] / nu, x=nu)
                             for _lnu in self._lnu
                         ]
@@ -691,7 +702,9 @@ class Sed:
             def inv(x):
                 return 1 / x
 
-            Lnu = integrate.quad(func, *lims)[0] / integrate.quad(inv, *lims)[0]
+            Lnu = (
+                integrate.quad(func, *lims)[0] / integrate.quad(inv, *lims)[0]
+            )
 
             Lnu = Lnu * self.lnu.units
 
@@ -793,7 +806,9 @@ class Sed:
             if self._spec_dims == 2:
                 beta = np.array(
                     [
-                        linregress(np.log10(self._lam[s]), np.log10(_lnu[..., s]))[0]
+                        linregress(
+                            np.log10(self._lam[s]), np.log10(_lnu[..., s])
+                        )[0]
                         - 2.0
                         for _lnu in self.lnu
                     ]
@@ -801,7 +816,10 @@ class Sed:
 
             else:
                 beta = (
-                    linregress(np.log10(self._lam[s]), np.log10(self._lnu[s]))[0] - 2.0
+                    linregress(np.log10(self._lam[s]), np.log10(self._lnu[s]))[
+                        0
+                    ]
+                    - 2.0
                 )
 
         # If two windows are provided
@@ -816,7 +834,8 @@ class Sed:
 
             # Measure beta
             beta = (
-                np.log10(lnu_blue / lnu_red) / np.log10(np.mean(blue) / np.mean(red))
+                np.log10(lnu_blue / lnu_red)
+                / np.log10(np.mean(blue) / np.mean(red))
                 - 2.0
             )
 
@@ -878,7 +897,9 @@ class Sed:
 
         # Finally, compute the flux SED and apply unit conversions to get
         # to nJy
-        self.fnu = self.lnu * (1.0 + z) / (4 * np.pi * luminosity_distance**2)
+        self.fnu = (
+            self.lnu * (1.0 + z) / (4 * np.pi * luminosity_distance**2)
+        )
 
         # If we are applying an IGM model apply it
         if igm:
@@ -1044,7 +1065,9 @@ class Sed:
             # Multiple spectra case
 
             # Perform polyfit for the continuum fit for all spectra
-            continuum_fits = np.polyfit([mean_blue, mean_red], [lnu_blue, lnu_red], 1)
+            continuum_fits = np.polyfit(
+                [mean_blue, mean_red], [lnu_blue, lnu_red], 1
+            )
             # Use the continuum fit to define the continuum for all spectra
             continuum = (
                 (
@@ -1058,16 +1081,22 @@ class Sed:
 
             # Define the continuum subtracted spectrum for all SEDs
             feature_lum = self.lnu[:, transmission]
-            feature_lum_continuum_subtracted = -(feature_lum - continuum) / continuum
+            feature_lum_continuum_subtracted = (
+                -(feature_lum - continuum) / continuum
+            )
 
             # Measure index for all SEDs
-            index = np.trapz(feature_lum_continuum_subtracted, x=feature_lam, axis=1)
+            index = np.trapz(
+                feature_lum_continuum_subtracted, x=feature_lam, axis=1
+            )
 
         else:
             # Single spectra case
 
             # Perform polyfit for the continuum fit
-            continuum_fit = np.polyfit([mean_blue, mean_red], [lnu_blue, lnu_red], 1)
+            continuum_fit = np.polyfit(
+                [mean_blue, mean_red], [lnu_blue, lnu_red], 1
+            )
 
             # Use the continuum fit to define the continuum
             continuum = (
@@ -1077,7 +1106,9 @@ class Sed:
 
             # Define the continuum subtracted spectrum
             feature_lum = self.lnu[transmission]
-            feature_lum_continuum_subtracted = -(feature_lum - continuum) / continuum
+            feature_lum_continuum_subtracted = (
+                -(feature_lum - continuum) / continuum
+            )
 
             # Measure index
             index = np.trapz(feature_lum_continuum_subtracted, x=feature_lam)
@@ -1164,7 +1195,8 @@ class Sed:
         if mask is not None:
             if self._lnu.ndim < 2:
                 raise exceptions.InconsistentArguments(
-                    "Masks are only applicable for Seds containing " "multiple spectra"
+                    "Masks are only applicable for Seds containing "
+                    "multiple spectra"
                 )
             if self._lnu.shape[0] != mask.size:
                 raise exceptions.InconsistentArguments(
@@ -1364,7 +1396,8 @@ def plot_spectra(
             # Ensure we have fluxes
             if sed.fnu is None:
                 raise exceptions.MissingSpectraType(
-                    f"This Sed has no fluxes ({key})! Have you called " "Sed.get_fnu()?"
+                    f"This Sed has no fluxes ({key})! Have you called "
+                    "Sed.get_fnu()?"
                 )
 
             # Ok everything is fine

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -148,7 +148,14 @@ class Sed:
             sed (object, Sed)
                 Summed 1D SED.
         """
-        return Sed(self.lam, np.sum(self._lnu, axis=0))
+
+        # Check that the lnu array is multidimensional
+        if len(self._lnu.shape) > 1:
+            # Return a new sed object with the first Lnu dimension collapsed
+            return Sed(self.lam, np.sum(self._lnu, axis=0))
+        else:
+            # If 1D, just return the original array
+            return self
 
     def concat(self, *other_seds):
         """
@@ -1770,3 +1777,21 @@ def get_attenuation_at_1500(intrinsic_sed, attenuated_sed):
         intrinsic_sed,
         attenuated_sed,
     )
+
+
+def combine_list_of_seds(sed_list):
+    """
+    Combine a list of `Sed` objects (length `Ngal`) into a single
+    `Sed` object, with dimensions `Ngal x Nlam`. Each `Sed` object
+    in the list should have an identical wavelength range.
+
+    Args:
+        sed_list (list)
+            list of `Sed` objects
+    """
+
+    out_sed = sed_list[0]
+    for sed in sed_list[1:]:
+        out_sed = out_sed.concat(sed)
+
+    return out_sed

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -139,6 +139,17 @@ class Sed:
         self.photo_luminosities = None
         self.photo_fluxes = None
 
+    def sum(self):
+        """
+        For multidimensional `sed`'s, sum the luminosity to provide a 1D
+        integrated SED.
+
+        Returns:
+            sed (object, Sed)
+                Summed 1D SED.
+        """
+        return Sed(self.lam, np.sum(self._lnu, axis=0))
+
     def concat(self, *other_seds):
         """
         Concatenate the spectra arrays of multiple Sed objects.
@@ -221,17 +232,13 @@ class Sed:
         # could instead check the first and last entry and the shape.
         # In rare instances this could fail though.
         if not np.array_equal(self._lam, second_sed._lam):
-            raise exceptions.InconsistentAddition(
-                "Wavelength grids must be identical"
-            )
+            raise exceptions.InconsistentAddition("Wavelength grids must be identical")
 
         # Ensure the lnu arrays are compatible
         # This check is redudant for Sed.lnu.shape = (nlam, ) spectra but will
         # not erroneously error. Nor is it expensive.
         if self._lnu.shape[0] != second_sed._lnu.shape[0]:
-            raise exceptions.InconsistentAddition(
-                "SEDs must have same dimensions"
-            )
+            raise exceptions.InconsistentAddition("SEDs must have same dimensions")
 
         # They're compatible, add them
         return Sed(self._lam, lnu=self._lnu + second_sed._lnu)
@@ -443,8 +450,7 @@ class Sed:
         """
 
         return (
-            self._get_lnu_at_nu(nu.to(self.nu.units).value, kind=kind)
-            * self.lnu.units
+            self._get_lnu_at_nu(nu.to(self.nu.units).value, kind=kind) * self.lnu.units
         )
 
     def _get_lnu_at_lam(self, lam, kind=False, ind=None):
@@ -590,18 +596,14 @@ class Sed:
             # base units.
             lims = (c / np.array(window)).to(self.nu.units).value
             luminosity = (
-                integrate.quad(self._get_lnu_at_nu, *lims)[0]
-                * self.lnu.units
-                * Hz
+                integrate.quad(self._get_lnu_at_nu, *lims)[0] * self.lnu.units * Hz
             )
 
         elif method == "trapz":
             # Define a pseudo transmission function
             transmission = (self.lam > window[0]) & (self.lam < window[1])
             transmission = transmission.astype(float)
-            luminosity = np.trapz(
-                self.lnu[::-1] * transmission[::-1], x=self.nu[::-1]
-            )
+            luminosity = np.trapz(self.lnu[::-1] * transmission[::-1], x=self.nu[::-1])
         else:
             raise exceptions.UnrecognisedOption(
                 f"Unrecognised integration method ({method}). "
@@ -664,9 +666,7 @@ class Sed:
                 Lnu = (
                     np.array(
                         [
-                            np.trapz(
-                                _lnu[::-1] * transmission[::-1] / nu, x=nu
-                            )
+                            np.trapz(_lnu[::-1] * transmission[::-1] / nu, x=nu)
                             / np.trapz(transmission[::-1] / nu, x=nu)
                             for _lnu in self._lnu
                         ]
@@ -691,9 +691,7 @@ class Sed:
             def inv(x):
                 return 1 / x
 
-            Lnu = (
-                integrate.quad(func, *lims)[0] / integrate.quad(inv, *lims)[0]
-            )
+            Lnu = integrate.quad(func, *lims)[0] / integrate.quad(inv, *lims)[0]
 
             Lnu = Lnu * self.lnu.units
 
@@ -795,9 +793,7 @@ class Sed:
             if self._spec_dims == 2:
                 beta = np.array(
                     [
-                        linregress(
-                            np.log10(self._lam[s]), np.log10(_lnu[..., s])
-                        )[0]
+                        linregress(np.log10(self._lam[s]), np.log10(_lnu[..., s]))[0]
                         - 2.0
                         for _lnu in self.lnu
                     ]
@@ -805,10 +801,7 @@ class Sed:
 
             else:
                 beta = (
-                    linregress(np.log10(self._lam[s]), np.log10(self._lnu[s]))[
-                        0
-                    ]
-                    - 2.0
+                    linregress(np.log10(self._lam[s]), np.log10(self._lnu[s]))[0] - 2.0
                 )
 
         # If two windows are provided
@@ -823,8 +816,7 @@ class Sed:
 
             # Measure beta
             beta = (
-                np.log10(lnu_blue / lnu_red)
-                / np.log10(np.mean(blue) / np.mean(red))
+                np.log10(lnu_blue / lnu_red) / np.log10(np.mean(blue) / np.mean(red))
                 - 2.0
             )
 
@@ -886,9 +878,7 @@ class Sed:
 
         # Finally, compute the flux SED and apply unit conversions to get
         # to nJy
-        self.fnu = (
-            self.lnu * (1.0 + z) / (4 * np.pi * luminosity_distance**2)
-        )
+        self.fnu = self.lnu * (1.0 + z) / (4 * np.pi * luminosity_distance**2)
 
         # If we are applying an IGM model apply it
         if igm:
@@ -1054,9 +1044,7 @@ class Sed:
             # Multiple spectra case
 
             # Perform polyfit for the continuum fit for all spectra
-            continuum_fits = np.polyfit(
-                [mean_blue, mean_red], [lnu_blue, lnu_red], 1
-            )
+            continuum_fits = np.polyfit([mean_blue, mean_red], [lnu_blue, lnu_red], 1)
             # Use the continuum fit to define the continuum for all spectra
             continuum = (
                 (
@@ -1070,22 +1058,16 @@ class Sed:
 
             # Define the continuum subtracted spectrum for all SEDs
             feature_lum = self.lnu[:, transmission]
-            feature_lum_continuum_subtracted = (
-                -(feature_lum - continuum) / continuum
-            )
+            feature_lum_continuum_subtracted = -(feature_lum - continuum) / continuum
 
             # Measure index for all SEDs
-            index = np.trapz(
-                feature_lum_continuum_subtracted, x=feature_lam, axis=1
-            )
+            index = np.trapz(feature_lum_continuum_subtracted, x=feature_lam, axis=1)
 
         else:
             # Single spectra case
 
             # Perform polyfit for the continuum fit
-            continuum_fit = np.polyfit(
-                [mean_blue, mean_red], [lnu_blue, lnu_red], 1
-            )
+            continuum_fit = np.polyfit([mean_blue, mean_red], [lnu_blue, lnu_red], 1)
 
             # Use the continuum fit to define the continuum
             continuum = (
@@ -1095,9 +1077,7 @@ class Sed:
 
             # Define the continuum subtracted spectrum
             feature_lum = self.lnu[transmission]
-            feature_lum_continuum_subtracted = (
-                -(feature_lum - continuum) / continuum
-            )
+            feature_lum_continuum_subtracted = -(feature_lum - continuum) / continuum
 
             # Measure index
             index = np.trapz(feature_lum_continuum_subtracted, x=feature_lam)
@@ -1184,8 +1164,7 @@ class Sed:
         if mask is not None:
             if self._lnu.ndim < 2:
                 raise exceptions.InconsistentArguments(
-                    "Masks are only applicable for Seds containing "
-                    "multiple spectra"
+                    "Masks are only applicable for Seds containing " "multiple spectra"
                 )
             if self._lnu.shape[0] != mask.size:
                 raise exceptions.InconsistentArguments(
@@ -1385,8 +1364,7 @@ def plot_spectra(
             # Ensure we have fluxes
             if sed.fnu is None:
                 raise exceptions.MissingSpectraType(
-                    f"This Sed has no fluxes ({key})! Have you called "
-                    "Sed.get_fnu()?"
+                    f"This Sed has no fluxes ({key})! Have you called " "Sed.get_fnu()?"
                 )
 
             # Ok everything is fine


### PR DESCRIPTION
Fixes FLARES method for loading data. Also includes a number of other relatively small changes and fixes, summarised below:

Changelog:
- Updated kernel class to be capitalised (kernel -> Kernel)
- Fixed error in the los extension where the length ratio was not square rooted
- Simplified LOS extension calculation
- Changed all `load_data` methods to load lengths (coordinates, smoothing lengths, etc.) in physical, rather than comoving coordinates
- Adds the `dust_to_metal_vijayan19` method for calculating the DTM ratio from galaxy properties, detailed in [Vijayan+21](https://ui.adsabs.harvard.edu/abs/2020arXiv200806057V/abstract)
- Fixes an error in the `generate_lnu` for stars component where an empty array was returned with the wrong dimensions
- Adds a `sum` method to `Sed` to collapse multidimensional objects down to 1D
- Adds a `combine_list_of_seds` helper method to the end of the `sed` submodule to combine a list of Seds into a single Sed object


## Issue Type
- Bug
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
