### PR TITLE
More intuitive multi-line `Line` objects (e.g. doublets).

### DIFF
--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -1204,7 +1204,7 @@ class StarsComponent:
         elif isinstance(line_ids, (list, tuple)):
             # Convert all tuple or list line_ids to strings
             line_ids = [
-                ",".join(line_id)
+                ", ".join(line_id)
                 if isinstance(line_id, (list, tuple))
                 else line_id
                 for line_id in line_ids

--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -1344,15 +1344,15 @@ class StarsComponent:
             )
 
             # Apply attenuation
-            luminosity = intrinsic_line._luminosity * T_nebular * T_stellar
-            continuum = intrinsic_line._continuum * T_stellar
+            luminosity = intrinsic_line.luminosity * T_nebular * T_stellar
+            continuum = intrinsic_line.continuum * T_stellar
 
             # Create the line object
             line = Line(
-                line_id,
-                intrinsic_line._wavelength,
-                luminosity,
-                continuum,
+                line_id=line_id,
+                wavelength=intrinsic_line.wavelength,
+                luminosity=luminosity,
+                continuum=continuum,
             )
 
             lines[line_id] = line

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -33,7 +33,7 @@ from matplotlib import cm
 from matplotlib.animation import FuncAnimation
 from matplotlib.colors import LogNorm
 from spectres import spectres
-from unyt import angstrom, unyt_array, unyt_quantity
+from unyt import Hz, angstrom, erg, s, unyt_array, unyt_quantity
 
 from synthesizer import exceptions
 from synthesizer.line import Line, LineCollection, flatten_linelist
@@ -677,9 +677,8 @@ class Grid:
         if isinstance(line_id, str):
             line_id = [line_id]
 
-        wavelength = []
-        luminosity = []
-        continuum = []
+        # Set up a list to hold all lines
+        lines = []
 
         for line_id_ in line_id:
             # Throw exception if tline_id not in list of available lines
@@ -689,12 +688,20 @@ class Grid:
                     "of available lines."
                 )
 
+            # Create the line
+            # TODO: Need to use units from the grid file but they currently
+            # aren't stored correctly.
             line_ = self.lines[line_id_]
-            wavelength.append(line_["wavelength"])
-            luminosity.append(line_["luminosity"][grid_point])
-            continuum.append(line_["continuum"][grid_point])
+            lines.append(
+                Line(
+                    line_id=line_id,
+                    wavelength=line_["wavelength"] * angstrom,
+                    luminosity=line_["luminosity"][grid_point] * erg / s,
+                    continuum=line_["continuum"][grid_point] * erg / s / Hz,
+                )
+            )
 
-        return Line(line_id, wavelength, luminosity, continuum)
+        return Line(*lines)
 
     def get_lines(self, grid_point, line_ids=None):
         """

--- a/src/synthesizer/line.py
+++ b/src/synthesizer/line.py
@@ -790,6 +790,10 @@ class Line:
         """
         Combine this line with an arbitrary number of other lines.
 
+        This is important for combing >2 lines together since the simple
+        line1 + line2 + line3 addition of multiple lines will not correctly
+        average over all lines.
+
         Args:
             lines (Line)
                 Any number of Line objects to combine into a single line.

--- a/src/synthesizer/line.py
+++ b/src/synthesizer/line.py
@@ -681,7 +681,8 @@ class Line:
         self.id = get_line_id([line.id for line in lines])
 
     def __str__(self):
-        """Function to print a basic summary of the Line object.
+        """
+        Return a basic summary of the Line object.
 
         Returns a string containing the id, wavelength, luminosity,
         equivalent width, and flux if generated.
@@ -730,25 +731,15 @@ class Line:
 
     def __add__(self, second_line):
         """
-        Function allowing adding of two Line objects together. This should
-        NOT be used to add different lines together.
+        Add another line to self.
+
+        Overloads + operator to allow direct addition of Line objects.
 
         Returns
-            (synthesizer.line.Line)
-                New instance of synthesizer.line.Line
+            (Line)
+                New instance of Line containing both lines.
         """
-        if second_line.id == self.id:
-            return Line(
-                self.id,
-                self._wavelength,
-                self._luminosity + second_line._luminosity,
-                self._continuum + second_line._continuum,
-            )
-
-        else:
-            raise exceptions.InconsistentAddition(
-                "Wavelength grids must be identical"
-            )
+        return Line(self, second_line)
 
     def get_flux(self, cosmo, z):
         """

--- a/src/synthesizer/line.py
+++ b/src/synthesizer/line.py
@@ -637,6 +637,8 @@ class Line:
         # Element
         self.element = [li.strip().split(" ")[0] for li in self.id.split(",")]
 
+        print("ID after init", self.id)
+
     def _make_line_from_values(
         self, line_id, wavelength, luminosity, continuum
     ):

--- a/src/synthesizer/line.py
+++ b/src/synthesizer/line.py
@@ -785,3 +785,25 @@ class Line:
         self.flux = self.luminosity / (4 * np.pi * luminosity_distance**2)
 
         return self.flux
+
+    def combine(self, lines):
+        """
+        Combine this line with an arbitrary number of other lines.
+
+        Args:
+            lines (Line)
+                Any number of Line objects to combine into a single line.
+
+        Returns:
+            (Line)
+                A new Line object containing the combined lines.
+        """
+        # Ensure we've been handed lines
+        if any([not isinstance(line, Line) for line in lines]):
+            raise exceptions.InconsistentArguments(
+                "args passed to a Line must all be Lines. Did you mean to "
+                "pass keyword arguments for wavelength, luminosity and "
+                "continuum"
+            )
+
+        return Line(self, *lines)

--- a/src/synthesizer/line.py
+++ b/src/synthesizer/line.py
@@ -39,7 +39,7 @@ def get_line_id(id):
     """
 
     if isinstance(id, list):
-        return ",".join(id)
+        return ", ".join(id)
     else:
         return id
 
@@ -63,7 +63,7 @@ def get_line_label(line_id):
 
     # if the line_id is a list (denoting a doublet or higher)
     if isinstance(line_id, list):
-        line_id = ",".join(line_id)
+        line_id = ", ".join(line_id)
 
     if line_id in line_ratios.line_labels.keys():
         line_label = line_ratios.line_labels[line_id]
@@ -636,8 +636,6 @@ class Line:
 
         # Element
         self.element = [li.strip().split(" ")[0] for li in self.id.split(",")]
-
-        print("ID after init", self.id)
 
     def _make_line_from_values(
         self, line_id, wavelength, luminosity, continuum

--- a/src/synthesizer/line.py
+++ b/src/synthesizer/line.py
@@ -522,14 +522,35 @@ class LineCollection:
 
 class Line:
     """
-    A class representing a spectral line or set of lines (e.g. a doublet)
+    A class representing a spectral line or set of lines (e.g. a doublet).
 
-    Attributes
-        lam
-            wavelength of the line
+    Although a Line can be instatiated directly most users should generate
+    them using the various different "get_line" methods implemented across
+    Synthesizer.
 
-    Methods
+    A Line object can either be a single line or a combination of multiple,
+    individually unresolved lines.
 
+    A collection of Line objects are stored within a LineCollection which
+    provides an interface to interact with multiple lines at once.
+
+    Attributes:
+        wavelength (Quantity)
+            The standard (not vacuum) wavelength of the line.
+        vacuum_wavelength (Quantity)
+            The vacuum wavelength of the line.
+        continuum (Quantity)
+            The continuum at the line.
+        luminosity (Quantity)
+            The luminosity of the line.
+        flux (Quantity)
+            The flux of the line.
+        equivalent_width (Quantity)
+            The equivalent width of the line.
+        individual_lines (list)
+            A list of individual lines that make up this line.
+        element (list)
+            A list of the elements that make up this line.
     """
 
     # Define quantities

--- a/src/synthesizer/line.py
+++ b/src/synthesizer/line.py
@@ -16,7 +16,7 @@ in plots etc.
 """
 
 import numpy as np
-from unyt import Angstrom, unyt_quantity
+from unyt import Angstrom, cm, unyt_quantity
 
 from synthesizer import exceptions, line_ratios
 from synthesizer.conversions import lnu_to_llam, standard_to_vacuum
@@ -29,7 +29,7 @@ def get_line_id(id):
     A function for converting a line id possibly represented as a list to
     a single string.
 
-    Arguments
+    Args
         id (str, list, tuple)
             a str, list, or tuple containing the id(s) of the lines
 
@@ -136,7 +136,7 @@ def get_ratio_label(ratio_id):
     """
     Get a label for a given ratio_id.
 
-    Arguments:
+    Args:
         ratio_id (str)
             The ratio identificantion, e.g. R23.
 
@@ -164,7 +164,7 @@ def get_diagram_labels(diagram_id):
     """
     Get a x and y labels for a given diagram_id
 
-    Arguments:
+    Args:
         diagram_id (str)
             The diagram identificantion, e.g. OHNO.
 
@@ -189,7 +189,7 @@ def get_roman_numeral(number):
 
     Used for renaming emission lines from the cloudy defaults.
 
-    Arguments:
+    Args:
         number (int)
             The number to convert into a roman numeral.
 
@@ -233,7 +233,7 @@ class LineCollection:
     A class holding a collection of emission lines. This enables additional
     functionality such as quickly calculating line ratios or line diagrams.
 
-    Arguments
+    Args
         lines (dictionary of Line objects)
             A dictionary of line objects.
 
@@ -245,7 +245,7 @@ class LineCollection:
         """
         Initialise LineCollection.
 
-        Arguments:
+        Args:
             lines (dict)
                 A dictionary of synthesizer.line.Line objects.
         """
@@ -435,7 +435,7 @@ class LineCollection:
         """
         Measure (and return) a line ratio.
 
-        Arguments:
+        Args:
             ratio_id (str, list)
                 Either a ratio_id where the ratio lines are defined in
                 line_ratios or a list of lines.
@@ -472,7 +472,7 @@ class LineCollection:
         """
         Return a pair of line ratios for a given diagram_id (E.g. BPT).
 
-        Arguments:
+        Args:
             diagram_id (str, list)
                 Either a diagram_id where the pairs of ratio lines are defined
                 in line_ratios or a list of lists defining the ratios.
@@ -551,7 +551,7 @@ class Line:
         """
         Initialise the Line object.
 
-        Arguments:
+        Args:
             lines (Line)
                 Any number of Line objects to combine into a single Line. If
                 these are passed all other kwargs are ignored.
@@ -743,14 +743,11 @@ class Line:
 
     def get_flux(self, cosmo, z):
         """
-        Calculate the line flux in units of erg/s/cm2
+        Calculate the line flux.
 
-        Returns the line flux and (optionally) updates the line object.
-
-        Arguments:
+        Args:
             cosmo (astropy.cosmology.)
                 Astropy cosmology object.
-
             z (float)
                 The redshift.
 
@@ -758,10 +755,12 @@ class Line:
             flux (float)
                 Flux of the line in units of erg/s/cm2 by default.
         """
+        # Get the luminosity distance
         luminosity_distance = (
             cosmo.luminosity_distance(z).to("cm").value
-        )  # the luminosity distance in cm
+        ) * cm
 
-        self.flux = self._luminosity / (4 * np.pi * luminosity_distance**2)
+        # Compute flux
+        self.flux = self.luminosity / (4 * np.pi * luminosity_distance**2)
 
         return self.flux

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -16,7 +16,7 @@ import cmasher as cmr
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy import integrate
-from unyt import angstrom, erg, s, unyt_array, unyt_quantity
+from unyt import Hz, angstrom, erg, s, unyt_array, unyt_quantity
 
 from synthesizer import exceptions
 from synthesizer.components import StarsComponent
@@ -491,7 +491,7 @@ class Stars(StarsComponent):
                     line_id=line_id_,
                     wavelength=lam,
                     luminosity=lum * erg / s,
-                    continuum=cont * erg / s,
+                    continuum=cont * erg / s / Hz,
                 )
             )
 

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -495,7 +495,11 @@ class Stars(StarsComponent):
                 )
             )
 
-        return Line(*lines)
+        # Don't init another line if there was only 1 in the first place
+        if len(lines) == 1:
+            return lines[0]
+        else:
+            return Line(*lines)
 
     def calculate_median_age(self):
         """

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1649,7 +1649,7 @@ class Stars(Particles, StarsComponent):
         elif isinstance(line_ids, (list, tuple)):
             # Convert all tuple or list line_ids to strings
             line_ids = [
-                ",".join(line_id)
+                ", ".join(line_id)
                 if isinstance(line_id, (list, tuple))
                 else line_id
                 for line_id in line_ids
@@ -1664,7 +1664,6 @@ class Stars(Particles, StarsComponent):
 
         # Loop over the lines
         for line_id in line_ids:
-            print(line_id)
             # Compute the line object
             line = self.generate_particle_line(
                 grid=grid,

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -787,7 +787,11 @@ class Stars(Particles, StarsComponent):
                 )
             )
 
-        return Line(*lines)
+        # Don't init another line if there was only 1 in the first place
+        if len(lines) == 1:
+            return lines[0]
+        else:
+            return Line(*lines)
 
     def generate_particle_lnu(
         self,
@@ -1023,7 +1027,11 @@ class Stars(Particles, StarsComponent):
                 )
             )
 
-        return Line(*lines)
+        # Don't init another line if there was only 1 in the first place
+        if len(lines) == 1:
+            return lines[0]
+        else:
+            return Line(*lines)
 
     def _get_masks(self, young=None, old=None):
         """
@@ -1656,6 +1664,7 @@ class Stars(Particles, StarsComponent):
 
         # Loop over the lines
         for line_id in line_ids:
+            print(line_id)
             # Compute the line object
             line = self.generate_particle_line(
                 grid=grid,
@@ -1791,7 +1800,6 @@ class Stars(Particles, StarsComponent):
                 luminosity=luminosity,
                 continuum=continuum,
             )
-
             lines[line_id] = line
 
         # Create a line collection

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -24,7 +24,7 @@ import warnings
 import cmasher as cmr
 import matplotlib.pyplot as plt
 import numpy as np
-from unyt import kpc
+from unyt import angstrom, erg, kpc, s
 
 from synthesizer import exceptions
 from synthesizer.components import StarsComponent
@@ -753,10 +753,8 @@ class Stars(Particles, StarsComponent):
         if not isinstance(line_id, str):
             raise exceptions.InconsistentArguments("line_id must be a string")
 
-        # Set up containers for the line information
-        luminosity = []
-        continuum = []
-        wavelength = []
+        # Set up a list to hold each individual Line
+        lines = []
 
         # Loop over the ids in this container
         for line_id_ in line_id.split(","):
@@ -764,7 +762,9 @@ class Stars(Particles, StarsComponent):
             line_id_ = line_id_.strip()
 
             # Get this line's wavelength
-            lam = grid.lines[line_id_]["wavelength"]
+            # TODO: The units here should be extracted from the grid but aren't
+            # yet stored.
+            lam = grid.lines[line_id_]["wavelength"] * angstrom
 
             # Get the luminosity and continuum
             lum, cont = compute_integrated_line(
@@ -778,11 +778,16 @@ class Stars(Particles, StarsComponent):
             )
 
             # Append this lines values to the containers
-            wavelength.append(lam)
-            luminosity.append(lum)
-            continuum.append(cont)
+            lines.append(
+                Line(
+                    line_id=line_id_,
+                    wavelength=lam,
+                    luminosity=lum * erg / s,
+                    continuum=cont * erg / s,
+                )
+            )
 
-        return Line(line_id, wavelength, luminosity, continuum)
+        return Line(*lines)
 
     def generate_particle_lnu(
         self,
@@ -984,10 +989,8 @@ class Stars(Particles, StarsComponent):
         if not isinstance(line_id, str):
             raise exceptions.InconsistentArguments("line_id must be a string")
 
-        # Set up containers for the line information
-        luminosity = []
-        continuum = []
-        wavelength = []
+        # Set up a list to hold each individual Line
+        lines = []
 
         # Loop over the ids in this container
         for line_id_ in line_id.split(","):
@@ -995,7 +998,9 @@ class Stars(Particles, StarsComponent):
             line_id_ = line_id_.strip()
 
             # Get this line's wavelength
-            lam = grid.lines[line_id_]["wavelength"]
+            # TODO: The units here should be extracted from the grid but aren't
+            # yet stored.
+            lam = grid.lines[line_id_]["wavelength"] * angstrom
 
             # Get the luminosity and continuum
             lum, cont = compute_particle_line(
@@ -1009,11 +1014,16 @@ class Stars(Particles, StarsComponent):
             )
 
             # Append this lines values to the containers
-            wavelength.append(lam)
-            luminosity.append(lum)
-            continuum.append(cont)
+            lines.append(
+                Line(
+                    line_id=line_id_,
+                    wavelength=lam,
+                    luminosity=lum * erg / s,
+                    continuum=cont * erg / s,
+                )
+            )
 
-        return Line(line_id, wavelength, luminosity, continuum)
+        return Line(*lines)
 
     def _get_masks(self, young=None, old=None):
         """

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -24,7 +24,7 @@ import warnings
 import cmasher as cmr
 import matplotlib.pyplot as plt
 import numpy as np
-from unyt import angstrom, erg, kpc, s
+from unyt import Hz, angstrom, erg, kpc, s
 
 from synthesizer import exceptions
 from synthesizer.components import StarsComponent
@@ -783,7 +783,7 @@ class Stars(Particles, StarsComponent):
                     line_id=line_id_,
                     wavelength=lam,
                     luminosity=lum * erg / s,
-                    continuum=cont * erg / s,
+                    continuum=cont * erg / s / Hz,
                 )
             )
 
@@ -1019,7 +1019,7 @@ class Stars(Particles, StarsComponent):
                     line_id=line_id_,
                     wavelength=lam,
                     luminosity=lum * erg / s,
-                    continuum=cont * erg / s,
+                    continuum=cont * erg / s / Hz,
                 )
             )
 
@@ -1781,15 +1781,15 @@ class Stars(Particles, StarsComponent):
             )
 
             # Apply attenuation
-            luminosity = intrinsic_line._luminosity * T_nebular * T_stellar
-            continuum = intrinsic_line._continuum * T_stellar
+            luminosity = intrinsic_line.luminosity * T_nebular * T_stellar
+            continuum = intrinsic_line.continuum * T_stellar
 
             # Create the line object
             line = Line(
-                line_id,
-                intrinsic_line._wavelength,
-                luminosity,
-                continuum,
+                line_id=line_id,
+                wavelength=intrinsic_line.wavelength,
+                luminosity=luminosity,
+                continuum=continuum,
             )
 
             lines[line_id] = line


### PR DESCRIPTION
A pretty minor improvement overall but this PR improves the intuitiveness of multi-line Lines. Previously a list or array of values for the individual lines making up a composite line was passed and stored. This required some logical gymnastics to make sure everything ended up where it needed to be in different situations. 

- Now a `Line` can be initialised using either an arbitrary number of `Line`s or the id, wavelength, luminosity and continuum that defines an individual line.
- Any individual lines used to create a new `Line` are stored in a `indiviudal_lines` attribute.
- A user-facing method to combine lines has been included for adding >2 lines together.
- `Line` addition has been fixed. It would have previously "run" but never would have given the correct answer unless you were adding 2 lines with the exact same ID... making it somewhat redundant.
- The `Line` definition is now fully documented.

Dependant on #599.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
