### PR TITLE
Fix photometry units and intialisation

### DIFF
--- a/src/synthesizer/photometry.py
+++ b/src/synthesizer/photometry.py
@@ -330,12 +330,12 @@ class PhotometryCollection:
         x_units = (
             x_units.replace("/", r"\ / \ ")
             .replace("**", "^")
-            .replace("*", "\ ")
+            .replace("*", r"\ ")
         )
         y_units = (
             y_units.replace("/", r"\ / \ ")
             .replace("**", "^")
-            .replace("*", "\ ")
+            .replace("*", r"\ ")
         )
 
         # Label the x axis

--- a/src/synthesizer/photometry.py
+++ b/src/synthesizer/photometry.py
@@ -8,7 +8,6 @@ return an instance of this class.
 """
 import numpy as np
 import matplotlib.pyplot as plt
-from unyt import unyt_array, W, m
 
 from synthesizer.units import Quantity, default_units
 

--- a/src/synthesizer/photometry.py
+++ b/src/synthesizer/photometry.py
@@ -68,7 +68,6 @@ class PhotometryCollection:
 
         # Get the photometry
         photometry = list(kwargs.values())
-        print(photometry, photometry[0].units.dimensions)
 
         # Get the dimensions of a flux for testing
         flux_dimensions = default_units["photo_fluxes"].units.dimensions

--- a/src/synthesizer/photometry.py
+++ b/src/synthesizer/photometry.py
@@ -327,8 +327,17 @@ class PhotometryCollection:
         # Parse the units for the labels and make them pretty
         x_units = str(self.filters[self.filter_codes[0]].lam.units)
         y_units = str(photometry.units)
-        x_units = x_units.replace("/", r"\ / \ ").replace("*", " ")
-        y_units = y_units.replace("/", r"\ / \ ").replace("*", " ")
+        print(y_units)
+        x_units = (
+            x_units.replace("/", r"\ / \ ")
+            .replace("**", "^")
+            .replace("*", "\ ")
+        )
+        y_units = (
+            y_units.replace("/", r"\ / \ ")
+            .replace("**", "^")
+            .replace("*", "\ ")
+        )
 
         # Label the x axis
         if self.photo_luminosities is not None:

--- a/src/synthesizer/photometry.py
+++ b/src/synthesizer/photometry.py
@@ -8,8 +8,9 @@ return an instance of this class.
 """
 import numpy as np
 import matplotlib.pyplot as plt
+from unyt import unyt_array, W, m
 
-from synthesizer.units import Quantity
+from synthesizer.units import Quantity, default_units
 
 
 class PhotometryCollection:
@@ -33,16 +34,13 @@ class PhotometryCollection:
         _look_up (dict):
             A dictionary for easy access to photometry values using
             filter codes.
-        rest_frame (bool):
-            A flag indicating whether the photometry is in the rest frame
-            (True) or observer frame (False).
     """
 
     # Define quantities (there has to be one for rest and observer frame)
     photo_luminosities = Quantity()
     photo_fluxes = Quantity()
 
-    def __init__(self, filters, rest_frame, **kwargs):
+    def __init__(self, filters, **kwargs):
         """
         Instantiate the photometry collection.
 
@@ -52,14 +50,10 @@ class PhotometryCollection:
         Args:
             filters (FilterCollection)
                 The FilterCollection used to produce the photometry.
-            rest_frame (bool)
-                A flag for whether the photometry is rest frame luminosity or
-                observer frame flux.
             kwargs (dict)
                 A dictionary of keyword arguments containing all the photometry
                 of the form {"filter_code": photometry}.
         """
-
         # Store the filter collection
         self.filters = filters
 
@@ -67,18 +61,21 @@ class PhotometryCollection:
         self.filter_codes = list(kwargs.keys())
 
         # Get the photometry
-        photometry = np.array(list(kwargs.values()))
+        photometry = list(kwargs.values())
+        print(photometry, photometry[0].units.dimensions)
 
-        # Put the photometry in the right place (we need to draw a distinction
-        # between rest and observer frame for units)
-        if rest_frame:
-            self.photo_luminosities = photometry
-            self.photo_fluxes = None
-            self.photometry = self.photo_luminosities
-        else:
+        # Get the dimensions of a flux for testing
+        flux_dimensions = default_units["photo_fluxes"].units.dimensions
+
+        # Check if the photometry is flux or luminosity
+        if photometry[0].units.dimensions == flux_dimensions:
             self.photo_fluxes = photometry
             self.photo_luminosities = None
             self.photometry = self.photo_fluxes
+        else:
+            self.photo_luminosities = photometry
+            self.photo_fluxes = None
+            self.photometry = self.photo_luminosities
 
         # Construct a dict for the look up, importantly we here store
         # the values in photometry not _photometry meaning they have units.
@@ -90,12 +87,10 @@ class PhotometryCollection:
             )
         }
 
-        # Store the rest frame flag for convinience
-        self.rest_frame = rest_frame
-
     def __getitem__(self, filter_code):
         """
-        Enable dictionary key look up syntax to extract specific photometry,
+        Enable dictionary key look up syntax to extract specific photometry.
+
         e.g. Sed.photo_luminosities["JWST/NIRCam.F150W"].
 
         NOTE: this will always return photometry with units. Unitless
@@ -108,31 +103,47 @@ class PhotometryCollection:
             filter_code (str)
                 The filter code of the desired photometry.
         """
-
         # Perform the look up
         return self._look_up[filter_code]
 
     def keys(self):
         """
         Enable dict.keys() behaviour.
+
+        Returns:
+            list
+                A list of filter codes.
         """
         return self._look_up.keys()
 
     def values(self):
         """
         Enable dict.values() behaviour.
+
+        Returns:
+            dict_values
+                A dict_values object containing the photometry.
         """
         return self._look_up.values()
 
     def items(self):
         """
-        Enables dict.items() behaviour.
+        Enable dict.items() behaviour.
+
+        Returns:
+            dict_items
+                A dict_items object containing the filter codes and
+                photometry.
         """
         return self._look_up.items()
 
     def __iter__(self):
         """
         Enable dict iter behaviour.
+
+        Returns:
+            iter
+                An iterator over the filter codes and photometry.
         """
         return iter(self._look_up.items())
 
@@ -143,7 +154,6 @@ class PhotometryCollection:
         Returns:
             str: A formatted string representation of the PhotometryCollection.
         """
-
         # Define the filter code column
         filters_col = [
             (
@@ -174,10 +184,10 @@ class PhotometryCollection:
         table = f"-{sep.replace('|', '-')}-\n"
 
         # Create the centered title
-        if self.rest_frame:
-            title = f"|{'REST FRAME PHOTOMETRY'.center(tot_width)}|"
+        if self.photo_luminosities is not None:
+            title = f"|{'PHOTOMETRY (LUMINOSITY)'.center(tot_width)}|"
         else:
-            title = f"|{'OBSERVED PHOTOMETRY'.center(tot_width)}|"
+            title = f"|{'PHOTOMETRY (FLUX)'.center(tot_width)}|"
         table += f"{title}\n|{sep}|\n"
 
         # Combine everything into the final table
@@ -260,9 +270,7 @@ class PhotometryCollection:
                 max_t = np.max(f.t)
 
         # Get the photometry
-        photometry = (
-            self.photo_luminosities if self.rest_frame else self.obs_photometry
-        )
+        photometry = self.photometry
 
         # Plot the photometry
         for f, phot in zip(self.filters, photometry.value):
@@ -323,7 +331,7 @@ class PhotometryCollection:
         y_units = y_units.replace("/", r"\ / \ ").replace("*", " ")
 
         # Label the x axis
-        if self.rest_frame:
+        if self.photo_luminosities is not None:
             ax.set_xlabel(r"$\lambda/[\mathrm{" + x_units + r"}]$")
         else:
             ax.set_xlabel(
@@ -331,7 +339,7 @@ class PhotometryCollection:
             )
 
         # Label the y axis handling all possibilities
-        if self.rest_frame:
+        if self.photo_luminosities is not None:
             ax.set_ylabel(r"$L/[\mathrm{" + y_units + r"}]$")
         else:
             ax.set_ylabel(r"$F/[\mathrm{" + y_units + r"}]$")

--- a/src/synthesizer/photometry.py
+++ b/src/synthesizer/photometry.py
@@ -14,13 +14,17 @@ from synthesizer.units import Quantity, default_units
 
 class PhotometryCollection:
     """
-    Represents a collection of photometry values and provides unit
+    A container for photometry data.
+
+    This represents a collection of photometry values and provides unit
     association and plotting functionality.
 
-    This is a utility class returned by functions else where. Although not
+    This is a utility class returned by functions elsewhere. Although not
     an issue if it is this should never really be directly instantiated.
 
     Attributes:
+        photometry (Quantity):
+            Quantity instance representing photometry data.
         photo_luminosities (Quantity):
             Quantity instance representing photometry data in the rest frame.
         photo_fluxes (Quantity):
@@ -45,6 +49,9 @@ class PhotometryCollection:
 
         To enable quantities a PhotometryCollection will store the data
         as arrays but enable access via dictionary syntax.
+
+        Whether the photometry is flux or luminosity is determined by the
+        units of the photometry passed.
 
         Args:
             filters (FilterCollection)

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -948,11 +948,11 @@ class Sed:
             # Apply the filter transmission curve and store the resulting
             # luminosity
             bb_lum = f.apply_filter(self._lnu, nu=self._nu)
-            photo_luminosities[f.filter_code] = bb_lum
+            photo_luminosities[f.filter_code] = bb_lum * self.lnu.units
 
         # Create the photometry collection and store it in the object
         self.photo_luminosities = PhotometryCollection(
-            filters, rest_frame=True, **photo_luminosities
+            filters, **photo_luminosities
         )
 
         return self.photo_luminosities
@@ -1000,12 +1000,10 @@ class Sed:
 
             # Calculate and store the broadband flux in this filter
             bb_flux = f.apply_filter(self._fnu, nu=self._obsnu)
-            photo_fluxes[f.filter_code] = bb_flux
+            photo_fluxes[f.filter_code] = bb_flux * self.fnu.units
 
         # Create the photometry collection and store it in the object
-        self.photo_fluxes = PhotometryCollection(
-            filters, rest_frame=False, **photo_fluxes
-        )
+        self.photo_fluxes = PhotometryCollection(filters, **photo_fluxes)
 
         return self.photo_fluxes
 

--- a/src/synthesizer/units.py
+++ b/src/synthesizer/units.py
@@ -90,8 +90,8 @@ default_units = {
     "fov": Mpc,
     "orig_resolution": Mpc,
     "centre": Mpc,
-    "photo_luminosities": erg / s,
-    "photo_fluxes": erg / s / cm**2,
+    "photo_luminosities": erg / s / Hz,
+    "photo_fluxes": erg / s / cm**2 / Hz,
 }
 
 
@@ -312,8 +312,8 @@ class Units(metaclass=UnitSingleton):
         self.flux = erg / s / cm**2  # rest frame "flux" at 10 pc
 
         # Photometry
-        self.photo_luminosities = erg / s  # rest frame photometry
-        self.photo_fluxes = erg / s / cm**2  # observer frame photometry
+        self.photo_luminosities = erg / s / Hz  # rest frame photometry
+        self.photo_fluxes = erg / s / cm**2 / Hz  # observer frame photometry
 
         # Equivalent width
         self.ew = Angstrom


### PR DESCRIPTION
Fixes a bug where photometry was not stored in spectral flux/luminosity density units, leading to issues with downstream tasks and removes the `rest_frame` flag when instantiating a `PhotometryCollection`.

- Photometry is now in spectral flux/luminosity density units.
- Whether a flux or luminosity has been passed is automatically detected.
- All rest frame vs observer frame nomenclature has been removed.
- Small fix applied to unit formatting on plot axes.
- `Sed.get_fnu` associates the `fnu` or `lnu` units to the photometry after calling `apply_filter`. This was returning `dimensionless` quantities. Which is fine when the units system isn't modified but would have led to conversion issues if the system had been modified to use differing units for photometry and spectra.

While the `PhotometryCollection` isn't explicitly documented anywhere it is demonstrated in multiple places that photometry are grabbed in examples and docs.

Closes #508 

## Issue Type
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
