### PR TITLE
Allow `FilterCollection`s to be made from existing `Filter`s

### DIFF
--- a/docs/source/filters.ipynb
+++ b/docs/source/filters.ipynb
@@ -95,7 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filt = Filter(\"top_hat/filter.1\", lam_min=3000, lam_max=5500, new_lam=lams)"
+    "filt1 = Filter(\"top_hat/filter.1\", lam_min=3000, lam_max=5500, new_lam=lams)"
    ]
   },
   {
@@ -113,7 +113,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filt = Filter(\"top_hat/filter.2\", lam_eff=7000, lam_fwhm=2000, new_lam=lams)"
+    "filt2 = Filter(\"top_hat/filter.2\", lam_eff=7000, lam_fwhm=2000, new_lam=lams)"
    ]
   },
   {
@@ -131,7 +131,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "filt = Filter(\"JWST/NIRCam.F200W\", new_lam=lams)"
+    "filt3 = Filter(\"JWST/NIRCam.F444W\", new_lam=lams)"
    ]
   },
   {
@@ -162,7 +162,7 @@
    "id": "db553b92",
    "metadata": {},
    "source": [
-    "For a set of top hat filters we must pass a dictionary containing the properties of each `Filter` where the key s the `Filter`'s filter code."
+    "For a set of top hat filters we must pass a dictionary containing the properties of each `Filter` where the keys are the `Filter`'s filter code."
    ]
   },
   {
@@ -200,6 +200,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a8646dcf",
+   "metadata": {},
+   "source": [
+    "You can also pass a list of existing `Filter`s."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bac2f425",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filt_lst = [filt1, filt2, filt3]\n",
+    "filt_filters = FilterCollection(filters=filt_lst, new_lam=lams)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5521961e-60df-4e06-a446-2c0b88275672",
    "metadata": {},
    "source": [
@@ -220,9 +239,18 @@
     "    \"J\": {\"lam_eff\": 12200, \"lam_fwhm\": 2130},\n",
     "}\n",
     "generics = {\"generic_filter3\": trans}\n",
+    "filt_lst = [filt1, filt2]\n",
     "combined_filters = FilterCollection(\n",
-    "    filter_codes=fs, tophat_dict=tophats, generic_dict=generics, new_lam=lams\n",
+    "    filter_codes=fs, tophat_dict=tophats, generic_dict=generics, filters=filt_lst, new_lam=lams\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d865c2d",
+   "metadata": {},
+   "source": [
+    "One important thing to note when creating a `FilterCollection` is that all `Filter`s in a `FilterCollection` will always be interpolated onto a common wavelength array. If a wavelength array hasn't been passed to `new_lam` then a wavelength array encompassing all `Filter`s will be found but if `new_lam` has been provided then all transmission curves will be interpolated on to it. "
    ]
   },
   {
@@ -329,6 +357,28 @@
     "new_filters = combined_filters + top_hat_filters\n",
     "new_filters += generic_filters\n",
     "print(\"My combined Filters:\", new_filters.filter_codes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4b15cb0e",
+   "metadata": {},
+   "source": [
+    "Note that adding `Filter`s or `FilterCollection`s to a `FilterCollection` will result in interpolation of the transmission curves onto the `FilterCollection`'s wavelength array. In the event the wavelength arrays differ, the wavelengths of the `FilterCollection` being added to are maintained and a warning is printed if this will truncate the transmission curve of the `Filter` being added. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31cb1568",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filter_codes = [f\"JWST/NIRCam.{f}\" for f in [\"F070W\", \"F444W\"]]\n",
+    "new_filters2 = FilterCollection(filter_codes=filter_codes)\n",
+    "out_of_range_filt = Filter(\"JWST/MIRI.F2550W\")\n",
+    "\n",
+    "new_filters2 = new_filters2 + out_of_range_filt "
    ]
   },
   {
@@ -556,8 +606,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "synthesizer-env",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/src/synthesizer/filters.py
+++ b/src/synthesizer/filters.py
@@ -630,6 +630,9 @@ class FilterCollection:
         self.lam = new_lam
 
         # Loop over filters unifying them onto this wavelength array
+        # NOTE: Filters already on self.lam will be uneffected but doing a
+        # np.all condition to check for matches and skip them is more expensive
+        # than just doing the interpolation for all filters
         for fcode in self.filters:
             f = self.filters[fcode]
             f.t = f._interpolate_wavelength(self.lam)

--- a/src/synthesizer/filters.py
+++ b/src/synthesizer/filters.py
@@ -309,7 +309,7 @@ class FilterCollection:
 
     def _include_svo_filters(self, filter_codes):
         """
-        Populate the FilterCollection with filters from SVO.
+        Populate the `FilterCollection` with filters from SVO.
 
         Args:
             filter_codes (list, string)
@@ -328,7 +328,7 @@ class FilterCollection:
 
     def _include_top_hat_filters(self, tophat_dict):
         """
-        Populate the FilterCollection with user defined top hat filters.
+        Populate the `FilterCollection` with user defined top-hat filters.
 
         Args:
             tophat_dict (dict)
@@ -379,7 +379,7 @@ class FilterCollection:
 
     def _include_generic_filters(self, generic_dict):
         """
-        Populate the FilterCollection with user defined filters.
+        Populate the `FilterCollection` with user defined filters.
 
         Args:
             generic_dict (dict)
@@ -404,7 +404,8 @@ class FilterCollection:
 
     def _include_synthesizer_filters(self, filters):
         """
-        Populate the FilterCollection with filters from SVO.
+        Populate the `FilterCollection` with a list of individual
+        `Filter` objects.
 
         Args:
             filter_codes (list, string)

--- a/src/synthesizer/filters.py
+++ b/src/synthesizer/filters.py
@@ -107,6 +107,7 @@ class FilterCollection:
         filter_codes=None,
         tophat_dict=None,
         generic_dict=None,
+        filters=None,
         path=None,
         new_lam=None,
     ):
@@ -117,7 +118,7 @@ class FilterCollection:
             filter_codes  (list, string)
                 A list of SVO filter codes, used to retrieve filter data from
                 the database.
-            tophat_dict (dict, Filter)
+            tophat_dict (dict)
                 A dictionary containing the data to make a collection of top
                 hat filters from user defined properties. The dictionary must
                 have the form:
@@ -133,6 +134,9 @@ class FilterCollection:
                 must have the form:
                     {<filter_code1> : {"transmission": <transmission_array>}}.
                 For generic filters new_lam must be provided.
+            filters (list, Filter)
+                A list of existing `Filter` objects to be added to the
+                collection.
             path (string)
                 A filepath defining the HDF5 file from which to load the
                 FilterCollection.
@@ -183,11 +187,13 @@ class FilterCollection:
 
             # Let's make the filters
             if filter_codes is not None:
-                self._make_svo_collection(filter_codes)
+                self._include_svo_filters(filter_codes)
             if tophat_dict is not None:
-                self._make_top_hat_collection(tophat_dict)
+                self._include_top_hat_filters(tophat_dict)
             if generic_dict is not None:
-                self._make_generic_collection(generic_dict)
+                self._include_generic_filters(generic_dict)
+            if filters is not None:
+                self._include_synthesizer_filters(filters)
 
             # How many filters are there?
             self.nfilters = len(self.filter_codes)
@@ -301,7 +307,7 @@ class FilterCollection:
 
         hdf.close()
 
-    def _make_svo_collection(self, filter_codes):
+    def _include_svo_filters(self, filter_codes):
         """
         Populate the FilterCollection with filters from SVO.
 
@@ -320,7 +326,7 @@ class FilterCollection:
             self.filters[_filter.filter_code] = _filter
             self.filter_codes.append(_filter.filter_code)
 
-    def _make_top_hat_collection(self, tophat_dict):
+    def _include_top_hat_filters(self, tophat_dict):
         """
         Populate the FilterCollection with user defined top hat filters.
 
@@ -371,7 +377,7 @@ class FilterCollection:
             self.filters[_filter.filter_code] = _filter
             self.filter_codes.append(_filter.filter_code)
 
-    def _make_generic_collection(self, generic_dict):
+    def _include_generic_filters(self, generic_dict):
         """
         Populate the FilterCollection with user defined filters.
 
@@ -392,6 +398,22 @@ class FilterCollection:
             # Instantiate the filter
             _filter = Filter(key, transmission=t, new_lam=self.lam)
 
+            # Store the filter and its code
+            self.filters[_filter.filter_code] = _filter
+            self.filter_codes.append(_filter.filter_code)
+
+    def _include_synthesizer_filters(self, filters):
+        """
+        Populate the FilterCollection with filters from SVO.
+
+        Args:
+            filter_codes (list, string)
+                A list of SVO filter codes, used to retrieve filter data from
+                the database.
+        """
+
+        # Loop over the given filter codes
+        for _filter in filters:
             # Store the filter and its code
             self.filters[_filter.filter_code] = _filter
             self.filter_codes.append(_filter.filter_code)
@@ -430,6 +452,16 @@ class FilterCollection:
 
         # Update the number of filters we have
         self.nfilters = len(self.filter_codes)
+
+        # Now resample the filters onto the filter collection's wavelength
+        # array,
+        # NOTE: If the new filter extends beyond the filter collection's
+        # wavlength array a warning is given and that filter curve will
+        # truncated at the limits. This is because we can't have the
+        # filter collection's wavelength array modified, if that were
+        # to happen it could become inconsistent with Sed wavelength arrays
+        # and photometry would be impossible.
+        self.resample_filters(new_lam=self.lam)
 
         return self
 
@@ -1165,6 +1197,22 @@ class Filter:
         # If we've been handed a wavelength array we must overwrite the
         # current one
         if new_lam is not None:
+            # Warn the user if we're about to truncate the existing wavelength
+            # array
+            truncated = False
+            if new_lam.min() > self.lam.min():
+                truncated = True
+            if new_lam.max() < self.lam.max():
+                truncated = True
+            if truncated:
+                print(
+                    f"Warning: {self.filter_code} is being truncated "
+                    "(old_lam_bounds = "
+                    f"({self.lam.min():.2e}, {self.lam.max():.2e}), "
+                    "new_lam_bounds = "
+                    f"({new_lam.min():.2e}, {new_lam.max():.2e}))"
+                )
+
             self.lam = new_lam
 
         # Perform interpolation


### PR DESCRIPTION
You can now make a `FilterCollection` from a list of existing `Filter` objects. In addition:

- Addition now ensures the added `Filter`s are on the same wavelength range.
- Documentation has been expanded to include a demonstration of this change.
- Documentation now explains the single wavelength array for a `FilterCollection` and behind the scenes behaviour to maintain it.

Closes #504 and closes #505 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
