### PR TITLE
Made sure Filters are loaded from a HDF5 file cleanly

### DIFF
--- a/src/synthesizer/filters.py
+++ b/src/synthesizer/filters.py
@@ -227,13 +227,12 @@ class FilterCollection:
 
     def _load_filters(self, path):
         """
-        Loads a `FilterCollection` from a HDF5 file.
+        Load a `FilterCollection` from a HDF5 file.
 
         Args:
             path (str)
                 The file path from which to load the `FilterCollection`.
         """
-
         # Open the HDF5 file
         hdf = h5py.File(path, "r")
 
@@ -257,73 +256,17 @@ class FilterCollection:
 
         # Loop over the groups and make the filters
         for filter_code in self.filter_codes:
-            # Open the filter group
-            f_grp = hdf[filter_code.replace("/", ".")]
-
-            # Get the filter type
-            filter_type = f_grp.attrs["filter_type"]
-
-            # For SVO filters we don't want to send a request to the
-            # database so instead instatiate it as a generic filter and
-            # overwrite some attributes after the fact
-            if filter_type == "SVO":
-                filt = Filter(
-                    filter_code,
-                    transmission=f_grp["Transmission"][:],
-                    new_lam=self.lam,
-                )
-
-                # Set the SVO specific attributes
-                filt.filter_type = filter_type
-                filt.svo_url = f_grp.attrs["svo_url"]
-                filt.observatory = f_grp.attrs["observatory"]
-                filt.instrument = f_grp.attrs["instrument"]
-                filt.filter_ = f_grp.attrs["filter_"]
-                filt.original_lam = unyt_array(
-                    f_grp["Original_Wavelength"][:], lam_units
-                )
-                filt.original_t = f_grp["Original_Transmission"][:]
-
-            elif filter_type == "TopHat":
-                # For a top hat filter we can pass the related parameters
-                # and build the filter as normal
-
-                # Set up key word params, we have to do this to handle to
-                # two methods for creating top hat filters
-                tophat_dict = {
-                    key: None
-                    for key in [
-                        "lam_min",
-                        "lam_max",
-                        "lam_eff",
-                        "lam_fwhm",
-                    ]
-                }
-
-                # Loop over f_grp keys and set those that exist
-                for key in f_grp.attrs.keys():
-                    if "lam" in key:
-                        tophat_dict[key] = unyt_quantity(
-                            f_grp.attrs[key],
-                            lam_units,
-                        )
-
-                # Create the filter
-                filt = Filter(filter_code, **tophat_dict)
-
-            else:
-                # For a generic filter just set the transmission and
-                # wavelengths
-                filt = Filter(
-                    filter_code,
-                    transmission=f_grp["Transmission"][:],
-                    new_lam=self.lam,
-                )
+            # Get the filter
+            filt = Filter(filter_code, hdf=hdf)
 
             # Store the created filter
             self.filters[filter_code] = filt
 
         hdf.close()
+
+        # We're done loading so lets merge the filters, if they need to be
+        # resampled they will be at the end of the __init__
+        self._merge_filter_lams()
 
     def _include_svo_filters(self, filter_codes):
         """
@@ -334,7 +277,6 @@ class FilterCollection:
                 A list of SVO filter codes, used to retrieve filter data from
                 the database.
         """
-
         # Loop over the given filter codes
         for f in filter_codes:
             # Get filter from SVO
@@ -360,7 +302,6 @@ class FilterCollection:
                                       "lam_max": <maximum_nonzero_wavelength>},
                                       ...}.
         """
-
         # Loop over the keys of the dictionary
         for key in tophat_dict:
             # Get this filter's properties
@@ -407,7 +348,6 @@ class FilterCollection:
                     {<filter_code1> : {"transmission": <transmission_array>}}.
                 For generic filters new_lam must be provided.
         """
-
         # Loop over the keys of the dictionary
         for key in generic_dict:
             # Get this filter's properties
@@ -430,7 +370,6 @@ class FilterCollection:
                 A list of SVO filter codes, used to retrieve filter data from
                 the database.
         """
-
         # Loop over the given filter codes
         for _filter in filters:
             # Store the filter and its code
@@ -1160,6 +1099,7 @@ class Filter:
         lam_eff=None,
         lam_fwhm=None,
         new_lam=None,
+        hdf=None,
     ):
         """
         Initialise a filter.
@@ -1183,6 +1123,9 @@ class Filter:
                 If a top hat filter: The FWHM of the filter curve.
             new_lam (array-like, float)
                 The wavelength array for which the transmission is defined.
+            hdf (h5py.Group)
+                The HDF5 root group of a HDF5 file from which to load the
+                filter.
         """
 
         # Metadata of this filter
@@ -1209,9 +1152,13 @@ class Filter:
         self.original_t = transmission
         self._shifted_t = None
 
+        # Are loading from a hdf5 group?
+        if hdf is not None:
+            self._load_filter_from_hdf5(hdf)
+
         # Is this a generic filter? (Everything other than the label is defined
         # above.)
-        if transmission is not None and new_lam is not None:
+        elif transmission is not None and new_lam is not None:
             self.filter_type = "Generic"
 
         # Is this a top hat filter?
@@ -1323,6 +1270,77 @@ class Filter:
             )
 
         return "\n".join(details)
+
+    def _load_filter_from_hdf5(self, hdf):
+        """
+        Load a filter from an HDF5 group.
+
+        Args:
+            hdf (h5py.Group)
+                The HDF5 root group containing the filter data.
+        """
+        # Get the wavelength units
+        lam_units = hdf["Header"].attrs["Wavelength_units"]
+
+        # Get the filter group
+        f_grp = hdf[self.filter_code.replace("/", ".")]
+
+        # Get the filter type
+        filter_type = f_grp.attrs["filter_type"]
+
+        # For SVO filters we don't want to send a request to the
+        # database so instead instatiate it as a generic filter and
+        # overwrite some attributes after the fact
+        if filter_type == "SVO":
+            # Set the SVO specific attributes
+            self.filter_type = filter_type
+            self.svo_url = f_grp.attrs["svo_url"]
+            self.observatory = f_grp.attrs["observatory"]
+            self.instrument = f_grp.attrs["instrument"]
+            self.filter_ = f_grp.attrs["filter_"]
+            self.original_lam = unyt_array(
+                f_grp["Original_Wavelength"][:], lam_units
+            )
+            self.original_t = f_grp["Original_Transmission"][:]
+            self.lam = hdf["Header"]["Wavelengths"] * lam_units
+            self.t = f_grp["Transmission"][:]
+
+        elif filter_type == "TopHat":
+            # For a top hat filter we can pass the related parameters
+            # and build the filter as normal
+
+            # Set up key word params, we have to do this to handle to
+            # two methods for creating top hat filters
+            tophat_dict = {
+                key: None
+                for key in [
+                    "lam_min",
+                    "lam_max",
+                    "lam_eff",
+                    "lam_fwhm",
+                ]
+            }
+
+            # Loop over f_grp keys and set those that exist
+            for key in f_grp.attrs.keys():
+                if "lam" in key:
+                    tophat_dict[key] = unyt_quantity(
+                        f_grp.attrs[key],
+                        lam_units,
+                    )
+
+            # Attach top hat properties
+            for key, value in tophat_dict.items():
+                setattr(self, key, value)
+
+            # Finally, construct the top hat filter
+            self.make_top_hat_filter()
+
+        else:
+            # For a generic filter just set the transmission and
+            # wavelengths
+            self.t = f_grp["Transmission"][:]
+            self.lam = hdf["Header"]["Wavelengths"] * lam_units
 
     def clip_transmission(self):
         """

--- a/src/synthesizer/filters.py
+++ b/src/synthesizer/filters.py
@@ -1302,7 +1302,7 @@ class Filter:
                 f_grp["Original_Wavelength"][:], lam_units
             )
             self.original_t = f_grp["Original_Transmission"][:]
-            self.lam = hdf["Header"]["Wavelengths"] * lam_units
+            self.lam = hdf["Header"]["Wavelengths"][:] * lam_units
             self.t = f_grp["Transmission"][:]
 
         elif filter_type == "TopHat":
@@ -1340,7 +1340,7 @@ class Filter:
             # For a generic filter just set the transmission and
             # wavelengths
             self.t = f_grp["Transmission"][:]
-            self.lam = hdf["Header"]["Wavelengths"] * lam_units
+            self.lam = hdf["Header"]["Wavelengths"][:] * lam_units
 
     def clip_transmission(self):
         """


### PR DESCRIPTION
@aswinpvijayan uncovered a bug when loading a `FilterCollection`. Previously when loading filters the logic was constructed in such a way that `original_nu` would be overwritten by a nu derived from `self.lam` instead of the true original wavelengths. This was only ever an issue when loading SVO filters and previously didn't matter until `apply_filter` was updated to be more robust and use the correct x-axis during interpolation ( in #629).

This PR moves the filter loading onto an individual `Filter` and thus removes an ambiguity in the logic and workflow of loading a `Filter`.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
