### PR TITLE
Handling z=0 in get_fnu

### DIFF
--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -879,8 +879,8 @@ class Sed:
         Calculate the observed frame spectral energy distribution.
 
         NOTE: if a redshift of 0 is passed the flux return will be calculated
-        assuming a distance of 10 pc. This can include an igm contribution
-        if a model has been passed.
+        assuming a distance of 10 pc omitting IGM since at this distance
+        IGM contribution makes no sense.
 
         Args:
             cosmo (astropy.cosmology)
@@ -902,14 +902,7 @@ class Sed:
         # If we have a redshift of 0 then the below will break since the
         # distance will be 0. Instead call get_fnu0 to get the flux at 10 pc
         if self.redshift == 0:
-            # Call the redshift 0 version (note this will assume flux at 10 pc)
-            self.get_fnu0()
-
-            # If we are applying an IGM model apply it
-            if igm:
-                self._fnu *= igm().T(z, self._obslam)
-
-            return self.fnu
+            return self.get_fnu0()
 
         # Get the observed wavelength and frequency arrays
         self.obslam = self._lam * (1.0 + z)

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -878,6 +878,10 @@ class Sed:
         """
         Calculate the observed frame spectral energy distribution.
 
+        NOTE: if a redshift of 0 is passed the flux return will be calculated
+        assuming a distance of 10 pc. This can include an igm contribution
+        if a model has been passed.
+
         Args:
             cosmo (astropy.cosmology)
                 astropy cosmology instance.
@@ -894,6 +898,18 @@ class Sed:
 
         # Store the redshift for later use
         self.redshift = z
+
+        # If we have a redshift of 0 then the below will break since the
+        # distance will be 0. Instead call get_fnu0 to get the flux at 10 pc
+        if self.redshift == 0:
+            # Call the redshift 0 version (note this will assume flux at 10 pc)
+            self.get_fnu0()
+
+            # If we are applying an IGM model apply it
+            if igm:
+                self._fnu *= igm().T(z, self._obslam)
+
+            return self.fnu
 
         # Get the observed wavelength and frequency arrays
         self.obslam = self._lam * (1.0 + z)


### PR DESCRIPTION
Now `get_fnu` will call automatically `get_fnu0` if a redshift of 0 is passed. This avoids infinities in the distance modulus. Note that this will ignore any explicitly stated IGM since it makes no sense at a distance of 10 pc. We could alternatively allow the user to provide a distance at which to calculate flux instead... but that feel arbitrary and over complex. This is simply to handle the case when a user should have called `get_fnu0` instead of `get_fnu` (a mistake I have personally made).

Closes #525.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
