### PR TITLE
added method on stars to generate attenuated spectra and produce summed Lines and LineCollections

### DIFF
--- a/src/synthesizer/line.py
+++ b/src/synthesizer/line.py
@@ -403,6 +403,18 @@ class LineCollection:
             # Return the filter
             return self.lines[self.line_ids[self._current_ind - 1]]
 
+    def sum(self):
+        """
+        For collections containing lines from multiple particles calculate the
+        integrated line properties and create a new LineCollection object.
+        """
+
+        summed_lines = {}
+        for line_id, line in self.lines.items():
+            summed_lines[line_id] = line.sum()
+
+        return LineCollection(summed_lines)
+
     def _get_ratio(self, line1, line2):
         """
         Measure (and return) a line ratio.
@@ -620,6 +632,9 @@ class Line:
                 " passed, or an arbitrary number of Lines to combine"
             )
 
+        # save line_id
+        self.line_id = line_id
+
         # Initialise an attribute to hold any individual lines used to make
         # this one.
         self.individual_lines = lines if len(lines) > 0 else [self]
@@ -761,6 +776,19 @@ class Line:
                 New instance of Line containing both lines.
         """
         return Line(self, second_line)
+
+    def sum(self):
+        """
+        For objects containing lines of multiple particles sum them to produce
+        the integrated quantities.
+        """
+
+        return Line(
+            line_id=self.line_id,
+            wavelength=self.wavelength,
+            luminosity=np.sum(self.luminosity),
+            continuum=np.sum(self.continuum),
+        )
 
     def get_flux(self, cosmo, z):
         """

--- a/src/synthesizer/line.py
+++ b/src/synthesizer/line.py
@@ -632,9 +632,6 @@ class Line:
                 " passed, or an arbitrary number of Lines to combine"
             )
 
-        # save line_id
-        self.line_id = line_id
-
         # Initialise an attribute to hold any individual lines used to make
         # this one.
         self.individual_lines = lines if len(lines) > 0 else [self]
@@ -784,7 +781,7 @@ class Line:
         """
 
         return Line(
-            line_id=self.line_id,
+            line_id=self.id,
             wavelength=self.wavelength,
             luminosity=np.sum(self.luminosity),
             continuum=np.sum(self.continuum),

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1775,6 +1775,7 @@ class Stars(Particles, StarsComponent):
         dust_curve_stellar=PowerLaw(slope=-1.0),
         mask=None,
         method="cic",
+        label="",
     ):
         """
         Get a LineCollection containing attenuated lines for each particle.
@@ -1814,6 +1815,11 @@ class Stars(Particles, StarsComponent):
             LineCollection
                 A dictionary like object containing line objects.
         """
+
+        # Make a dummy mask if none has been passed
+        if mask is None:
+            mask = np.ones(self.nparticles, dtype=bool)
+
         # If the intrinsic lines haven't already been calculated and saved
         # then generate them
         if "intrinsic" not in self.particle_lines:

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1537,6 +1537,10 @@ class Stars(Particles, StarsComponent):
                 An Sed object containing the intrinsic spectra.
         """
 
+        # add underscore to label if it doesn't have one
+        if len(label) > 0 and label[-1] != "_":
+            label = f"{label}_"
+
         # The incident emission
         incident = self.get_particle_spectra_incident(
             grid,
@@ -1646,6 +1650,10 @@ class Stars(Particles, StarsComponent):
                 An Sed object containing the attenuated spectra.
         """
 
+        # add underscore to label if it doesn't have one
+        if len(label) > 0 and label[-1] != "_":
+            label = f"{label}_"
+
         # If the reprocessed spectra haven't already been calculated and saved
         # then generate them.
 
@@ -1687,6 +1695,7 @@ class Stars(Particles, StarsComponent):
         fesc=0.0,
         mask=None,
         method="cic",
+        label="",
     ):
         """
         Get a LineCollection containing intrinsic lines for each particle.
@@ -1715,6 +1724,11 @@ class Stars(Particles, StarsComponent):
             LineCollection
                 A dictionary like object containing line objects.
         """
+
+        # add underscore to label if it doesn't have one
+        if len(label) > 0 and label[-1] != "_":
+            label = f"{label}_"
+
         # Handle the line ids
         if isinstance(line_ids, str):
             # If only one line specified convert to a list
@@ -1816,6 +1830,10 @@ class Stars(Particles, StarsComponent):
                 A dictionary like object containing line objects.
         """
 
+        # add underscore to label if it doesn't have one
+        if len(label) > 0 and label[-1] != "_":
+            label = f"{label}_"
+
         # Make a dummy mask if none has been passed
         if mask is None:
             mask = np.ones(self.nparticles, dtype=bool)
@@ -1904,6 +1922,7 @@ class Stars(Particles, StarsComponent):
         dust_curve=PowerLaw(slope=-1.0),
         mask=None,
         method="cic",
+        label="",
     ):
         """
         Get a LineCollection with screen attenuated lines for each particle.
@@ -1948,6 +1967,7 @@ class Stars(Particles, StarsComponent):
             dust_curve_stellar=dust_curve,
             mask=mask,
             method=method,
+            label=label,
         )
 
     def _prepare_sfzh_args(

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1613,6 +1613,7 @@ class Stars(Particles, StarsComponent):
         dust_curve=PowerLaw(slope=-1.0),
         mask=None,
         method="cic",
+        label="",
     ):
         """
         Generates the dust attenuated spectra. First generates the intrinsic
@@ -1647,37 +1648,37 @@ class Stars(Particles, StarsComponent):
 
         # If the reprocessed spectra haven't already been calculated and saved
         # then generate them.
-        if "intrinsic" not in self.particle_spectra:
+
+        if label + "intrinsic" not in self.particle_spectra:
             self.get_particle_spectra_reprocessed(
                 grid,
                 fesc=fesc,
                 mask=mask,
                 method=method,
+                label=label,
             )
 
         # If tau_v is None use the tau_v on stars otherwise raise exception.
-        if not tau_v:
+        if tau_v is not None:
             if hasattr(self, "tau_v"):
-                tau_v = self.tau_v
+                tau_v = self.tau_v[mask]
             else:
                 raise exceptions.InconsistentArguments(
-                    """
-                    tau_v must either be provided or exist on stars for
-                    attenuated spectra to be calculated.
-                    """
+                    "tau_v must either be provided or exist on stars for"
+                    "attenuated spectra to be calculated."
                 )
 
-        intrinsic_spectra = self.particle_spectra["intrinsic"]
+        intrinsic_spectra = self.particle_spectra[label + "intrinsic"]
 
         # apply attenuated and save Sed object
-        self.particle_spectra["attenuated"] = (
+        self.particle_spectra[label + "attenuated"] = (
             intrinsic_spectra.apply_attenuation(
                 tau_v=tau_v,
                 dust_curve=dust_curve,
             )
         )
 
-        return self.particle_spectra["attenuated"]
+        return self.particle_spectra[label + "attenuated"]
 
     def get_particle_line_intrinsic(
         self,


### PR DESCRIPTION
Adds a new method on `particles.stars` to generate dust attenuated spectra, in this case for a simple screen.

I have mistakenly also implemented line summing on this branch (fulfilling #610) too. No point separating it.

Closes #610.

## Issue Type
<!-- delete options below as required -->
- [x] Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
