### PR TITLE
fix unit of ages in particle stars documentation

### DIFF
--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -51,7 +51,7 @@ class Stars(Particles, StarsComponent):
         initial_masses (array-like, float)
             The intial stellar mass of each particle in Msun.
         ages (array-like, float)
-            The age of each stellar particle in Myrs.
+            The age of each stellar particle in yrs.
         metallicities (array-like, float)
             The metallicity of each stellar particle.
         tau_v (array-like, float)


### PR DESCRIPTION
## Issue Type
<!-- delete options below as required -->
- Document

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
