### PR TITLE
Add a method to calculate integrated spectra for all the available particle_spectra

### DIFF
--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1973,16 +1973,30 @@ class Stars(Particles, StarsComponent):
             label=label,
         )
 
-    def calculate_integrated_spectra(self):
+    def calculate_integrated_spectra(self, update=True):
         """
-        Calculates all the integrated spectra available.
+        Calculates integrated spectra for the available particle spectra.
+
+        Arguments
+            update (bool)
+                Whether to update self.spectra or simply return the spectra.
+
+        Returns
+            spectra (dict)
+                Dictionary of integrated spectra.
+
         """
 
         # loop over available particle spectra and calculate integrated spectra
+        spectra = {}
         for spectra_type, particle_spectra in self.particle_spectra.items():
-            self.spectra[spectra_type] = particle_spectra.sum()
+            spectra[spectra_type] = particle_spectra.sum()
 
-        return self.spectra
+        # update self.spectra with spectra
+        if update:
+            self.spectra = spectra
+
+        return spectra
 
     def _prepare_sfzh_args(
         self,

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1970,6 +1970,17 @@ class Stars(Particles, StarsComponent):
             label=label,
         )
 
+    def calculate_integrated_spectra(self):
+        """
+        Calculates all the integrated spectra available.
+        """
+
+        # loop over available particle spectra and calculate integrated spectra
+        for spectra_type, particle_spectra in self.particle_spectra.items():
+            self.spectra[spectra_type] = particle_spectra.sum()
+
+        return self.spectra
+
     def _prepare_sfzh_args(
         self,
         grid,


### PR DESCRIPTION
Adds a method to calculate integrated spectra for all the available particle_spectra.

## Issue Type
<!-- delete options below as required -->
- Bug
- Document
- Enhancement

## Checklist
- [ ] I have read the [CONTRIBUTING.md]() -->
- [ ] I have added docstrings to all methods
- [ ] I have added sufficient comments to all lines
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no pep8 errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
