### PR TITLE
Fixing emergent spectra issue #550

### DIFF
--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -929,6 +929,11 @@ class StarsComponent:
                     + self.spectra["old_attenuated"]._lnu
                 )
 
+            # Combine emergent spectra for young and old stars
+            self.spectra["emergent"] = (
+                self.spectra["young_emergent"] + self.spectra["old_emergent"]
+            )
+
             # Force updating of the bolometric luminosity attribute. I don't
             # know why this is necessary.
             self.spectra["young_emergent"].measure_bolometric_luminosity()


### PR DESCRIPTION
In `get_spectra_pacman` you could provide a set of arguments which led to the `"emergent"` key never being combined from the young and old components. 

Closes #550.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
