### PR TITLE
Fix some issues with attenuated spectra

### DIFF
--- a/src/synthesizer/dust/attenuation.py
+++ b/src/synthesizer/dust/attenuation.py
@@ -146,6 +146,7 @@ class AttenuationLaw:
         # Include the V band optical depth in the exponent
         # For a scalar we can just multiply but for an array we need to
         # broadcast
+
         if np.isscalar(tau_v):
             exponent = tau_v * tau_x_v
         else:

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -798,6 +798,7 @@ class Stars(Particles, StarsComponent):
         grid,
         spectra_name,
         fesc=0.0,
+        mask=None,
         young=None,
         old=None,
         verbose=False,
@@ -914,7 +915,8 @@ class Stars(Particles, StarsComponent):
                 )
 
         # Get particle age masks
-        mask = self._get_masks(young, old)
+        if mask is None:
+            mask = self._get_masks(young, old)
 
         # Ensure and warn that the masking hasn't removed everything
         if np.sum(mask) == 0:
@@ -952,7 +954,7 @@ class Stars(Particles, StarsComponent):
         line_id,
         fesc,
         mask=None,
-        method="cic",
+        grid_assignment_method="cic",
     ):
         """
         Calculate rest frame line luminosity and continuum from an SPS Grid.
@@ -1013,7 +1015,7 @@ class Stars(Particles, StarsComponent):
                     line_id_,
                     fesc,
                     mask=mask,
-                    grid_assignment_method=method,
+                    grid_assignment_method=grid_assignment_method,
                 )
             )
 
@@ -1616,7 +1618,6 @@ class Stars(Particles, StarsComponent):
         tau_v=None,
         dust_curve=PowerLaw(slope=-1.0),
         mask=None,
-        method="cic",
         label="",
     ):
         """
@@ -1654,6 +1655,10 @@ class Stars(Particles, StarsComponent):
         if len(label) > 0 and label[-1] != "_":
             label = f"{label}_"
 
+        # Make a dummy mask if none has been passed
+        if mask is None:
+            mask = np.ones(self.nparticles, dtype=bool)
+
         # If the reprocessed spectra haven't already been calculated and saved
         # then generate them.
 
@@ -1662,7 +1667,6 @@ class Stars(Particles, StarsComponent):
                 grid,
                 fesc=fesc,
                 mask=mask,
-                method=method,
                 label=label,
             )
 


### PR DESCRIPTION

`get_particle_spectra_screen()` was bugged previously. Because this method sets `tau_v` with a mask, we need to define a dummy (empty) mask if one is not provided. Normally this happens elsewhere.


## Issue Type
<!-- delete options below as required -->
- [x] Bug
- [ ] Document
- [ ] Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
