### PR TITLE
Particle line fix

### DIFF
--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -1273,7 +1273,7 @@ class StarsComponent:
             fesc (float)
                 The Lyman continuum escaped fraction, the fraction of
                 ionising photons that entirely escaped.
-            tau_v_BS (float)
+            tau_v_nebular (float)
                 V-band optical depth of the nebular emission.
             tau_v_stellar (float)
                 V-band optical depth of the stellar emission.
@@ -1323,6 +1323,18 @@ class StarsComponent:
                 method=method,
             )
 
+        # Check that tau_v_nebular and tau_v_stellar are floats and raise
+        # an exception otherwise.
+        if not isinstance(tau_v_nebular, float):
+            raise exceptions.InconsistentArguments(
+                """ tau_v_* must be a float (i.e. single value)."""
+            )
+
+        if not isinstance(tau_v_stellar, float):
+            raise exceptions.InconsistentArguments(
+                """ tau_v_* must be a float (i.e. single value)."""
+            )
+
         # Get the intrinsic lines now we're sure they are there
         intrinsic_lines = self.lines["intrinsic"]
 
@@ -1342,13 +1354,6 @@ class StarsComponent:
             T_stellar = dust_curve_stellar.get_transmission(
                 tau_v_stellar, intrinsic_line._wavelength
             )
-
-            # get the correct array shape
-            if not np.isscalar(T_nebular):
-                T_nebular = T_nebular[:, 0]
-
-            if not np.isscalar(T_stellar):
-                T_stellar = T_stellar[:, 0]
 
             # Apply attenuation
             luminosity = intrinsic_line.luminosity * T_nebular

--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -1343,8 +1343,15 @@ class StarsComponent:
                 tau_v_stellar, intrinsic_line._wavelength
             )
 
+            # get the correct array shape
+            if not np.isscalar(T_nebular):
+                T_nebular = T_nebular[:, 0]
+
+            if not np.isscalar(T_stellar):
+                T_stellar = T_stellar[:, 0]
+
             # Apply attenuation
-            luminosity = intrinsic_line.luminosity * T_nebular * T_stellar
+            luminosity = intrinsic_line.luminosity * T_nebular
             continuum = intrinsic_line.continuum * T_stellar
 
             # Create the line object
@@ -1417,7 +1424,7 @@ class StarsComponent:
             grid,
             line_ids,
             fesc=fesc,
-            tau_v_nebular=0,
+            tau_v_nebular=tau_v,
             tau_v_stellar=tau_v,
             dust_curve_nebular=dust_curve,
             dust_curve_stellar=dust_curve,

--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -1327,12 +1327,12 @@ class StarsComponent:
         # an exception otherwise.
         if not isinstance(tau_v_nebular, float):
             raise exceptions.InconsistentArguments(
-                """ tau_v_* must be a float (i.e. single value)."""
+                "tau_v_* must be a float (i.e. single value)."
             )
 
         if not isinstance(tau_v_stellar, float):
             raise exceptions.InconsistentArguments(
-                """ tau_v_* must be a float (i.e. single value)."""
+                "tau_v_* must be a float (i.e. single value)."
             )
 
         # Get the intrinsic lines now we're sure they are there

--- a/src/synthesizer/dust/attenuation.py
+++ b/src/synthesizer/dust/attenuation.py
@@ -149,7 +149,10 @@ class AttenuationLaw:
         if np.isscalar(tau_v):
             exponent = tau_v * tau_x_v
         else:
-            exponent = tau_v[:, None] * tau_x_v
+            if np.ndim(lam) == 0:
+                exponent = tau_v[:] * tau_x_v
+            else:
+                exponent = tau_v[:, None] * tau_x_v
 
         return np.exp(-exponent)
 

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1788,9 +1788,15 @@ class Stars(Particles, StarsComponent):
                 tau_v_stellar, intrinsic_line._wavelength
             )
 
+            if not np.isscalar(T_nebular):
+                T_nebular = T_nebular[:, 0]
+
+            if not np.isscalar(T_stellar):
+                T_stellar = T_stellar[:, 0]
+
             # Apply attenuation
-            luminosity = intrinsic_line.luminosity * T_nebular[:, 0]
-            continuum = intrinsic_line.continuum * T_stellar[:, 0]
+            luminosity = intrinsic_line.luminosity * T_nebular
+            continuum = intrinsic_line.continuum * T_stellar
 
             # Create the line object
             line = Line(

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1861,7 +1861,7 @@ class Stars(Particles, StarsComponent):
             grid,
             line_ids,
             fesc=fesc,
-            tau_v_nebular=0,
+            tau_v_nebular=tau_v,
             tau_v_stellar=tau_v,
             dust_curve_nebular=dust_curve,
             dust_curve_stellar=dust_curve,

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1789,7 +1789,7 @@ class Stars(Particles, StarsComponent):
             )
 
             # Apply attenuation
-            luminosity = intrinsic_line.luminosity * T_nebular * T_stellar
+            luminosity = intrinsic_line.luminosity * T_nebular
             continuum = intrinsic_line.continuum * T_stellar
 
             # Create the line object

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1789,8 +1789,8 @@ class Stars(Particles, StarsComponent):
             )
 
             # Apply attenuation
-            luminosity = intrinsic_line.luminosity * T_nebular
-            continuum = intrinsic_line.continuum * T_stellar
+            luminosity = intrinsic_line.luminosity * T_nebular[:, 0]
+            continuum = intrinsic_line.continuum * T_stellar[:, 0]
 
             # Create the line object
             line = Line(

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1788,12 +1788,6 @@ class Stars(Particles, StarsComponent):
                 tau_v_stellar, intrinsic_line._wavelength
             )
 
-            if not np.isscalar(T_nebular):
-                T_nebular = T_nebular[:, 0]
-
-            if not np.isscalar(T_stellar):
-                T_stellar = T_stellar[:, 0]
-
             # Apply attenuation
             luminosity = intrinsic_line.luminosity * T_nebular
             continuum = intrinsic_line.continuum * T_stellar


### PR DESCRIPTION
Fixes a pair of bugs in the `get_particle_line_attenuated` and `get_particle_line_screen`.

- The attenuation felt by the line emission should *probably* just be `T_nebular` not `T_nebular * T_stellar`. I can see an argument for `T_nebular * T_stellar` if there is attenuation between the source and the nebular but that isn't consistently modelled by cloudy.
- Probably related to the above. For a screen `tau_v_nebular = tau_v_screen = tau_v`.
- A bigger bug was caused by the fact that `T_nebular` and `T_stellar` have shapes `(npart, 1)` for a line, not `(npart)` as assumed by the calculation.
- Also improved `component.stars.get_line_attenuated` by raising an exception if `tau_v_*` is not a float (e.g. if the user tries to provide an array as I did.

## Issue Type
<!-- delete options below as required -->
- [x] Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
