### PR TITLE
Fix bug where `filter_codes` aren't updated during `ImageCollection` addition

### DIFF
--- a/src/synthesizer/imaging/image_collection.py
+++ b/src/synthesizer/imaging/image_collection.py
@@ -357,7 +357,7 @@ class ImageCollection:
 
         Returns:
             composite_img (ImageCollection)
-                A new Image object contain the composite image of self and
+                A new Image object containing the composite image of self and
                 other_img.
 
         Raises:
@@ -391,6 +391,7 @@ class ImageCollection:
 
         # Combine any common filters
         for f in filters:
+            composite_img.filter_codes.append(f)
             composite_img.imgs[f] = self.imgs[f] + other_img.imgs[f]
 
         return composite_img


### PR DESCRIPTION
`filter_codes` weren't associated to the new image object during addition. This closes #555.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [ ] I have read the [CONTRIBUTING.md]() -->
- [ ] I have added docstrings to all methods
- [ ] I have added sufficient comments to all lines
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no pep8 errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
