### PR TITLE
fix normalisation of SFH and ZH distributions derived from SFZH

### DIFF
--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -11,6 +11,7 @@ Example usage:
     stars.get_spectra_incident(grid)
     stars.plot_spectra()
 """
+
 import numpy as np
 from scipy import integrate
 from unyt import unyt_quantity, unyt_array
@@ -321,6 +322,12 @@ class Stars(StarsComponent):
                 self.sf_hist[ia] = sf
                 min_age = max_age
 
+            # Normalise SFH array
+            self.sf_hist /= np.sum(self.sf_hist)
+
+            # Multiply by initial stellar mass
+            self.sf_hist *= self._initial_mass
+
         # Calculate SFH from function if necessary
         if self.metal_dist_func is not None and self.metal_dist is None:
             # Set up SFH array
@@ -341,6 +348,12 @@ class Stars(StarsComponent):
                 )[0]
                 self.metal_dist[imetal] = sf
                 min_metal = max_metal
+
+            # Normalise ZH array
+            self.metal_dist /= np.sum(self.metal_dist)
+
+            # Multiply by initial stellar mass
+            self.metal_dist *= self._initial_mass
 
         # Ensure that by this point we have an array for SFH and ZH
         if self.sf_hist is None or self.metal_dist is None:


### PR DESCRIPTION
Previously, on a parametric Stars object, when a parametric SFH and ZH were provided they were used to build a SFZH, `stars.sfzh`, which was then normalised by the `initial_mass` provided. Unfortunately, the `sf_hist` and `metal_dist` derived from this SFZH were not normalised. This PR fixes that omission.

## Issue Type
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
