### PR TITLE
Giving grid.py some TLC

### DIFF
--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -338,8 +338,8 @@ class StarsComponent:
         spectra this saves the incident, nebular, and escaped spectra.
 
         Note, if a grid that has not been post-processed through a
-        photoionisation code is provided (i.e. read_lines=False) this will
-        just call `get_spectra_incident`.
+        photoionisation code is provided (i.e. grid.reprocessed=False) this
+        will just call `get_spectra_incident`.
 
         Args:
             grid (obj):
@@ -384,7 +384,7 @@ class StarsComponent:
         young, old = self._check_young_old_units(young, old)
 
         # Check if grid has been run through a photoionisation code
-        if grid.read_lines is False:
+        if not grid.reprocessed:
             if verbose:
                 print(
                     (
@@ -675,7 +675,7 @@ class StarsComponent:
                 )
 
         # If grid has photoinoisation outputs, use the reprocessed outputs
-        if grid.read_lines:
+        if grid.reprocessed:
             reprocessed_name = "reprocessed"
         else:  # otherwise just use the intrinsic stellar spectra
             reprocessed_name = "intrinsic"
@@ -728,8 +728,9 @@ class StarsComponent:
                 **kwargs,
             )
 
-            # Combine young and old spectra
-            if grid.read_lines:
+            # Combine young and old spectra (only if the grid has been
+            # reprocessed through photoionisation code)
+            if grid.reprocessed:
                 self.spectra["incident"] = (
                     self.spectra["young_incident"]
                     + self.spectra["old_incident"]

--- a/src/synthesizer/dust/emission.py
+++ b/src/synthesizer/dust/emission.py
@@ -389,9 +389,9 @@ class IR_templates:
         """
 
         # Define the models parameters
-        qpahs = grid.axes_values["qpah"]
-        umins = grid.axes_values["umin"]
-        alphas = grid.axes_values["alpha"]
+        qpahs = grid.qpah
+        umins = grid.umin
+        alphas = grid.alpha
 
         # default Umax=1e7
         umax = 1e7

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -369,7 +369,7 @@ class Grid:
 
         # If a list isn't provided then use all available lines to the grid
         else:
-            read_lines = self.get_available_lines(
+            read_lines, _ = self.get_available_lines(
                 self.grid_name, self.grid_dir
             )
 
@@ -474,17 +474,9 @@ class Grid:
 
         return self._lines_available
 
-    def get_available_lines(
-        self, grid_name, grid_dir, include_wavelengths=False
-    ):
+    def get_available_lines(self):
         """
-        Get a list of the lines available to a grid
-
-        Args:
-            grid_name (str):
-                The name of the grid file.
-            grid_dir (str):
-                The directory to the grid file.
+        Get a list of the lines available to a grid.
 
         Returns:
             lines (list):
@@ -495,13 +487,10 @@ class Grid:
         with h5py.File(self.grid_filename, "r") as hf:
             lines = list(hf["lines"].keys())
 
-            if include_wavelengths:
-                wavelengths = np.array(
-                    [hf["lines"][line].attrs["wavelength"] for line in lines]
-                )
-                return lines, wavelengths
-            else:
-                return lines
+            wavelengths = np.array(
+                [hf["lines"][line].attrs["wavelength"] for line in lines]
+            )
+        return lines, wavelengths
 
     def interp_spectra(self, new_lam, loop_grid=False):
         """

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -44,11 +44,11 @@ from . import __file__ as filepath
 
 
 class Grid:
-    r"""
+    """
     The Grid class containing tabulated spectral and line data.
 
     This object contains attributes and methods for reading and
-    manipulating the spectral grids which under pin all spectra\line
+    manipulating the spectral grids which under pin all spectra/line
     generation in the synthesizer.
 
     Attributes:

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -48,8 +48,8 @@ class Grid:
     The Grid class containing tabulated spectral and line data.
 
     This object contains attributes and methods for reading and
-    manipulating the spectral grids which under pin all spectra/line
-    generation in the synthesizer.
+    manipulating the spectral grids which underpin all spectra/line
+    generation in synthesizer.
 
     Attributes:
         grid_dir (str)
@@ -114,7 +114,7 @@ class Grid:
         lam_lims=(),
     ):
         """
-        Initailise the grid object.
+        Initialise the grid object.
 
         This will open the grid file and extract the axes, spectra (if
         requested), and lines (if requested) and any other relevant data.
@@ -440,7 +440,11 @@ class Grid:
     @property
     def lines_available(self):
         """
-        Check that lines are available on this grid.
+        Flag for whether line emission information is available 
+        on this grid.
+
+        This will only access the file the first time this property is
+        accessed.
 
         Returns:
             bool:
@@ -464,7 +468,7 @@ class Grid:
 
     def get_grid_spectra_ids(self):
         """
-        Get a list of the spectra available to a grid.
+        Get a list of the spectra available on a grid.
 
         Returns:
             list:
@@ -475,7 +479,7 @@ class Grid:
 
     def get_grid_line_ids(self):
         """
-        Get a list of the lines available to a grid.
+        Get a list of the lines available on a grid.
 
         Returns:
             list:
@@ -629,14 +633,14 @@ class Grid:
         # Throw exception if the spectra_id not in list of available spectra
         if spectra_id not in self.available_spectra:
             raise exceptions.InconsistentParameter(
-                "Provided spectra_id is not in list of available spectra."
+                "Provided spectra_id is not in the list of available spectra."
             )
 
         # Throw exception if the grid_point has a different shape from the grid
         if len(grid_point) != self.naxes:
             raise exceptions.InconsistentParameter(
                 "The grid_point tuple provided"
-                "as an argument should have same shape as the grid."
+                "as an argument should have the same shape as the grid."
             )
 
         # Throw an exception if grid point is outside grid bounds
@@ -667,7 +671,7 @@ class Grid:
         if len(grid_point) != self.naxes:
             raise exceptions.InconsistentParameter(
                 "The grid_point tuple provided"
-                "as an argument should have same shape as the grid."
+                "as an argument should have the same shape as the grid."
             )
 
         if isinstance(line_id, str):
@@ -681,7 +685,7 @@ class Grid:
             # Throw exception if tline_id not in list of available lines
             if line_id_ not in self.available_lines:
                 raise exceptions.InconsistentParameter(
-                    "Provided line_id is not in list of available lines."
+                    "Provided line_id is not in the list of available lines."
                 )
 
             line_ = self.lines[line_id_]
@@ -731,16 +735,16 @@ class Grid:
         max_log10age=None,
     ):
         """
-        Make a simple plot of the specific ionsing photon luminosity.
+        Make a simple plot of the specific ionising photon luminosity.
 
-        The resulting plot will plot the logged specific ionsing photon
-        luminosity as a function of log10age and metallicity for a given grid
+        The resulting figure will show the (log) specific ionsing photon
+        luminosity as a function of (log) age and metallicity for a given grid
         and ion.
 
         Args:
            ion (str)
-                The desired ion, most grids only have HI and HII calculated by
-                default at present.
+                The desired ion. Most grids only have HI and HII calculated by
+                default.
 
             hsize (float)
                 The horizontal size of the figure

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -86,7 +86,9 @@ class Grid:
         naxes
             The number of axes the spectral grid has.
         logQ10 (dict)
-            A dictionary of ionisation Q parameters.
+            A dictionary of ionisation Q parameters. (DEPRECATED)
+        log10_specific_ionising_luminosity (dict)
+            A dictionary of log10 specific ionising luminosities.
         <grid_axis> (array-like, float)
             A Grid will always contain 1D arrays corresponding to the axes
             of the spectral grid. These are read dynamically from the HDF5

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -302,13 +302,21 @@ class Grid:
         """
         # Double check we actually have lines to read
         if not self.lines_available:
-            raise Exception(
-                (
-                    "No lines available on this grid object. "
-                    "Either set `read_lines=False`, or load a grid "
-                    "containing line information"
+            if not self.reprocessed:
+                raise exceptions.GridError(
+                    "Grid hasn't been reprocessed with cloudy and has no"
+                    "lines. Either pass `read_lines=False` or load a grid"
+                    "which has been run through cloudy."
                 )
-            )
+
+            else:
+                raise Exception(
+                    (
+                        "No lines available on this grid object. "
+                        "Either set `read_lines=False`, or load a grid "
+                        "containing line information"
+                    )
+                )
 
         with h5py.File(self.grid_filename, "r") as hf:
             # Are we only reading a subset?

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -219,7 +219,7 @@ class Grid:
             self.axes = list(hf.attrs["axes"])
 
             # Set the values of each axis as an attribute
-            # e.g. self.log10age == self.axes_values['log10age']
+            # e.g. self.log10age == hdf["axes"]["log10age"]
             for axis in self.axes:
                 setattr(self, axis, hf["axes"][axis][:])
 

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -99,11 +99,16 @@ class Grid:
         grid_ext (str)
             The grid extension. Either ".hdf5" or ".h5". If the passed
             grid_name has no extension then ".hdf5" is assumed.
+        grid_filename (str)
+            The full path to the grid file.
         read_lines (bool/list)
-            Flag for whether to read lines. If False they are not read,
-            otherwise, this is a list of the requested lines.
+            Flag for whether to read lines. If False they are not read, if True
+            all lines are read, otherwise, this is a list of the requested
+            lines.
         read_spectra (bool/list)
-            Flag for whether to read spectra.
+            Flag for whether to read spectra. If False they are not read, if
+            True all spectra are read, otherwise, this is a list of the
+            requested spectra.
         spectra (dict, array-like, float)
             The spectra array from the grid. This is an N-dimensional
             grid where N is the number of axes of the SPS grid. The final
@@ -192,6 +197,9 @@ class Grid:
         # just stay as empty dicts)
         self.spectra = {}
         self.lines = {}
+
+        # Set up dictionary to hold parameters used in grid generation
+        self.parameters = {}
 
         # Get the axes of the grid from the HDF5 file
         self._get_axes()
@@ -285,7 +293,7 @@ class Grid:
                 Flag for whether to read all available spectra or subset of
                 spectra to read.
         """
-        with h5py.File(f"{self.grid_dir}/{self.grid_name}.hdf5", "r") as hf:
+        with h5py.File(self.grid_filename, "r") as hf:
             # Are we only reading a subset?
             if isinstance(read_spectra, list):
                 self.available_spectra = read_spectra

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -452,6 +452,16 @@ class Grid:
 
         return self._lines_available
 
+    @property
+    def has_spectra(self):
+        """Return whether the Grid has spectra."""
+        return len(self.spectra) > 0
+
+    @property
+    def has_lines(self):
+        """Return whether the Grid has lines."""
+        return len(self.lines) > 0
+
     def get_grid_spectra_ids(self):
         """
         Get a list of the spectra available to a grid.

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -310,7 +310,7 @@ class Grid:
                 )
 
             else:
-                raise Exception(
+                raise exceptions.GridError(
                     (
                         "No lines available on this grid object. "
                         "Either set `read_lines=False`, or load a grid "

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -440,7 +440,7 @@ class Grid:
     @property
     def lines_available(self):
         """
-        Flag for whether line emission information is available 
+        Flag for whether line emission information is available
         on this grid.
 
         This will only access the file the first time this property is

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -36,50 +36,11 @@ from spectres import spectres
 from unyt import angstrom, unyt_array, unyt_quantity
 
 from synthesizer import exceptions
-from synthesizer.line import Line, LineCollection
+from synthesizer.line import Line, LineCollection, flatten_linelist
 from synthesizer.sed import Sed
 from synthesizer.units import Quantity
 
 from . import __file__ as filepath
-
-
-def flatten_linelist(list_to_flatten):
-    """
-    Flatten a mixed list of lists and strings and remove duplicates. Used when
-    converting a desired line list which may contain single lines and doublets.
-
-    Args:
-        list_to_flatten (list)
-            list containing lists and/or strings and integers
-
-    Returns:
-        (list)
-            flattened list
-    """
-
-    flattened_list = []
-    for lst in list_to_flatten:
-        if isinstance(lst, list) or isinstance(lst, tuple):
-            for ll in lst:
-                flattened_list.append(ll)
-
-        elif isinstance(lst, str):
-            # If the line is a doublet, resolve it and add each line
-            # individually
-            if len(lst.split(",")) > 1:
-                flattened_list += lst.split(",")
-            else:
-                flattened_list.append(lst)
-
-        else:
-            raise Exception(
-                (
-                    "Unrecognised type provided. Please provide"
-                    "a list of lists and strings"
-                )
-            )
-
-    return list(set(flattened_list))
 
 
 class Grid:

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -62,14 +62,16 @@ class Grid:
             grid_name has no extension then ".hdf5" is assumed.
         grid_filename (str)
             The full path to the grid file.
-        read_lines (bool/list)
-            Flag for whether to read lines. If False they are not read, if True
-            all lines are read, otherwise, this is a list of the requested
-            lines.
-        read_spectra (bool/list)
-            Flag for whether to read spectra. If False they are not read, if
-            True all spectra are read, otherwise, this is a list of the
-            requested spectra.
+        available_lines (bool/list)
+            A list of lines on the Grid.
+        available_spectra (bool/list)
+            A list of spectra on the Grid.
+        reprocessed (bool)
+            Flag for whether the grid has been reprocessed through cloudy.
+        lines_available (bool)
+            Flag for whether lines are available on this grid.
+        lam (Quantity, float)
+            The wavelengths at which the spectra are defined.
         spectra (dict, array-like, float)
             The spectra array from the grid. This is an N-dimensional
             grid where N is the number of axes of the SPS grid. The final

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1,3 +1,27 @@
+"""The Grid class containing tabulated spectral and line data.
+
+This object underpins all of Synthesizer function which generates synthetic
+spectra and line luminosities from models or simulation outputs. The Grid
+object contains attributes and methods for interfacing with spectral and line
+grids.
+
+The grids themselves use a standardised HDF5 format which can be generated
+using the synthesizer-grids sister package.
+
+Example usage:
+
+    from synthesizer import Grid
+
+    # Load a grid
+    grid = Grid("bc03_salpeter")
+
+    # Get the axes of the grid
+    print(grid.axes)
+
+    # Get the spectra grid
+    print(grid.spectra)
+"""
+
 import os
 
 import cmasher as cmr

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -82,60 +82,6 @@ def flatten_linelist(list_to_flatten):
     return list(set(flattened_list))
 
 
-def parse_grid_id(grid_id):
-    """
-    This is used for parsing a grid ID to return the SPS model,
-    version, and IMF
-
-    Args:
-        grid_id (str)
-            string grid identifier
-    """
-
-    if len(grid_id.split("_")) == 2:
-        sps_model_, imf_ = grid_id.split("_")
-        cloudy = cloudy_model = ""
-
-    if len(grid_id.split("_")) == 4:
-        sps_model_, imf_, cloudy, cloudy_model = grid_id.split("_")
-
-    if len(sps_model_.split("-")) == 1:
-        sps_model = sps_model_.split("-")[0]
-        sps_model_version = ""
-
-    if len(sps_model_.split("-")) == 2:
-        sps_model = sps_model_.split("-")[0]
-        sps_model_version = sps_model_.split("-")[1]
-
-    if len(sps_model_.split("-")) > 2:
-        sps_model = sps_model_.split("-")[0]
-        sps_model_version = "-".join(sps_model_.split("-")[1:])
-
-    if len(imf_.split("-")) == 1:
-        imf = imf_.split("-")[0]
-        imf_hmc = ""
-
-    if len(imf_.split("-")) == 2:
-        imf = imf_.split("-")[0]
-        imf_hmc = imf_.split("-")[1]
-
-    if imf in ["chab", "chabrier03", "Chabrier03"]:
-        imf = "Chabrier (2003)"
-    if imf in ["kroupa"]:
-        imf = "Kroupa (2003)"
-    if imf in ["salpeter", "135all"]:
-        imf = "Salpeter (1955)"
-    if imf.isnumeric():
-        imf = rf"$\alpha={float(imf)/100}$"
-
-    return {
-        "sps_model": sps_model,
-        "sps_model_version": sps_model_version,
-        "imf": imf,
-        "imf_hmc": imf_hmc,
-    }
-
-
 class Grid:
     r"""
     The Grid class containing tabulated spectral and line data.

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -245,16 +245,10 @@ class Grid:
             # Get list of axes
             self.axes = list(hf.attrs["axes"])
 
-            # Put the values of each axis in a dictionary
-            # TODO: no point double storing this!
-            self.axes_values = {
-                axis: hf["axes"][axis][:] for axis in self.axes
-            }
-
             # Set the values of each axis as an attribute
             # e.g. self.log10age == self.axes_values['log10age']
             for axis in self.axes:
-                setattr(self, axis, self.axes_values[axis])
+                setattr(self, axis, hf["axes"][axis][:])
 
             # Number of axes
             self.naxes = len(self.axes)

--- a/src/synthesizer/line.py
+++ b/src/synthesizer/line.py
@@ -91,6 +91,46 @@ def get_line_label(line_id):
     return line_label
 
 
+def flatten_linelist(list_to_flatten):
+    """
+    Flatten a mixed list of lists and strings and remove duplicates.
+
+    Used when converting a line list which may contain single lines
+    and doublets.
+
+    Args:
+        list_to_flatten (list)
+            list containing lists and/or strings and integers
+
+    Returns:
+        (list)
+            flattened list
+    """
+    flattened_list = []
+    for lst in list_to_flatten:
+        if isinstance(lst, list) or isinstance(lst, tuple):
+            for ll in lst:
+                flattened_list.append(ll)
+
+        elif isinstance(lst, str):
+            # If the line is a doublet, resolve it and add each line
+            # individually
+            if len(lst.split(",")) > 1:
+                flattened_list += lst.split(",")
+            else:
+                flattened_list.append(lst)
+
+        else:
+            raise Exception(
+                (
+                    "Unrecognised type provided. Please provide"
+                    "a list of lists and strings"
+                )
+            )
+
+    return list(set(flattened_list))
+
+
 def get_ratio_label(ratio_id):
     """
     Get a label for a given ratio_id.

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -823,10 +823,10 @@ class BlackHoles(Particles, BlackholesComponent):
                 )
 
                 # Calculate normalised dust emission spectrum
-                self.particle_spectra[
-                    "dust"
-                ] = dust_emission_model.get_spectra(
-                    self.particle_spectra["emergent"].lam
+                self.particle_spectra["dust"] = (
+                    dust_emission_model.get_spectra(
+                        self.particle_spectra["emergent"].lam
+                    )
                 )
 
                 # Scale the dust spectra by the dust_bolometric_luminosity.

--- a/src/synthesizer/utils.py
+++ b/src/synthesizer/utils.py
@@ -149,3 +149,58 @@ def value_to_array(value):
         )
 
     return arr
+
+
+def parse_grid_id(grid_id):
+    """
+    Parse a grid name for the properties of the grid.
+
+    This is used for parsing a grid ID to return the SPS model,
+    version, and IMF
+
+    Args:
+        grid_id (str)
+            string grid identifier
+    """
+    if len(grid_id.split("_")) == 2:
+        sps_model_, imf_ = grid_id.split("_")
+        cloudy = cloudy_model = ""
+
+    if len(grid_id.split("_")) == 4:
+        sps_model_, imf_, cloudy, cloudy_model = grid_id.split("_")
+
+    if len(sps_model_.split("-")) == 1:
+        sps_model = sps_model_.split("-")[0]
+        sps_model_version = ""
+
+    if len(sps_model_.split("-")) == 2:
+        sps_model = sps_model_.split("-")[0]
+        sps_model_version = sps_model_.split("-")[1]
+
+    if len(sps_model_.split("-")) > 2:
+        sps_model = sps_model_.split("-")[0]
+        sps_model_version = "-".join(sps_model_.split("-")[1:])
+
+    if len(imf_.split("-")) == 1:
+        imf = imf_.split("-")[0]
+        imf_hmc = ""
+
+    if len(imf_.split("-")) == 2:
+        imf = imf_.split("-")[0]
+        imf_hmc = imf_.split("-")[1]
+
+    if imf in ["chab", "chabrier03", "Chabrier03"]:
+        imf = "Chabrier (2003)"
+    if imf in ["kroupa"]:
+        imf = "Kroupa (2003)"
+    if imf in ["salpeter", "135all"]:
+        imf = "Salpeter (1955)"
+    if imf.isnumeric():
+        imf = rf"$\alpha={float(imf)/100}$"
+
+    return {
+        "sps_model": sps_model,
+        "sps_model_version": sps_model_version,
+        "imf": imf,
+        "imf_hmc": imf_hmc,
+    }


### PR DESCRIPTION
This PR cleans up grid.py a bit.

- The initialisation was previously pretty impenetrable. This has now been packaged up into private methods which do specific jobs to aid interpretation.
- There were subtle conflicts between the various lists of spectra and lines which could be used. This has now been simplified with only `available_lines/spectra` now front facing. 
- `read_spectra` and `read_lines` are now only inputs and not stored. There are more intuitive ways to check if a Grid has spectra or lines.
- Properties have been introduced to flag if a `Grid` has lines and spectra. 
- A cloudy `reprocessed` flag has been introduced + a more informative error if someone tries to load lines from a grid without cloudy reprocessing.
- Line related function is now in `line` module.
- Functions only used within the grid are now methods. (They were used no where else and nowhere in `synthesizer-grids`)
- Module is now fully documented.
- `get_nearest_index` is now static but could simply be moved into utils as a generic function for getting the nearest index with units.

Closes #564, closes #563, closes #560.

## Issue Type
<!-- delete options below as required -->
- Document
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
