### PR TITLE
fixing BlueTides ages bug (yrs --> Myrs) (fresh clone with pre-commit hook)

### DIFF
--- a/src/synthesizer/load_data/load_bluetides.py
+++ b/src/synthesizer/load_data/load_bluetides.py
@@ -2,7 +2,7 @@ import numpy as np
 import scipy.interpolate as interpolate
 from bigfile import BigFile
 from scipy import integrate
-from unyt import Msun, c, kpc, Myr, yr
+from unyt import Msun, Myr, c, kpc, yr
 
 from ..particle.galaxy import Galaxy
 

--- a/src/synthesizer/load_data/load_bluetides.py
+++ b/src/synthesizer/load_data/load_bluetides.py
@@ -2,7 +2,7 @@ import numpy as np
 import scipy.interpolate as interpolate
 from bigfile import BigFile
 from scipy import integrate
-from unyt import Msun, c, kpc, yr
+from unyt import Msun, c, kpc, Myr, yr
 
 from ..particle.galaxy import Galaxy
 
@@ -283,7 +283,7 @@ def load_BlueTides(
         ]
         ages = (
             dataholder.gen_SFT_to_age(star_time) / 1e6
-        )  # translate galaxy star formation time to ages in years
+        )  # translate galaxy star formation time to ages in MEGAyears
 
         initial_gas_particle_mass = np.full(ages.shape, 2.36e6) / dataholder.hh
         imasses = initial_gas_particle_mass / 4
@@ -313,8 +313,8 @@ def load_BlueTides(
         coords = np.transpose([x, y, z])
         galaxies[ii].load_stars(
             initial_masses=imasses * Msun,
-            ages=ages * yr,
-            metallicities=metallicities,
+            ages=ages * Myr,
+            metals=metallicities,
             coordinates=coords * kpc,
             current_masses=masses * Msun,
             smoothing_lengths=smoothing_lengths,


### PR DESCRIPTION
## Issue Type
<!-- delete options below as required -->
- Bug
BlueTides ages are in Myr and the previous version of this script loaded them in in years instead.

## Checklist
- [X] I have read the [CONTRIBUTING.md]() -->
- [X] I have added docstrings to all methods
- [X] I have added sufficient comments to all lines
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no pep8 errors
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
