### PR TITLE
Simplifies `Filter.apply_filter` slightly

### DIFF
--- a/src/synthesizer/filters.py
+++ b/src/synthesizer/filters.py
@@ -1481,24 +1481,10 @@ class Filter:
             # We haven't been handed anything, use the filters frequency array
             nu = self._nu
 
-        # Ok, we have frequencies but they might be shifted. Calculate the
-        # redshift from the filter frequencies which are by definition in the
-        # rest frame.
-        # (This assumes the wavelength arrays match which SHOULD be guaranteed)
-        redshift = self._nu / nu - 1
-
-        # Be safe, if redshift is negative something horrid happened
-        if redshift < 0:
-            raise exceptions.InconsistentWavelengths(
-                "The provided wavelength array does not match the filter "
-                "wavelength array (we found a negative redshift)."
-            )
-
         # Interpolate the transmission curve onto the provided frequencies
-        # including any redshift
         func = interp1d(
-            self._nu * (1 + redshift),
-            self.t,
+            self._original_nu,
+            self.original_t,
             kind="linear",
             bounds_error=False,
         )

--- a/src/synthesizer/filters.py
+++ b/src/synthesizer/filters.py
@@ -1462,13 +1462,18 @@ class Filter:
         xs = None
         original_xs = None
 
-        # If we haven't been handed anything we'll use the filter's frequencies
+        # Get the right x array to integrate over
         if lam is None and nu is None:
+            # If we haven't been handed anything we'll use the filter's
+            # frequencies
+            #
             # Use the filters frequency array
             xs = self._nu
             original_xs = self._original_nu
 
         elif lam is not None:
+            # If we have lams we are intergrating over llam or flam
+
             # Ensure the passed wavelengths have units
             if not isinstance(lam, unyt_array):
                 lam *= Angstrom
@@ -1476,7 +1481,10 @@ class Filter:
             # Use the passed wavelength and original lam
             xs = lam.to(Angstrom).value
             original_xs = self._original_lam
+
         elif nu is not None:
+            # If we've been handed nu we are integrating over lnu or fnu
+
             # Ensure the passed frequencies have units
             if not isinstance(nu, unyt_array):
                 nu *= Hz
@@ -1484,6 +1492,7 @@ class Filter:
             # Use the passed frequency and original frequency
             xs = nu.to(Hz).value
             original_xs = self._original_nu
+
         else:
             # If both have been handed then frequencies take precedence
             if verbose:
@@ -1517,7 +1526,7 @@ class Filter:
         xs_in_band = xs[in_band]
         t_in_band = t[in_band]
 
-        # Multiply the IFU by the filter transmission curve
+        # Multiply the array by the filter transmission curve
         transmission = arr_in_band * t_in_band
 
         # Sum over the final axis to "collect" transmission in this filer

--- a/src/synthesizer/filters.py
+++ b/src/synthesizer/filters.py
@@ -1423,7 +1423,9 @@ class Filter:
         verbose=True,
     ):
         """
-        Apply this filter's transmission curve to an arbitrary dimensioned
+        Apply the transmission curve to any array.
+
+        Applies this filter's transmission curve to an arbitrary dimensioned
         array returning the sum of the array convolved with the filter
         transmission curve along the wavelength axis (final axis).
 
@@ -1466,7 +1468,7 @@ class Filter:
         if lam is None and nu is None:
             # If we haven't been handed anything we'll use the filter's
             # frequencies
-            #
+
             # Use the filters frequency array
             xs = self._nu
             original_xs = self._original_nu

--- a/src/synthesizer/filters.py
+++ b/src/synthesizer/filters.py
@@ -1521,7 +1521,8 @@ class Filter:
         if arr.shape[-1] != t.shape[0]:
             raise exceptions.InconsistentArguments(
                 "The shape of the transmission curve and the final axis of "
-                "the array to be convolved do not match."
+                "the array to be convolved do not match. "
+                f"(arr.shape={arr.shape}, transmission.shape={t.shape})"
             )
 
         # Store this observed frame transmission

--- a/src/synthesizer/filters.py
+++ b/src/synthesizer/filters.py
@@ -1432,7 +1432,7 @@ class Filter:
         If no wavelength or frequency array is provided then the filters rest
         frame frequency is assumed.
 
-        To apply to llam of flam wavelengths must be provided. To apply to
+        To apply to llam or flam, wavelengths must be provided. To apply to
         lnu or fnu frequencies must be provided.
 
         Args:

--- a/src/synthesizer/filters.py
+++ b/src/synthesizer/filters.py
@@ -1517,6 +1517,13 @@ class Filter:
         )
         t = func(xs)
 
+        # Ensure the xs array and arr are a compatible shape
+        if arr.shape[-1] != t.shape[0]:
+            raise exceptions.InconsistentArguments(
+                "The shape of the transmission curve and the final axis of "
+                "the array to be convolved do not match."
+            )
+
         # Store this observed frame transmission
         self._shifted_t = t
 

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -626,7 +626,7 @@ class Stars(StarsComponent):
 
         # Calculate the current luminosity in scale_filter
         sed = self.spectra[spectra_type]
-        current_lum = scale_filter.apply_filter(sed.lnu)
+        current_lum = scale_filter.apply_filter(sed.lnu, nu=sed.nu)
 
         # Calculate the conversion ratio between the requested and current
         # luminosity


### PR DESCRIPTION
This PR refactors `Filter.apply_filter`. In essence the method is unchanged but is now a bit more robust. 

- Documentation has been improved.
- Can now integrate over `llam` or `flam` safely by passing `lam` to integrate over.
- Interpolation of the transmission curve onto the input x array is now done as standard (not just for observed arrays). This simplifies some of the logic but also makes the method safer since it will now correctly handles any input array.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
