### PR TITLE
Fix masking for particle_spectra_screen method

### DIFF
--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1615,8 +1615,8 @@ class Stars(Particles, StarsComponent):
         fesc=0.0,
         tau_v=None,
         dust_curve=PowerLaw(slope=-1.0),
-        mask=None,
-        method="cic",
+        young=None,
+        old=None,
         label="",
     ):
         """
@@ -1661,10 +1661,13 @@ class Stars(Particles, StarsComponent):
             self.get_particle_spectra_reprocessed(
                 grid,
                 fesc=fesc,
-                mask=mask,
-                method=method,
+                young=young,
+                old=old,
                 label=label,
             )
+
+        # we need the mask based on young old arguments for this to work
+        mask = self._get_masks(young, old)
 
         # If tau_v is None use the tau_v on stars otherwise raise exception.
         if tau_v is not None:


### PR DESCRIPTION
Fixes `get_particle_spectra_screen` method by including a call to `_get_mask`.

## Issue Type
<!-- delete options below as required -->
- [x] Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
