### PR TITLE
moved verbose to init, added more warnings

### DIFF
--- a/docs/source/abundances.ipynb
+++ b/docs/source/abundances.ipynb
@@ -688,8 +688,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.10.11"
+   "pygments_lexer": "ipython3"
   },
   "vscode": {
    "interpreter": {

--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -56,6 +56,7 @@ class Galaxy(BaseGalaxy):
         black_holes=None,
         redshift=None,
         centre=None,
+        verbose=True
     ):
         """Initialise a particle based Galaxy with objects derived from
            Particles.
@@ -91,6 +92,7 @@ class Galaxy(BaseGalaxy):
 
         # Set the type of galaxy
         self.galaxy_type = "Particle"
+        self.verbose = verbose
 
         # Instantiate the parent (load stars and gas below)
         BaseGalaxy.__init__(
@@ -137,6 +139,20 @@ class Galaxy(BaseGalaxy):
                     np.sum(self.stars.ages * self.stars.current_masses)
                     / self.stellar_mass
                 )
+            else:
+                self.stellar_mass_weighted_age = None
+                if self.verbose:
+                    print(
+                        "Ages of stars not provided, "
+                        "setting stellar_mass_weighted_age to `None`"
+                    )
+        else:
+            self.stellar_mass_weighted_age = None
+            if self.verbose:
+                print(
+                    "Current mass of stars not provided, "
+                    "setting stellar_mass_weighted_age to `None`"
+                )
 
     def calculate_integrated_gas_properties(self):
         """
@@ -175,7 +191,6 @@ class Galaxy(BaseGalaxy):
         ages=None,
         metallicities=None,
         stars=None,
-        verbose=True,
         **kwargs,
     ):
         """
@@ -191,8 +206,6 @@ class Galaxy(BaseGalaxy):
                 Star particle metallicity (total metal fraction)
             stars (stars particle object)
                 A pre-existing stars particle object to use. Defaults to None.
-            verbose (bool)
-                If True, print warnings and information messages.
             **kwargs
                 Arbitrary keyword arguments.
 
@@ -209,7 +222,7 @@ class Galaxy(BaseGalaxy):
                 | (ages is None)
                 | (metallicities is None)
             ):
-                if verbose:
+                if self.verbose:
                     print(
                         "In `load_stars`: one of either `initial_masses`"
                         ", `ages` or `metallicities` is not provided, setting "
@@ -234,7 +247,6 @@ class Galaxy(BaseGalaxy):
         masses=None,
         metallicities=None,
         gas=None,
-        verbose=True,
         **kwargs,
     ):
         """
@@ -248,8 +260,6 @@ class Galaxy(BaseGalaxy):
                 gas particle metallicity (total metal fraction)
             gas (gas particle object)
                 A pre-existing gas particle object to use. Defaults to None.
-            verbose (bool)
-                If True, print warnings and information messages.
         **kwargs
 
         Returns:
@@ -261,7 +271,7 @@ class Galaxy(BaseGalaxy):
         else:
             # If nothing has been provided, just set to None and return
             if (masses is None) | (metallicities is None):
-                if verbose:
+                if self.verbose:
                     print(
                         "In `load_stars`: one of either `masses`"
                         " or `metallicities` is not provided, setting "

--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -56,7 +56,7 @@ class Galaxy(BaseGalaxy):
         black_holes=None,
         redshift=None,
         centre=None,
-        verbose=True
+        verbose=True,
     ):
         """Initialise a particle based Galaxy with objects derived from
            Particles.

--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -168,6 +168,13 @@ class Galaxy(BaseGalaxy):
                 np.sum(self.gas.masses * self.gas.metallicities)
                 / self.gas_mass
             )
+        else:
+            self.mass_weighted_gas_metallicity = None
+            if self.verbose:
+                print(
+                    "Mass of gas particles not provided, "
+                    "setting mass_weighted_gas_metallicity to `None`"
+                )
 
         if self.gas.star_forming is not None:
             mask = self.gas.star_forming
@@ -183,6 +190,14 @@ class Galaxy(BaseGalaxy):
                         self.gas.masses[mask] * self.gas.metallicities[mask]
                     )
                     / self.sf_gas_mass
+                )
+        else:
+            self.sf_gas_mass = None
+            self.sf_gas_metallicity = None
+            if self.verbose:
+                print(
+                    "Star forming gas particle mask not provided, "
+                    "setting sf_gas_mass and sf_gas_metallicity to `None`"
                 )
 
     def load_stars(


### PR DESCRIPTION
## Issue Type
- Enhancement

Related to #619, moved the verbose to init so user can suppress warnings on galaxy functions. Added warning to calculated_integrated_stellar_properties as that is used to calculte DTM ratios if using the L-Galaxy formula, and setting quantities to None. Also added warnings to calculate_integrated_gas_properties calculations and setting quantities to None.

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->

