### PR TITLE
Remove depracated script from docs workflow

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -26,9 +26,6 @@ jobs:
         env:
             GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
         run: |
-          cd tests/
-          ./get_test_grid.sh
-          cd ../
           synthesizer-download --test-grids -d tests/test_grid/
       - name: Sphinx Build
         run: |


### PR DESCRIPTION
The old download script hadn't been removed from the docs workflow.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
