### PR TITLE
Fix dust bugs

### DIFF
--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -543,12 +543,12 @@ class StarsComponent:
         )
 
         # Apply the dust screen
-        emergent = self.spectra["intrinsic"].apply_attenuation(
+        emergent = self.spectra["{label}intrinsic"].apply_attenuation(
             tau_v, dust_curve=dust_curve
         )
 
         # Store the Sed object
-        self.spectra["emergent"] = emergent
+        self.spectra["{label}emergent"] = emergent
 
         return emergent
 

--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -543,12 +543,12 @@ class StarsComponent:
         )
 
         # Apply the dust screen
-        emergent = self.spectra["{label}intrinsic"].apply_attenuation(
+        emergent = self.spectra[f"{label}intrinsic"].apply_attenuation(
             tau_v, dust_curve=dust_curve
         )
 
         # Store the Sed object
-        self.spectra["{label}emergent"] = emergent
+        self.spectra[f"{label}emergent"] = emergent
 
         return emergent
 

--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -1098,7 +1098,6 @@ class StarsComponent:
             grid,
             fesc=0,
             fesc_LyA=1,
-            dust_curve=PowerLaw(),
             tau_v=[tau_v_ISM, tau_v_BC],
             alpha=[alpha_ISM, alpha_BC],
             young_old_thresh=young_old_thresh,

--- a/src/synthesizer/dust/attenuation.py
+++ b/src/synthesizer/dust/attenuation.py
@@ -525,7 +525,7 @@ class ParametricLI08(AttenuationLaw):
         OPT_NIR_slope=1.0,
         FUV_slope=1.0,
         bump=0.0,
-        model="MW",
+        model=None,
     ):
         """
         Initialise the dust curve.
@@ -557,7 +557,7 @@ class ParametricLI08(AttenuationLaw):
         elif "Calzetti" in model:
             self.model = "Calzetti"
         else:
-            self.model = "None"
+            self.model = "Custom"
 
     def get_tau(self, lam):
         """

--- a/src/synthesizer/dust/attenuation.py
+++ b/src/synthesizer/dust/attenuation.py
@@ -548,13 +548,13 @@ class ParametricLI08(AttenuationLaw):
         self.bump = bump
 
         # Get the correct model string
-        if "MW" in model:
+        if model == "MW":
             self.model = "MW"
-        elif "LMC" in model:
+        elif model == "LMC":
             self.model = "LMC"
-        elif "SMC" in model:
+        elif model == "SMC":
             self.model = "SMC"
-        elif "Calzetti" in model:
+        elif model == "Calzetti":
             self.model = "Calzetti"
         else:
             self.model = "Custom"


### PR DESCRIPTION
Fixes three small bugs:
- Removes the dust_curve specified in the default arguments inside get_spectra_CharlotFall
- Makes sure labels are properly propagated to downstream referenced spectra in `get_spectra_` methods
- In the Li+08 dust model, custom parameter values were always overwritten by the Milky Way values due to a bug in initialisation

## Issue Type
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
