### PR TITLE
Introduced collective photometry methods on `Galaxy` and components

### DIFF
--- a/docs/source/cosmo/cosmo_example.ipynb
+++ b/docs/source/cosmo/cosmo_example.ipynb
@@ -191,6 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "8b36b9b0",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,7 +396,8 @@
     "fc = UVJ(new_lam=grid.lam)\n",
     "\n",
     "_UVJ = spec.get_photo_fluxes(fc)\n",
-    "print(_UVJ)"
+    "print(_UVJ)\n",
+    "_UVJ.plot_photometry(show=True)"
    ]
   },
   {
@@ -435,6 +437,37 @@
     "plt.xlabel(\"VJ\")\n",
     "plt.ylabel(\"UV\")\n",
     "plt.colorbar(label=\"$\\mathrm{log_{10}} \\, M_{\\star} \\,/\\, \\mathrm{M_{\\odot}}$\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ad40079",
+   "metadata": {},
+   "source": [
+    "## Collective operations\n",
+    "\n",
+    "It is often useful to collectively do different operations on a `Galaxy`. Synthesizer enables this via some wrapper methods on a galaxy which will operate on it's components to, for instance, get the observed spectra or photometry for all spectra nested in a `Galaxy`. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b93562d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.cosmology import Planck18 as cosmo\n",
+    "\n",
+    "\n",
+    "# Get observed spectra for all spectra\n",
+    "g.get_observed_spectra(cosmo=cosmo)\n",
+    "\n",
+    "# Get UVJ photometry for all spectra\n",
+    "g.get_photo_luminosities(fc)\n",
+    "g.get_photo_fluxes(fc)\n",
+    "\n",
+    "print(\"Stellar luminosities available:\", list(g.stars.photo_luminosities.keys()))\n",
+    "print(\"Stellar fluxes available:\", list(g.stars.photo_fluxes.keys()))"
    ]
   }
  ],

--- a/docs/source/galaxies/galaxy_obj.ipynb
+++ b/docs/source/galaxies/galaxy_obj.ipynb
@@ -83,7 +83,7 @@
     "\n",
     "Now that we have the building blocks of both a particle and parametric galaxy we can import the factory function and get our galaxies. \n",
     "\n",
-    "To do so we simply pass the factory function the arguments for the desired type of `Galaxy`. These are `Stars`, `Gas`, and `BlackHoles` objects from the `particle` and `parametric` packages respectively.\n",
+    "To do so we simply pass the factory function the arguments for the desired type of `Galaxy`. These are `Stars`, `Gas`, and `BlackHoles` objects from the `particle` and `parametric` modules respectively. In Synthesizer these different objects are called \"components\".\n",
     "\n",
     "Note that both a particle and parametric `Galaxy` can be intialised with any combination of `Stars`, `Gas`, or `BlackHoles`. Each is a keyword argument which default to `None`."
    ]

--- a/src/synthesizer/base_galaxy.py
+++ b/src/synthesizer/base_galaxy.py
@@ -182,27 +182,10 @@ class BaseGalaxy:
                 igm=igm,
             )
 
-        # Loop over all stellar spectra
-        for sed in self.stars.spectra.values():
-            # Calculate the observed spectra
-            sed.get_fnu(
-                cosmo=cosmo,
-                z=self.redshift,
-                igm=igm,
-            )
-
-        # Loop over all black hole spectra
-        for sed in self.black_holes.spectra.values():
-            # Calculate the observed spectra
-            sed.get_fnu(
-                cosmo=cosmo,
-                z=self.redshift,
-                igm=igm,
-            )
-
-        # Loop over all stellar particle spectra
-        if getattr(self.stars, "particle_spectra", None) is not None:
-            for sed in self.stars.particle_spectra.values():
+        # Do we have stars?
+        if self.stars is not None:
+            # Loop over all stellar spectra
+            for sed in self.stars.spectra.values():
                 # Calculate the observed spectra
                 sed.get_fnu(
                     cosmo=cosmo,
@@ -210,15 +193,36 @@ class BaseGalaxy:
                     igm=igm,
                 )
 
-        # Loop over all black hole particle spectra
-        if getattr(self.black_holes, "particle_spectra", None) is not None:
-            for sed in self.black_holes.particle_spectra.values():
+            # Loop over all stellar particle spectra
+            if getattr(self.stars, "particle_spectra", None) is not None:
+                for sed in self.stars.particle_spectra.values():
+                    # Calculate the observed spectra
+                    sed.get_fnu(
+                        cosmo=cosmo,
+                        z=self.redshift,
+                        igm=igm,
+                    )
+
+        # Do we have black holes?
+        if self.black_holes is not None:
+            # Loop over all black hole spectra
+            for sed in self.black_holes.spectra.values():
                 # Calculate the observed spectra
                 sed.get_fnu(
                     cosmo=cosmo,
                     z=self.redshift,
                     igm=igm,
                 )
+
+            # Loop over all black hole particle spectra
+            if getattr(self.black_holes, "particle_spectra", None) is not None:
+                for sed in self.black_holes.particle_spectra.values():
+                    # Calculate the observed spectra
+                    sed.get_fnu(
+                        cosmo=cosmo,
+                        z=self.redshift,
+                        igm=igm,
+                    )
 
     def get_spectra_combined(self):
         """

--- a/src/synthesizer/base_galaxy.py
+++ b/src/synthesizer/base_galaxy.py
@@ -45,6 +45,10 @@ class BaseGalaxy:
         # Add some place holder attributes which are overloaded on the children
         self.spectra = {}
 
+        # Initialise the photometry dictionaries
+        self.photo_luminosities = {}
+        self.photo_fluxes = {}
+
         # Attach the components
         self.stars = stars
         self.gas = gas
@@ -142,7 +146,12 @@ class BaseGalaxy:
         - Galaxy.spectra
         - Galaxy.stars.spectra
         - Galaxy.gas.spectra (WIP)
-        - Galaxy.black_holes.spectra (WIP)
+        - Galaxy.black_holes.spectra
+
+        And in the case of particle galaxies
+        - Galaxy.stars.particle_spectra
+        - Galaxy.gas.particle_spectra (WIP)
+        - Galaxy.black_holes.particle_spectra
 
         Args:
             cosmo (astropy.cosmology.Cosmology)
@@ -153,9 +162,10 @@ class BaseGalaxy:
                 Inoue14).
 
         Raises:
+            MissingAttribute
+                If a galaxy has no redshift we can't get the observed spectra.
 
         """
-
         # Ensure we have a redshift
         if self.redshift is None:
             raise exceptions.MissingAttribute(
@@ -181,11 +191,39 @@ class BaseGalaxy:
                 igm=igm,
             )
 
-        # TODO: Once implemented do this for gas and black holes too
+        # Loop over all black hole spectra
+        for sed in self.black_holes.spectra.values():
+            # Calculate the observed spectra
+            sed.get_fnu(
+                cosmo=cosmo,
+                z=self.redshift,
+                igm=igm,
+            )
+
+        # Loop over all stellar particle spectra
+        if getattr(self.stars, "particle_spectra", None) is not None:
+            for sed in self.stars.particle_spectra.values():
+                # Calculate the observed spectra
+                sed.get_fnu(
+                    cosmo=cosmo,
+                    z=self.redshift,
+                    igm=igm,
+                )
+
+        # Loop over all black hole particle spectra
+        if getattr(self.black_holes, "particle_spectra", None) is not None:
+            for sed in self.black_holes.particle_spectra.values():
+                # Calculate the observed spectra
+                sed.get_fnu(
+                    cosmo=cosmo,
+                    z=self.redshift,
+                    igm=igm,
+                )
 
     def get_spectra_combined(self):
         """
-        Combine all common component spectra from components onto the galaxy,
+        Combine all common component spectra from components onto the galaxy.
+
         e.g.:
             intrinsc = stellar_intrinsic + black_hole_intrinsic.
 
@@ -200,7 +238,6 @@ class BaseGalaxy:
 
         Note that this process is only applicable to integrated spectra.
         """
-
         # Get the spectra we have on the components to combine
         spectra = {"total": [], "intrinsic": [], "emergent": []}
         for key in spectra:
@@ -222,6 +259,82 @@ class BaseGalaxy:
         for key, lst in spectra.items():
             if len(lst) > 1:
                 self.spectra[key] = sum(lst)
+
+    def get_photo_luminosities(self, filters, verbose=True):
+        """
+        Calculate luminosity photometry using a FilterCollection object.
+
+        Args:
+            filters (filters.FilterCollection)
+                A FilterCollection object.
+            verbose (bool)
+                Are we talking?
+        """
+        # Get stellar photometry
+        if self.stars is not None:
+            self.stars.get_photo_luminosities(filters, verbose)
+
+            # If we have particle spectra do that too (not applicable to
+            # parametric Galaxy)
+            if getattr(self.stars, "particle_spectra", None) is not None:
+                self.stars.get_particle_photo_luminosities(filters, verbose)
+
+        # Get black hole photometry
+        if self.black_holes is not None:
+            self.black_holes.get_photo_luminosities(filters, verbose)
+
+            # If we have particle spectra do that too (not applicable to
+            # parametric Galaxy)
+            if getattr(self.black_holes, "particle_spectra", None) is not None:
+                self.black_holes.get_particle_photo_luminosities(
+                    filters, verbose
+                )
+
+        # Get the combined photometry
+        for spectra in self.spectra:
+            # Create the photometry collection and store it in the object
+            self.photo_luminosities[spectra] = self.spectra[
+                spectra
+            ].get_photo_luminosities(filters, verbose)
+
+    def get_photo_fluxes(self, filters, verbose=True):
+        """
+        Calculate flux photometry using a FilterCollection object.
+
+        Args:
+            filters (object)
+                A FilterCollection object.
+            verbose (bool)
+                Are we talking?
+
+        Returns:
+            (dict)
+                A dictionary of fluxes in each filter in filters.
+        """
+        # Get stellar photometry
+        if self.stars is not None:
+            self.stars.get_photo_fluxes(filters, verbose)
+
+            # If we have particle spectra do that too (not applicable to
+            # parametric Galaxy)
+            if getattr(self.stars, "particle_spectra", None) is not None:
+                self.stars.get_particle_photo_fluxes(filters, verbose)
+
+        # Get black hole photometry
+        if self.black_holes is not None:
+            self.black_holes.get_photo_fluxes(filters, verbose)
+
+            # If we have particle spectra do that too (not applicable to
+            # parametric Galaxy)
+            if getattr(self.black_holes, "particle_spectra", None) is not None:
+                self.black_holes.get_particle_photo_fluxes(filters, verbose)
+
+        # Get the combined photometry
+        for spectra in self.spectra:
+            # Create the photometry collection and store it in the object
+            self.photo_fluxes[spectra] = self.spectra[
+                spectra
+            ].get_photo_fluxes(filters, verbose)
 
     def plot_spectra(
         self,

--- a/src/synthesizer/components/blackhole.py
+++ b/src/synthesizer/components/blackhole.py
@@ -98,6 +98,10 @@ class BlackholesComponent:
         # Initialise spectra
         self.spectra = {}
 
+        # Intialise the photometry dictionaries
+        self.photo_luminosities = {}
+        self.photo_fluxes = {}
+
         # Save the arguments as attributes
         self.mass = mass
         self.accretion_rate = accretion_rate
@@ -795,6 +799,52 @@ class BlackholesComponent:
             )
 
         return self.spectra
+
+    def get_photo_luminosities(self, filters, verbose=True):
+        """
+        Calculate luminosity photometry using a FilterCollection object.
+
+        Args:
+            filters (filters.FilterCollection)
+                A FilterCollection object.
+            verbose (bool)
+                Are we talking?
+
+        Returns:
+            photo_luminosities (dict)
+                A dictionary of rest frame broadband luminosities.
+        """
+        # Loop over spectra in the component
+        for spectra in self.spectra:
+            # Create the photometry collection and store it in the object
+            self.photo_luminosities[spectra] = self.spectra[
+                spectra
+            ].get_photo_luminosities(filters, verbose)
+
+        return self.photo_luminosities
+
+    def get_photo_fluxes(self, filters, verbose=True):
+        """
+        Calculate flux photometry using a FilterCollection object.
+
+        Args:
+            filters (object)
+                A FilterCollection object.
+            verbose (bool)
+                Are we talking?
+
+        Returns:
+            (dict)
+                A dictionary of fluxes in each filter in filters.
+        """
+        # Loop over spectra in the component
+        for spectra in self.spectra:
+            # Create the photometry collection and store it in the object
+            self.photo_fluxes[spectra] = self.spectra[
+                spectra
+            ].get_photo_fluxes(filters, verbose)
+
+        return self.photo_fluxes
 
     def plot_spectra(
         self,

--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -52,6 +52,10 @@ class StarsComponent:
         # Define the line dictionary to hold the stellar emission lines
         self.lines = {}
 
+        # Define the photometry dictionaries to hold the stellar photometry
+        self.photo_luminosities = {}
+        self.photo_fluxes = {}
+
         # The common stellar attributes between particle and parametric stars
         self.ages = ages
         self.metallicities = metallicities
@@ -809,15 +813,16 @@ class StarsComponent:
                     - self.spectra["emergent"].bolometric_luminosity
                 )
 
-                if hasattr(dust_emission_model, 'template'):
+                if hasattr(dust_emission_model, "template"):
                     print("Using IR template models for dust emission")
                     if dust_emission_model.ldust is None:
                         dust_emission_model.ldust = (
                             dust_bolometric_luminosity.to(Lsun)
                         )
 
-                    self.spectra['dust'] = dust_emission_model.get_spectra(
-                        grid.lam)
+                    self.spectra["dust"] = dust_emission_model.get_spectra(
+                        grid.lam
+                    )
 
                 else:
                     print(
@@ -826,13 +831,14 @@ class StarsComponent:
                     )
                     # Get normalised dust spectrum, this is an synthesizer.sed.
                     # Sed object.
-                    self.spectra['dust'] = dust_emission_model.get_spectra(
-                        grid.lam)
+                    self.spectra["dust"] = dust_emission_model.get_spectra(
+                        grid.lam
+                    )
 
                     # scale the dust spectra by the dust_bolometric_luminosity
-                    self.spectra['dust']._lnu *= (
-                        dust_bolometric_luminosity.value
-                    )
+                    self.spectra[
+                        "dust"
+                    ]._lnu *= dust_bolometric_luminosity.value
 
                 # define total as the sum of emergent and dust
                 self.spectra["total"] = (
@@ -928,9 +934,9 @@ class StarsComponent:
             self.spectra["old_emergent"].measure_bolometric_luminosity()
 
             if dust_emission_model is not None:
-                if (not isinstance(dust_emission_model, list)) \
-                        and (not hasattr(dust_emission_model, 'template')):
-
+                if (not isinstance(dust_emission_model, list)) and (
+                    not hasattr(dust_emission_model, "template")
+                ):
                     print(
                         (
                             "Separate dust emission model for diffuse and "
@@ -949,15 +955,17 @@ class StarsComponent:
                     - self.spectra["young_attenuated_BC"].bolometric_luminosity
                 )
 
-                if hasattr(dust_emission_model, 'template'):
+                if hasattr(dust_emission_model, "template"):
                     ldust = dust_bolometric_luminosity.to(Lsun)
                 else:
-                    self.spectra['young_dust_BC'] = (
-                        dust_emission_model[1].get_spectra(grid.lam))
+                    self.spectra["young_dust_BC"] = dust_emission_model[
+                        1
+                    ].get_spectra(grid.lam)
 
                     # Scale the dust spectra by the dust_bolometric_luminosity.
-                    self.spectra['young_dust_BC']._lnu *= (
-                        dust_bolometric_luminosity.value)
+                    self.spectra[
+                        "young_dust_BC"
+                    ]._lnu *= dust_bolometric_luminosity.value
 
                 # ISM dust heated by young stars. This is the difference
                 # between the birth cloud and ISM attenuated spectra.
@@ -966,18 +974,20 @@ class StarsComponent:
                     - self.spectra["young_attenuated"].bolometric_luminosity
                 )
 
-                if hasattr(dust_emission_model, 'template'):
+                if hasattr(dust_emission_model, "template"):
                     ldust += dust_bolometric_luminosity.to(Lsun)
                 else:
-                    self.spectra['young_dust_ISM'] = (
-                        dust_emission_model[0].get_spectra(grid.lam))
+                    self.spectra["young_dust_ISM"] = dust_emission_model[
+                        0
+                    ].get_spectra(grid.lam)
 
                     # Scale the dust spectra by the dust_bolometric_luminosity.
-                    self.spectra['young_dust_ISM']._lnu *= (
-                        dust_bolometric_luminosity.value)
+                    self.spectra[
+                        "young_dust_ISM"
+                    ]._lnu *= dust_bolometric_luminosity.value
 
                     # Combine both dust components for young stars
-                    self.spectra['young_dust'] = (
+                    self.spectra["young_dust"] = (
                         self.spectra["young_dust_BC"]
                         + self.spectra["young_dust_ISM"]
                     )
@@ -988,43 +998,47 @@ class StarsComponent:
                     - self.spectra["old_attenuated"].bolometric_luminosity
                 )
 
-                if hasattr(dust_emission_model, 'template'):
+                if hasattr(dust_emission_model, "template"):
                     ldust += dust_bolometric_luminosity.to(Lsun)
                     dust_emission_model.ldust = ldust
 
                     # making dust components from IR templates
                     # Better classified as diffuse dust and
                     # pdr dust
-                    self.spectra['old_dust'], self.spectra['young_dust'] = (
-                        dust_emission_model.get_spectra(grid.lam,
-                                                        dust_components=True)
+                    (
+                        self.spectra["old_dust"],
+                        self.spectra["young_dust"],
+                    ) = dust_emission_model.get_spectra(
+                        grid.lam, dust_components=True
                     )
 
                 else:
-                    self.spectra['old_dust'] = (
-                        dust_emission_model[0].get_spectra(grid.lam))
+                    self.spectra["old_dust"] = dust_emission_model[
+                        0
+                    ].get_spectra(grid.lam)
 
                     # Scale the dust spectra by the dust_bolometric_luminosity.
-                    self.spectra['old_dust']._lnu *= (
-                        dust_bolometric_luminosity.value)
+                    self.spectra[
+                        "old_dust"
+                    ]._lnu *= dust_bolometric_luminosity.value
 
                 # Combine both dust components for young stars
-                self.spectra['young_total'] = (
-                    self.spectra['young_emergent']
-                    + self.spectra['young_dust']
+                self.spectra["young_total"] = (
+                    self.spectra["young_emergent"] + self.spectra["young_dust"]
                 )
 
                 # Combine both dust components for young stars
-                self.spectra['old_total'] = (
-                    self.spectra['old_emergent']
-                    + self.spectra['old_dust']
+                self.spectra["old_total"] = (
+                    self.spectra["old_emergent"] + self.spectra["old_dust"]
                 )
 
-                self.spectra['dust'] = (self.spectra['young_dust']
-                                        + self.spectra['old_dust'])
+                self.spectra["dust"] = (
+                    self.spectra["young_dust"] + self.spectra["old_dust"]
+                )
 
-                self.spectra['total'] = (self.spectra['young_total']
-                                         + self.spectra['old_total'])
+                self.spectra["total"] = (
+                    self.spectra["young_total"] + self.spectra["old_total"]
+                )
 
         # Return total spectra if a dust_emission_model is provided, otherwise
         # return the emergent spectra.
@@ -1305,6 +1319,52 @@ class StarsComponent:
                 )
 
         return young, old
+
+    def get_photo_luminosities(self, filters, verbose=True):
+        """
+        Calculate luminosity photometry using a FilterCollection object.
+
+        Args:
+            filters (filters.FilterCollection)
+                A FilterCollection object.
+            verbose (bool)
+                Are we talking?
+
+        Returns:
+            photo_luminosities (dict)
+                A dictionary of rest frame broadband luminosities.
+        """
+        # Loop over spectra in the component
+        for spectra in self.spectra:
+            # Create the photometry collection and store it in the object
+            self.photo_luminosities[spectra] = self.spectra[
+                spectra
+            ].get_photo_luminosities(filters, verbose)
+
+        return self.photo_luminosities
+
+    def get_photo_fluxes(self, filters, verbose=True):
+        """
+        Calculate flux photometry using a FilterCollection object.
+
+        Args:
+            filters (object)
+                A FilterCollection object.
+            verbose (bool)
+                Are we talking?
+
+        Returns:
+            (dict)
+                A dictionary of fluxes in each filter in filters.
+        """
+        # Loop over spectra in the component
+        for spectra in self.spectra:
+            # Create the photometry collection and store it in the object
+            self.photo_fluxes[spectra] = self.spectra[
+                spectra
+            ].get_photo_fluxes(filters, verbose)
+
+        return self.photo_fluxes
 
     def plot_spectra(
         self,

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -67,12 +67,15 @@ class Particles:
             nparticle : int
                 How many particles are there?
         """
-
         # Check arguments are valid
 
         # Set phase space coordinates
         self.coordinates = coordinates
         self.velocities = velocities
+
+        # Initialise the particle photometry dictionaries
+        self.particle_photo_luminosities = {}
+        self.particle_photo_fluxes = {}
 
         # Set unit information
 
@@ -163,6 +166,52 @@ class Particles:
             "https://github.com/flaresimulations/synthesizer/blob/main/"
             "docs/CONTRIBUTING.md"
         )
+
+    def get_particle_photo_luminosities(self, filters, verbose=True):
+        """
+        Calculate luminosity photometry using a FilterCollection object.
+
+        Args:
+            filters (filters.FilterCollection)
+                A FilterCollection object.
+            verbose (bool)
+                Are we talking?
+
+        Returns:
+            photo_luminosities (dict)
+                A dictionary of rest frame broadband luminosities.
+        """
+        # Loop over spectra in the component
+        for spectra in self.particle_spectra:
+            # Create the photometry collection and store it in the object
+            self.particle_photo_luminosities[spectra] = self.particle_spectra[
+                spectra
+            ].get_photo_luminosities(filters, verbose)
+
+        return self.particle_photo_luminosities
+
+    def get_particle_photo_fluxes(self, filters, verbose=True):
+        """
+        Calculate flux photometry using a FilterCollection object.
+
+        Args:
+            filters (object)
+                A FilterCollection object.
+            verbose (bool)
+                Are we talking?
+
+        Returns:
+            (dict)
+                A dictionary of fluxes in each filter in filters.
+        """
+        # Loop over spectra in the component
+        for spectra in self.particle_spectra:
+            # Create the photometry collection and store it in the object
+            self.particle_photo_fluxes[spectra] = self.particle_spectra[
+                spectra
+            ].get_photo_fluxes(filters, verbose)
+
+        return self.particle_photo_fluxes
 
 
 class CoordinateGenerator:


### PR DESCRIPTION
This PR introduces wrappers on a `Galaxy` and components for getting photometry. These methods take a filter collection and compute the photometry for all spectra nested within a galaxy. This includes particle spectra if they exist. 

This has been demonstrated in the cosmo_example docs. 

This also implements improvement on `get_observed_spectra` which hadn't been updated to include black holes and didn't have protections for when a component was `None`.

Closes #515 

Requires #519 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
