### PR TITLE
Ensure filter resampling on new filter collection

### DIFF
--- a/src/synthesizer/filters.py
+++ b/src/synthesizer/filters.py
@@ -195,6 +195,7 @@ class FilterCollection:
             # Do we have an wavelength array? If so we will resample the
             # transmissions.
             self.lam = new_lam
+            self.resample_filters(new_lam=self.lam)
 
             # Let's make the filters
             if filter_codes is not None:

--- a/src/synthesizer/filters.py
+++ b/src/synthesizer/filters.py
@@ -195,7 +195,6 @@ class FilterCollection:
             # Do we have an wavelength array? If so we will resample the
             # transmissions.
             self.lam = new_lam
-            self.resample_filters(new_lam=self.lam)
 
             # Let's make the filters
             if filter_codes is not None:
@@ -214,6 +213,12 @@ class FilterCollection:
             # filters onto a universal wavelength grid.
             if self.lam is None:
                 self.resample_filters(fill_gaps=fill_gaps)
+
+        # If we were passed a wavelength array we need to resample on to
+        # it. NOTE: this can also be done for a loaded FilterCollection
+        # so we just do it here outside the logic
+        if new_lam is not None:
+            self.resample_filters(new_lam)
 
         # Calculate mean and pivot wavelengths for each filter
         self.mean_lams = self.calc_mean_lams()


### PR DESCRIPTION
DWISOTT. Was not called by default on instantiation when it should have been.

## Issue Type
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
