### PR TITLE
Fixed powers and whitespace in spectra labels

### DIFF
--- a/src/synthesizer/photometry.py
+++ b/src/synthesizer/photometry.py
@@ -6,6 +6,7 @@ internal methods that calculate photometry
 (e.g. Sed.get_photo_luminosities)
 return an instance of this class.
 """
+import re
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -317,10 +318,14 @@ class PhotometryCollection:
         filter_ax.set_xlim(*ax.get_xlim())
 
         # Parse the units for the labels and make them pretty
-        x_units = str(self.filters[self.filter_codes[0]].lam.units)
-        y_units = str(photometry.units)
-        x_units = x_units.replace("/", r"\ / \ ").replace("*", " ")
-        y_units = y_units.replace("/", r"\ / \ ").replace("*", " ")
+        x_units = self.filters[self.filter_codes[0]].lam.units.latex_repr
+        y_units = photometry.units.latex_repr
+
+        # Replace any \frac with a \ division
+        pattern = r"\{(.*?)\}\{(.*?)\}"
+        replacement = r"\1 \ / \ \2"
+        x_units = re.sub(pattern, replacement, x_units).replace(r"\frac", "")
+        y_units = re.sub(pattern, replacement, y_units).replace(r"\frac", "")
 
         # Label the x axis
         if self.rest_frame:

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -1490,8 +1490,12 @@ def plot_spectra(
         y_units = str(plt_spectra.units)
     else:
         y_units = str(y_units)
-    x_units = x_units.replace("/", r"\ / \ ").replace("*", " ")
-    y_units = y_units.replace("/", r"\ / \ ").replace("*", " ")
+    x_units = (
+        x_units.replace("/", r"\ / \ ").replace("**", r"^").replace("*", r"\ ")
+    )
+    y_units = (
+        y_units.replace("/", r"\ / \ ").replace("**", r"^").replace("*", r"\ ")
+    )
 
     # Label the x axis
     if rest_frame:

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -12,6 +12,7 @@ Example usage:
     sed.apply_attenutation(tau_v=0.7)
     sed.get_photo_fluxes(filters)
 """
+import re
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.interpolate import interp1d
@@ -1483,19 +1484,19 @@ def plot_spectra(
 
     # Parse the units for the labels and make them pretty
     if x_units is None:
-        x_units = str(lam.units)
+        x_units = lam.units.latex_repr
     else:
         x_units = str(x_units)
     if y_units is None:
-        y_units = str(plt_spectra.units)
+        y_units = plt_spectra.units.latex_repr
     else:
         y_units = str(y_units)
-    x_units = (
-        x_units.replace("/", r"\ / \ ").replace("**", r"^").replace("*", r"\ ")
-    )
-    y_units = (
-        y_units.replace("/", r"\ / \ ").replace("**", r"^").replace("*", r"\ ")
-    )
+
+    # Replace any \frac with a \ division
+    pattern = r"\{(.*?)\}\{(.*?)\}"
+    replacement = r"\1 \ / \ \2"
+    x_units = re.sub(pattern, replacement, x_units).replace(r"\frac", "")
+    y_units = re.sub(pattern, replacement, y_units).replace(r"\frac", "")
 
     # Label the x axis
     if rest_frame:


### PR DESCRIPTION
DWISOTT: automatic parsing of `unyt` units into an axis label was missing whitespace and a handler for powers.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
