### PR TITLE
Introduced a warnings module with a deprecation function and decorator

### DIFF
--- a/src/synthesizer/warnings.py
+++ b/src/synthesizer/warnings.py
@@ -5,7 +5,7 @@ user.
 
 Example usage:
 
-    deprecation("x will have to be a unt_array in future versions.")
+    deprecation("x will have to be a unyt_array in future versions.")
 
     @deprecated
     def old_function():
@@ -21,15 +21,16 @@ def deprecation(message, category=FutureWarning):
     Issue a deprecation warning to the end user.
 
     A message must be specified, and a category can be optionally specified.
-    FutureWarning will by default warn the end user, DeprecationWarning will
-    only warn when the user has set the PYTHONWARNINGS environment variable,
-    and PendingDeprecationWarning can be used for far future deprecations.
+    FutureWarning will, by default, warn the end user, DeprecationWarning
+    will only warn when the user has set the PYTHONWARNINGS environment
+    variable, and `PendingDeprecationWarning` can be used for far future
+    deprecations.
 
     Args:
         message (str)
             The message to be displayed to the end user.
         category (Warning)
-            The warning category to use.
+            The warning category to use. `FutureWarning` by default.
 
     """
     warnings.warn(message, category=category, stacklevel=3)
@@ -41,7 +42,7 @@ def deprecated(func, message=None, category=FutureWarning):
 
     This decorator will issue a warning to the end user when the function is
     called. The message and category can be optionally specified, if not a
-    default message will be used and FutureWarning will be issued (which will
+    default message will be used and `FutureWarning` will be issued (which will
     by default warn the end user unless explicitly silenced).
 
     Args:
@@ -49,7 +50,7 @@ def deprecated(func, message=None, category=FutureWarning):
             The message to be displayed to the end user. If None a default
             message will be used.
         category (Warning)
-            The warning category to use.
+            The warning category to use. `FutureWarning` by default.
 
     """
 

--- a/src/synthesizer/warnings.py
+++ b/src/synthesizer/warnings.py
@@ -1,0 +1,73 @@
+"""A module containing warnings and deprecation utilities.
+
+This module contains functions and decorators for issuing warnings to the end
+user.
+
+Example usage:
+
+    deprecation("x will have to be a unt_array in future versions.")
+
+    @deprecated
+    def old_function():
+        pass
+
+"""
+
+import warnings
+
+
+def deprecation(message, category=FutureWarning):
+    """
+    Issue a deprecation warning to the end user.
+
+    A message must be specified, and a category can be optionally specified.
+    FutureWarning will by default warn the end user, DeprecationWarning will
+    only warn when the user has set the PYTHONWARNINGS environment variable,
+    and PendingDeprecationWarning can be used for far future deprecations.
+
+    Args:
+        message (str)
+            The message to be displayed to the end user.
+        category (Warning)
+            The warning category to use.
+
+    """
+    warnings.warn(message, category=category, stacklevel=3)
+
+
+def deprecated(func, message=None, category=FutureWarning):
+    """
+    Decorate a function to mark it as deprecated.
+
+    This decorator will issue a warning to the end user when the function is
+    called. The message and category can be optionally specified, if not a
+    default message will be used and FutureWarning will be issued (which will
+    by default warn the end user unless explicitly silenced).
+
+    Args:
+        message (str)
+            The message to be displayed to the end user. If None a default
+            message will be used.
+        category (Warning)
+            The warning category to use.
+
+    """
+
+    def wrapped(*args, **kwargs):
+        # Determine the specific deprecation message
+        if message is None:
+            _message = (
+                f"{func.__name__} is deprecated and "
+                "will be removed in a future version."
+            )
+        else:
+            _message = f"{func.__name__} {message}"
+
+        # Issue the warning
+        deprecation(
+            _message,
+            category=category,
+        )
+        return func(*args, **kwargs)
+
+    return wrapped


### PR DESCRIPTION
This PR introduces a `warnings` module (this could in the future include warnings for units, or any possible inconsistencies the user should know about).

Within the `warnings` module are a function and decorator that can be used for deprecations. The function can be called with a message to warn the user about future changes in functionality/ behaviour (e.g. changes in the expected argument type of a function, or something else more specific than a whole deprecated function). The decorator can be used to decorator deprecated functions. Both can take custom messages or categories but the decorator has a default that can be used most of the time.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
