### PR TITLE
Fixed agn masking in `_prepare_sed_args`

### DIFF
--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -310,9 +310,9 @@ class BlackHoles(Particles, BlackholesComponent):
         # as many values as particles
         for ind, prop in enumerate(props):
             if isinstance(prop, float):
-                props[ind] = np.full(npart, prop)
+                props[ind] = np.full(self.nbh, prop)
             elif prop.size == 1:
-                props[ind] = np.full(npart, prop)
+                props[ind] = np.full(self.nbh, prop)
 
         # Apply the mask to each property and make contiguous
         props = [

--- a/src/synthesizer/utils.py
+++ b/src/synthesizer/utils.py
@@ -122,9 +122,7 @@ def value_to_array(value):
     # Just return it if we have been handed an array already or None
     # NOTE: unyt_arrays and quantities are by definition arrays and thus
     # return True for the isinstance below.
-    if (
-        isinstance(value, (np.ndarray, unyt_array)) and value.size > 1
-    ) or value is None:
+    if (isinstance(value, np.ndarray) and value.size > 1) or value is None:
         return value
 
     if isinstance(value, float):
@@ -134,7 +132,7 @@ def value_to_array(value):
             ]
         )
 
-    elif isinstance(value, unyt_quantity):
+    elif isinstance(value, (unyt_quantity, unyt_array)):
         arr = (
             np.array(
                 [

--- a/src/synthesizer/utils.py
+++ b/src/synthesizer/utils.py
@@ -122,7 +122,9 @@ def value_to_array(value):
     # Just return it if we have been handed an array already or None
     # NOTE: unyt_arrays and quantities are by definition arrays and thus
     # return True for the isinstance below.
-    if (isinstance(value, np.ndarray) and value.size > 1) or value is None:
+    if (
+        isinstance(value, np.ndarray, unyt_array) and value.size > 1
+    ) or value is None:
         return value
 
     if isinstance(value, float):

--- a/src/synthesizer/utils.py
+++ b/src/synthesizer/utils.py
@@ -123,7 +123,7 @@ def value_to_array(value):
     # NOTE: unyt_arrays and quantities are by definition arrays and thus
     # return True for the isinstance below.
     if (
-        isinstance(value, np.ndarray, unyt_array) and value.size > 1
+        isinstance(value, (np.ndarray, unyt_array)) and value.size > 1
     ) or value is None:
         return value
 


### PR DESCRIPTION
I have no idea how this has slipped through the cracks for so long but the expansion of floats into particle arrays for particle spectra used the number of BH derived from the mask rather than the number of BH in a `BlackHoles` object. This meant the mask was the wrong shape when applied.

There was also an issue when a single particle was passed to a black hole object with units and it passed through the `value_to_array` logic without being captured correctly and triggered an error.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
