### PR TITLE
fixed issues with masks

### DIFF
--- a/src/synthesizer/components/blackhole.py
+++ b/src/synthesizer/components/blackhole.py
@@ -247,9 +247,9 @@ class BlackholesComponent:
         # If the mask is False (parametric case) or contains only
         # 0 (particle case) just return an array of zeros
         if isinstance(mask, bool) and not mask:
-            return np.zeros(grid.lam)
+            return np.zeros(len(grid.lam))
         if mask is not None and np.sum(mask) == 0:
-            return np.zeros(grid.lam)
+            return np.zeros(len(grid.lam))
 
         from ..extensions.integrated_spectra import compute_integrated_sed
 
@@ -421,6 +421,9 @@ class BlackholesComponent:
         # Calculate the incident spectra. It doesn't matter which spectra we
         # use here since we're just using the incident. Note: this assumes the
         # NLR and BLR are not overlapping.
+
+        # Mask should be None here since this is meant to be before any
+        # reprocessing by either the torus.
         self.spectra["disc_incident"] = Sed(
             lam,
             self.generate_lnu(
@@ -429,7 +432,7 @@ class BlackholesComponent:
                 spectra_name="incident",
                 line_region="nlr",
                 fesc=0.0,
-                mask=mask,
+                mask=None,
                 verbose=verbose,
                 grid_assignment_method=grid_assignment_method,
             ),
@@ -463,7 +466,7 @@ class BlackholesComponent:
             1
             - emission_model.covering_fraction_blr
             - emission_model.covering_fraction_nlr
-        ) * self.spectra["disc_incident"]
+        ) * (self.spectra["disc_incident"] * mask)
 
         # calculate the total spectra, the sum of escaping and transmitted
         self.spectra["disc"] = (
@@ -563,6 +566,10 @@ class BlackholesComponent:
         torus_bolometric_luminosity = (
             emission_model.theta_torus / (90 * deg)
         ) * disc_spectra.measure_bolometric_luminosity()
+
+        print(disc_spectra.measure_bolometric_luminosity())
+        print(torus_bolometric_luminosity)
+        print(emission_model.theta_torus / (90 * deg))
 
         # create torus spectra
         sed = emission_model.torus_emission_model.get_spectra(disc_spectra.lam)

--- a/src/synthesizer/components/blackhole.py
+++ b/src/synthesizer/components/blackhole.py
@@ -415,8 +415,6 @@ class BlackholesComponent:
                 transmitted disc emission.
         """
 
-        print(mask)
-
         # Get the wavelength array
         lam = emission_model.grid["nlr"].lam
 
@@ -593,10 +591,6 @@ class BlackholesComponent:
         torus_bolometric_luminosity = (
             emission_model.theta_torus / (90 * deg)
         ) * disc_spectra.measure_bolometric_luminosity()
-
-        print(disc_spectra.measure_bolometric_luminosity())
-        print(torus_bolometric_luminosity)
-        print(emission_model.theta_torus / (90 * deg))
 
         # create torus spectra
         sed = emission_model.torus_emission_model.get_spectra(disc_spectra.lam)


### PR DESCRIPTION
Fixing a bug were high-inclinations (i.e. obscured by the torus) didn't work properly.

- zeroed spectra were initialised with `np.zeros(grid.lam)` instead of `np.zeros(len(grid.lam))`
- Torus modelling needs the isotropic disc_incident spectra so have added this and used it.
- We now saved both the masked and unmasked `disc_incident` spectra. The masked is used to generate the "disc_escaped" spectra. Since `disc_incident` and `disc_incident_masked` are equivalent at low-inclination and `disc_incident_masked` is zero otherwise there is probably a better of way of handling this, for example, by multiplying `self.spectra["disc_incident"]` by the mask when used. However, this doesn't seem to work as the shapes are incorrect which is slightly puzzling and may point to a deeper issue.

## Issue Type
<!-- delete options below as required -->
- Bug
- Document
- [x] Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
