### PR TITLE
Fixed flux photometry

### DIFF
--- a/src/synthesizer/photometry.py
+++ b/src/synthesizer/photometry.py
@@ -261,7 +261,7 @@ class PhotometryCollection:
 
         # Get the photometry
         photometry = (
-            self.photo_luminosities if self.rest_frame else self.obs_photometry
+            self.photo_luminosities if self.rest_frame else self.photo_fluxes
         )
 
         # Plot the photometry


### PR DESCRIPTION
When some photometry initialisation was changed, a bug slipped in for fluxes. When assigning fluxes an old variable was used. This PR is a one-line change fixing that oversight.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
