### PR TITLE
Parametric young pops

### DIFF
--- a/examples/cosmo/test_parametric_young_stars.py
+++ b/examples/cosmo/test_parametric_young_stars.py
@@ -1,0 +1,162 @@
+"""
+Test the effect on the intrinsic emission of assuming a
+parametric SFH for young star particles.
+
+This is now implemented within call to `generate_lnu` 
+on a parametric stars object.
+"""
+
+import numpy as np
+from unyt import Myr
+import matplotlib.pyplot as plt
+
+from synthesizer.load_data.load_camels import load_CAMELS_IllustrisTNG
+from synthesizer.grid import Grid
+from synthesizer.parametric import SFH, ZDist, Stars
+from synthesizer.parametric.galaxy import Galaxy
+
+
+grid_dir = "../../tests/test_grid"
+grid_name = "test_grid"
+grid = Grid(grid_name, grid_dir=grid_dir)
+
+gals = load_CAMELS_IllustrisTNG(
+    "../../tests/data/",
+    snap_name="camels_snap.hdf5",
+    fof_name="camels_subhalo.hdf5",
+    fof_dir="../../tests/data/",
+)
+
+# Select a single galaxy
+gal = gals[1]
+
+# Age limit at which we replace star particles
+age_lim = 500 * Myr
+
+"""
+We first demonstrate the process *manually*.
+This also allows us to obtain the SFH of each parametric
+model for plotting purposes.
+"""
+# First, filter for star particles
+pmask = gal.stars.ages < age_lim
+
+stars = []
+# Loop through each young star particle
+for _pmask in np.where(pmask)[0]:
+    # Parametric SFH parameters
+    sfh_p = {"duration": age_lim}
+    Z_p = {"metallicity": gal.stars.metallicities[_pmask]}
+    stellar_mass = gal.stars.initial_masses[_pmask]
+
+    # Initialise SFH and ZH objects
+    sfh = SFH.Constant(**sfh_p)
+    metal_dist = ZDist.DeltaConstant(**Z_p)  # constant metallicity
+
+    # Create a parametric stars object
+    stars.append(
+        Stars(
+            grid.log10age,
+            grid.metallicity,
+            sf_hist=sfh,
+            metal_dist=metal_dist,
+            initial_mass=stellar_mass,
+        )
+    )
+
+# Sum each individual Stars object
+stars = sum(stars[1:], stars[0])
+
+# Create a parametric galaxy
+para_gal = Galaxy(stars)
+
+para_spec = para_gal.stars.get_spectra_incident(grid)
+part_spec_old = gal.stars.get_spectra_incident(grid=grid, old=age_lim)
+part_spec = gal.stars.get_spectra_incident(grid=grid)
+
+"""
+We can also do this directly from call to `generate_lnu`,
+as well as any downstream `get_spectra_*` methods.
+This shows an example on `get_spectra_incident`, supplying
+the optional `parametric_young_stars` keyword argument.
+"""
+
+combined_spec = gal.stars.get_spectra_incident(
+    grid=grid, parametric_young_stars=age_lim
+)
+
+assert (combined_spec.lnu == (part_spec_old.lnu + para_spec.lnu)).all()
+
+"""
+Plot intrinsic emission from pure particle, parametric
+and parametric + particle models
+"""
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 5))
+
+ax1.loglog(para_spec.lam, para_spec.lnu, label="Parametric young", color="C0")
+ax1.loglog(
+    part_spec_old.lam, part_spec_old.lnu, label="Particle old", color="C3"
+)
+ax1.loglog(
+    part_spec.lam,
+    part_spec.lnu,
+    label="Particle all",
+    color="C1",
+    linestyle="dashed",
+)
+ax1.loglog(
+    part_spec.lam,
+    part_spec_old.lnu + para_spec.lnu,
+    label="Para + Part",
+    color="C2",
+)
+ax1.set_ylim(1e20, 1e30)
+ax1.set_xlim(1e2, 2e4)
+ax1.legend()
+ax1.set_xlabel("$\lambda \,/\, \AA$")
+ax1.set_ylabel("$L_{\lambda} / \mathrm{erg / Hz / s}$")
+
+"""
+Plot SFH from particles and parametric
+"""
+binLimits = np.linspace(5, 10, 30)
+
+ax2.hist(
+    np.log10(np.hstack([gal.stars.ages[~pmask].value, stars.ages.value])),
+    histtype="step",
+    weights=np.hstack([gal.stars.initial_masses[~pmask].value, stars.sf_hist]),
+    bins=binLimits,
+    log=True,
+    label="Particle + Parametric",
+    color="C2",
+    linewidth=3,
+)
+ax2.hist(
+    np.log10(gal.stars.ages),
+    histtype="step",
+    weights=gal.stars.initial_masses.value,
+    bins=binLimits,
+    log=True,
+    label="All Particles",
+    color="C1",
+    linestyle="dashed",
+    linewidth=3,
+)
+ax2.hist(
+    np.log10(stars.ages.value),
+    histtype="step",
+    weights=stars.sf_hist,
+    bins=binLimits,
+    log=True,
+    label="Young Parametric",
+    color="C0",
+    linewidth=3,
+    linestyle="dashed",
+)
+ax2.legend()
+# plt.show()
+ax2.set_xlabel("$\mathrm{\log_{10} Age \,/\, yr}$")
+ax2.set_ylabel("$\mathrm{log_{10} (Mass \,/\, M_{\odot})}$")
+
+plt.show()
+# plt.savefig("young_star_parametric.png", dpi=200, bbox_inches="tight")

--- a/src/synthesizer/parametric/galaxy.py
+++ b/src/synthesizer/parametric/galaxy.py
@@ -1,16 +1,15 @@
 """
 """
+
 import numpy as np
 
 from synthesizer.base_galaxy import BaseGalaxy
 from synthesizer import exceptions
 from synthesizer.imaging import ImageCollection, SpectralCube
 from synthesizer.art import Art, get_centred_art
-from synthesizer.particle import Stars as ParticleStars
 
 
 class Galaxy(BaseGalaxy):
-
     """A class defining parametric galaxy objects"""
 
     def __init__(
@@ -35,13 +34,6 @@ class Galaxy(BaseGalaxy):
         Raises:
             InconsistentArguments
         """
-
-        # Check we haven't been given Stars
-        if isinstance(stars, ParticleStars):
-            raise exceptions.InconsistentArguments(
-                "Stars passed instead of SFZH object (Stars)."
-                " Did you mean synthesizer.particle.Galaxy instead?"
-            )
 
         # Set the type of galaxy
         self.galaxy_type = "Parametric"

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -11,6 +11,7 @@ Example usage:
     stars.get_spectra_incident(grid)
     stars.plot_spectra()
 """
+
 import numpy as np
 from scipy import integrate
 from unyt import unyt_quantity, unyt_array
@@ -321,6 +322,12 @@ class Stars(StarsComponent):
                 self.sf_hist[ia] = sf
                 min_age = max_age
 
+            # Normalise SFH array
+            self.sf_hist /= np.sum(self.sf_hist)
+
+            # Multiply by initial stellar mass
+            self.sf_hist *= self._initial_mass
+
         # Calculate SFH from function if necessary
         if self.metal_dist_func is not None and self.metal_dist is None:
             # Set up SFH array
@@ -341,6 +348,12 @@ class Stars(StarsComponent):
                 )[0]
                 self.metal_dist[imetal] = sf
                 min_metal = max_metal
+
+            # Normalise ZH array
+            self.metal_dist /= np.sum(self.metal_dist)
+
+            # Multiply by initial stellar mass
+            self.metal_dist *= self._initial_mass
 
         # Ensure that by this point we have an array for SFH and ZH
         if self.sf_hist is None or self.metal_dist is None:

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -18,6 +18,7 @@ Example usages:
                         smoothing_lengths=smoothing_lengths,
                         tau_v=tau_vs, coordinates=coordinates, ...)
 """
+
 import warnings
 
 import numpy as np
@@ -32,6 +33,8 @@ from synthesizer.plt import single_histxy
 from synthesizer.sed import Sed
 from synthesizer.units import Quantity
 from synthesizer import exceptions
+from synthesizer.parametric import SFH, ZDist
+from synthesizer.parametric import Stars as Para_Stars
 
 
 class Stars(Particles, StarsComponent):
@@ -374,6 +377,8 @@ class Stars(Particles, StarsComponent):
         verbose=False,
         do_grid_check=False,
         grid_assignment_method="cic",
+        parametric_young_stars=None,
+        parametric_sfh=SFH.Constant,
     ):
         """
         Generate the integrated rest frame spectra for a given grid key
@@ -410,6 +415,11 @@ class Stars(Particles, StarsComponent):
                 point. Allowed methods are cic (cloud in cell) or nearest
                 grid point (ngp) or there uppercase equivalents (CIC, NGP).
                 Defaults to cic.
+            parametric_young_stars (bool/float)
+                If not None, specifies age in Myr at which to use a parametric
+                SFH for young particles.
+            parametric_sfh (SFH object)
+                Form of the parametric SFH to use for young stars
 
         Returns:
             Numpy array of integrated spectra in units of (erg / s / Hz).
@@ -495,6 +505,21 @@ class Stars(Particles, StarsComponent):
 
             return np.zeros(len(grid.lam))
 
+        if parametric_young_stars:
+            # Get mask for particles we're going to replace with parametric
+            pmask = self._get_masks(parametric_young_stars, None)
+
+            # Update the young/old mask to ignore those we're replacing
+            mask[pmask] = False
+
+            lnu_parametric = self._parametric_young_stars(
+                pmask=pmask,
+                age=parametric_young_stars,
+                parametric_sfh=parametric_sfh,
+                grid=grid,
+                spectra_name=spectra_name,
+            )
+
         from ..extensions.integrated_spectra import compute_integrated_sed
 
         # Prepare the arguments for the C function.
@@ -507,7 +532,58 @@ class Stars(Particles, StarsComponent):
         )
 
         # Get the integrated spectra in grid units (erg / s / Hz)
-        return compute_integrated_sed(*args)
+        lnu_particle = compute_integrated_sed(*args)
+
+        if parametric_young_stars:
+            return lnu_particle + lnu_parametric
+        else:
+            return lnu_particle
+
+    def _parametric_young_stars(
+        self,
+        pmask,
+        age,
+        parametric_sfh,
+        grid,
+        spectra_name,
+    ):
+        """
+        Replace young stars with parametric SFH
+
+        Args:
+
+        """
+
+        # Set the duration of the parametric SFH
+        sfh_p = {"duration": age}
+
+        # initialise SFH object
+        sfh = parametric_sfh(**sfh_p)
+
+        stars = [None] * np.sum(pmask)
+
+        # Loop through particles to be replaced
+        for i, _pmask in enumerate(np.where(pmask)[0]):
+            # Set metallicity to that of the parent star particle
+            Z_p = {"metallicity": self.metallicities[_pmask]}
+
+            # Initialise ZH object
+            metal_dist = ZDist.DeltaConstant(**Z_p)  # constant metallicity
+
+            # Create a parametric Stars object
+            stars[i] = Para_Stars(
+                grid.log10age,
+                grid.metallicity,
+                sf_hist=sfh,
+                metal_dist=metal_dist,
+                initial_mass=self.initial_masses[_pmask],
+            )
+
+        # Combine the invidivual parametric forms for each particle
+        stars = sum(stars[1:], stars[0])
+
+        # Get the spectra for this parametric form
+        return stars.generate_lnu(grid=grid, spectra_name=spectra_name)
 
     def generate_line(self, grid, line_id, fesc):
         """


### PR DESCRIPTION
Add the option to use a parametric SFH for young star particles. This has been implemented on the `generate_lnu` method on a particle stars object. All downstream `get_spectra_*` methods can utilise this by setting the optional keyword `parametric_young_stars`, where the value give the age in Myr at which to filter for star particles to be replaced. 

Optionally, the form of the SFH can be set using `parametric_sfh`, which should be set to a parametric SFH object. This is set to a Constant SFH by default, over the age interval set by the value of `parametric_young_stars`.

A test example is provided in the `examples/cosmo` directory, showing the implementation, it's use, and a comparison of the spectra and SFH generated.

## Issue Type
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
