### PR TITLE
Load FLARES now loads stellar smoothing lengths

### DIFF
--- a/src/synthesizer/load_data/load_flares.py
+++ b/src/synthesizer/load_data/load_flares.py
@@ -37,6 +37,7 @@ def load_FLARES(master_file, region, tag):
         )  # Mpc (physical)
         masses = hf[f"{region}/{tag}/Particle/S_Mass"][:]  # 1e10 Msol
         imasses = hf[f"{region}/{tag}/Particle/S_MassInitial"][:]  # 1e10 Msol
+        s_hsml = hf[f"{region}/{tag}/Particle/S_sml"][:]  # Mpc (physical)
 
         metals = hf[f"{region}/{tag}/Particle/S_Z_smooth"][:]
         s_oxygen = hf[f"{region}/{tag}/Particle/S_Abundance_Oxygen"][:]
@@ -72,6 +73,7 @@ def load_FLARES(master_file, region, tag):
             s_hydrogen=s_hydrogen[b:e],
             coordinates=coods[b:e, :] * Mpc,
             current_masses=masses[b:e] * Msun,
+            smoothing_lengths=s_hsml[b:e] * Mpc,
         )
 
     # Get the gas particle begin / end indices


### PR DESCRIPTION
The load_FLARES function previously didn't load the stellar smoothing lengths leading to errors in image creation. 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
