### PR TITLE
Rename blackhole methods

### DIFF
--- a/src/synthesizer/components/blackhole.py
+++ b/src/synthesizer/components/blackhole.py
@@ -247,9 +247,9 @@ class BlackholesComponent:
         # If the mask is False (parametric case) or contains only
         # 0 (particle case) just return an array of zeros
         if isinstance(mask, bool) and not mask:
-            return np.zeros(grid.lam)
+            return np.zeros(len(grid.lam))
         if mask is not None and np.sum(mask) == 0:
-            return np.zeros(grid.lam)
+            return np.zeros(len(grid.lam))
 
         from ..extensions.integrated_spectra import compute_integrated_sed
 
@@ -421,6 +421,9 @@ class BlackholesComponent:
         # Calculate the incident spectra. It doesn't matter which spectra we
         # use here since we're just using the incident. Note: this assumes the
         # NLR and BLR are not overlapping.
+
+        # Mask should be None here since this is meant to be before any
+        # reprocessing by either the torus.
         self.spectra["disc_incident"] = Sed(
             lam,
             self.generate_lnu(
@@ -429,7 +432,7 @@ class BlackholesComponent:
                 spectra_name="incident",
                 line_region="nlr",
                 fesc=0.0,
-                mask=mask,
+                mask=None,
                 verbose=verbose,
                 grid_assignment_method=grid_assignment_method,
             ),
@@ -463,7 +466,7 @@ class BlackholesComponent:
             1
             - emission_model.covering_fraction_blr
             - emission_model.covering_fraction_nlr
-        ) * self.spectra["disc_incident"]
+        ) * (self.spectra["disc_incident"] * mask)
 
         # calculate the total spectra, the sum of escaping and transmitted
         self.spectra["disc"] = (
@@ -563,6 +566,10 @@ class BlackholesComponent:
         torus_bolometric_luminosity = (
             emission_model.theta_torus / (90 * deg)
         ) * disc_spectra.measure_bolometric_luminosity()
+
+        print(disc_spectra.measure_bolometric_luminosity())
+        print(torus_bolometric_luminosity)
+        print(emission_model.theta_torus / (90 * deg))
 
         # create torus spectra
         sed = emission_model.torus_emission_model.get_spectra(disc_spectra.lam)

--- a/src/synthesizer/components/blackhole.py
+++ b/src/synthesizer/components/blackhole.py
@@ -415,8 +415,6 @@ class BlackholesComponent:
                 transmitted disc emission.
         """
 
-        print(mask)
-
         # Get the wavelength array
         lam = emission_model.grid["nlr"].lam
 
@@ -593,10 +591,6 @@ class BlackholesComponent:
         torus_bolometric_luminosity = (
             emission_model.theta_torus / (90 * deg)
         ) * disc_spectra.measure_bolometric_luminosity()
-
-        print(disc_spectra.measure_bolometric_luminosity())
-        print(torus_bolometric_luminosity)
-        print(emission_model.theta_torus / (90 * deg))
 
         # create torus spectra
         sed = emission_model.torus_emission_model.get_spectra(disc_spectra.lam)

--- a/src/synthesizer/components/blackhole.py
+++ b/src/synthesizer/components/blackhole.py
@@ -774,6 +774,9 @@ class BlackholesComponent:
 
             return self.spectra
 
+        raise exceptions.UnrecognisedOption("""AGN emission model not
+                                                recognised""")
+
     def get_spectra_attenuated(
         self,
         emission_model,


### PR DESCRIPTION
If we are really intent to keep all the spectra generation methods for different blackhole models in `component/blackholes.py` we need to name them sensibly since e.g. the torus modelling in `UnifiedAGN` may differ from the torus modelling in a later model. This PR renames the methods used by the `UnifiedAGN` model, adds an if statement for that model, and raises an exception if the emission_model is not implemented (i.e. not Template or UnifiedAGN").

- Draft until #570 merged.
- Closes #568.


## Issue Type
<!-- delete options below as required -->
- Bug
- Document
- Enhancement

## Checklist
- [ ] I have read the [CONTRIBUTING.md]() -->
- [ ] I have added docstrings to all methods
- [ ] I have added sufficient comments to all lines
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no pep8 errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
