### PR TITLE
Adds a method to interpolate a Grid onto a `FilterCollection` wavelength array

### DIFF
--- a/docs/source/grids/grids_example.ipynb
+++ b/docs/source/grids/grids_example.ipynb
@@ -251,7 +251,7 @@
     "\n",
     "It's important when working with a `Grid` and any `Filter` objects (see the filter [docs](../filters.ipynb)) to have a single wavelength array shared between the two to ensure filter transmission curves are applied correctly. Additionally, when focused on photometry in certain filters focus a `Grid`'s spectral range to that of the filters in question can drastically reduce the memory footprint of a calculation. \n",
     "\n",
-    "To ensure the former and enable the latter a `Grid` provides the `unify_with_filters` method. This method will take a `FilterCollection` as an arguement and interpolate the `Grid` spectra onto the filters' wavelength array.\n",
+    "To ensure the former and enable the latter a `Grid` provides the `unify_with_filters` method. This method will take a `FilterCollection` as an arguement and interpolate the `Grid` spectra onto the filters' wavelength array. You can also initialise a `Grid` by passing the filter collection via the `filters` keyword argument at instantiation.\n",
     "\n",
     "We demonstrate this below using a set of `UVJ` filters. "
    ]

--- a/docs/source/grids/grids_example.ipynb
+++ b/docs/source/grids/grids_example.ipynb
@@ -241,6 +241,40 @@
     "# Measure the balmer break for all spectra in the grid (limiting the output)\n",
     "sed.measure_balmer_break()[5:10, 5:10]"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c159d2a",
+   "metadata": {},
+   "source": [
+    "## Unifying a `Grid` with a `FilterCollection`\n",
+    "\n",
+    "It's important when working with a `Grid` and any `Filter` objects (see the filter [docs](../filters.ipynb)) to have a single wavelength array shared between the two to ensure filter transmission curves are applied correctly. Additionally, when focused on photometry in certain filters focus a `Grid`'s spectral range to that of the filters in question can drastically reduce the memory footprint of a calculation. \n",
+    "\n",
+    "To ensure the former and enable the latter a `Grid` provides the `unify_with_filters` method. This method will take a `FilterCollection` as an arguement and interpolate the `Grid` spectra onto the filters' wavelength array.\n",
+    "\n",
+    "We demonstrate this below using a set of `UVJ` filters. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ab7e7b1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from synthesizer.filters import UVJ\n",
+    "\n",
+    "# Get the filter collection\n",
+    "fc = UVJ()\n",
+    "\n",
+    "print(\"Shape before:\", grid.spectra[\"incident\"].shape)\n",
+    "\n",
+    "# Unify the grid with this filter collection\n",
+    "grid.unify_with_filters(fc)\n",
+    "\n",
+    "print(\"Shape after:\", grid.spectra[\"incident\"].shape)"
+   ]
   }
  ],
  "metadata": {
@@ -259,7 +293,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/docs/source/grids/grids_example.ipynb
+++ b/docs/source/grids/grids_example.ipynb
@@ -265,6 +265,7 @@
    "source": [
     "from synthesizer.filters import UVJ\n",
     "\n",
+    "\n",
     "# Get the filter collection\n",
     "fc = UVJ()\n",
     "\n",
@@ -273,7 +274,11 @@
     "# Unify the grid with this filter collection\n",
     "grid.unify_with_filters(fc)\n",
     "\n",
-    "print(\"Shape after:\", grid.spectra[\"incident\"].shape)"
+    "print(\"Shape after:\", grid.spectra[\"incident\"].shape)\n",
+    "\n",
+    "# Or you can get the grid interpolated onto the filter wavelength\n",
+    "# at the point of initialisation\n",
+    "grid = Grid(grid_name, grid_dir=grid_dir, filters=fc)"
    ]
   }
  ],

--- a/src/synthesizer/filters.py
+++ b/src/synthesizer/filters.py
@@ -582,7 +582,6 @@ class FilterCollection:
         """
         return self.filters[key]
 
-
     def get_non_zero_lam_lims(self):
         """
         Find the minimum and maximum wavelengths with non-zero transmission.

--- a/src/synthesizer/filters.py
+++ b/src/synthesizer/filters.py
@@ -587,9 +587,9 @@ class FilterCollection:
         Find the minimum and maximum wavelengths with non-zero transmission.
 
         Returns:
-            float
+            unyt_quantity
                 Minimum wavelength with non-zero transmission.
-            float
+            unyt_quantity
                 Maximum wavelength with non-zero transmission.
         """
         # Get the minimum and maximum wavelength at which transmission is
@@ -604,7 +604,14 @@ class FilterCollection:
             if this_max > max_lam:
                 max_lam = this_max
 
-        return min_lam * self.lam.units, max_lam * self.lam.units
+        # It's possible to be here without having set self.lam, in that
+        # case we use the last filter in the iteration.
+        if self.lam is not None:
+            return min_lam * self.lam.units, max_lam * self.lam.units
+        return (
+            min_lam * self.filters[f].lam.units,
+            max_lam * self.filters[f].lam.units,
+        )
 
     def _merge_filter_lams(self, fill_gaps):
         """

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -941,4 +941,3 @@ class Grid:
             plt.close(fig)
 
         return anim
-

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -791,3 +791,25 @@ class Grid:
                 The spectra grid as an Sed object.
         """
         return Sed(self.lam, self.spectra[spectra_type])
+
+    def unify_with_filters(self, filters, loop_spectra=False):
+        """
+        Unify the grid with a FilterCollection object.
+
+        This will interpolate the grid onto the wavelength grid of the
+        filters.
+
+        Args:
+            filters (synthesizer.filter.FilterCollection)
+                The FilterCollection object to unify the grid with.
+            loop_spectra (bool)
+                Flag for whether to do the interpolation over the whole
+                grid, or loop over the first axes. The latter is less memory
+                intensive, but slower. Defaults to False.
+        """
+
+        # Extract the filter collection's wavelength array
+        new_lam = filters.lam
+
+        # Interpolate the grid onto this wavelength grid
+        self.interp_spectra(new_lam, loop_spectra)


### PR DESCRIPTION
DWISOTT: now there's a simple method to unify a grid and filter collection. This has also been demonstrated in the docs.

This also allows a grid to be instantiated with a filter collection to automatically perform the unification at instantiation.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
