### PR TITLE
Raise warning when particle arrays empty and setting stars or gas to none

### DIFF
--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -191,6 +191,8 @@ class Galaxy(BaseGalaxy):
                 Star particle metallicity (total metal fraction)
             stars (stars particle object)
                 A pre-existing stars particle object to use. Defaults to None.
+            verbose (bool)
+                If True, print warnings and information messages.
             **kwargs
                 Arbitrary keyword arguments.
 
@@ -209,9 +211,9 @@ class Galaxy(BaseGalaxy):
             ):
                 if verbose:
                     print(
-                        ("In `load_stars`: one of either `initial_masses`"
+                        "In `load_stars`: one of either `initial_masses`"
                         ", `ages` or `metallicities` is not provided, setting "
-                        "`stars` object to `None`")
+                        "`stars` object to `None`"
                     )
                 self.stars = None
                 return None
@@ -227,7 +229,14 @@ class Galaxy(BaseGalaxy):
         self.stars.redshift = self.redshift
         self.stars.centre = self.centre
 
-    def load_gas(self, masses=None, metallicities=None, gas=None, **kwargs):
+    def load_gas(
+        self,
+        masses=None,
+        metallicities=None,
+        gas=None,
+        verbose=True,
+        **kwargs,
+    ):
         """
         Load arrays for gas particle properties into a `Gas` object,
         and attach to this galaxy object
@@ -239,6 +248,8 @@ class Galaxy(BaseGalaxy):
                 gas particle metallicity (total metal fraction)
             gas (gas particle object)
                 A pre-existing gas particle object to use. Defaults to None.
+            verbose (bool)
+                If True, print warnings and information messages.
         **kwargs
 
         Returns:
@@ -252,9 +263,9 @@ class Galaxy(BaseGalaxy):
             if (masses is None) | (metallicities is None):
                 if verbose:
                     print(
-                        ("In `load_stars`: one of either `masses`"
+                        "In `load_stars`: one of either `masses`"
                         " or `metallicities` is not provided, setting "
-                        "`gas` object to `None`")
+                        "`gas` object to `None`"
                     )
                 self.gas = None
                 return None

--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -175,6 +175,7 @@ class Galaxy(BaseGalaxy):
         ages=None,
         metallicities=None,
         stars=None,
+        verbose=True,
         **kwargs,
     ):
         """
@@ -206,6 +207,12 @@ class Galaxy(BaseGalaxy):
                 | (ages is None)
                 | (metallicities is None)
             ):
+                if verbose:
+                    print(
+                        ("In `load_stars`: one of either `initial_masses`"
+                        ", `ages` or `metallicities` is not provided, setting "
+                        "`stars` object to `None`")
+                    )
                 self.stars = None
                 return None
             else:
@@ -243,9 +250,17 @@ class Galaxy(BaseGalaxy):
         else:
             # If nothing has been provided, just set to None and return
             if (masses is None) | (metallicities is None):
+                if verbose:
+                    print(
+                        ("In `load_stars`: one of either `masses`"
+                        " or `metallicities` is not provided, setting "
+                        "`gas` object to `None`")
+                    )
                 self.gas = None
                 return None
-            self.gas = Gas(masses, metallicities, **kwargs)
+            else:
+                # Create a new `gas` object from particle arrays
+                self.gas = Gas(masses, metallicities, **kwargs)
 
         self.calculate_integrated_gas_properties()
 


### PR DESCRIPTION
When loading stars or gas particles into a stars or gas component, previously if one of these arrays was not present (or spelled incorrectly) it would silently just return `None`. This adds an explicit warning, that can be disabled by setting verbosity to False.

## Issue Type
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
