### PR TITLE
Moved `intergrate_particle_spectra` to component level

### DIFF
--- a/src/synthesizer/load_data/load_illustris.py
+++ b/src/synthesizer/load_data/load_illustris.py
@@ -72,23 +72,23 @@ def load_IllustrisTNG(
 
     # Get header information
     header = il.groupcat.loadHeader(directory, snap_number)
-    scale_factor = header['Time']
-    redshift = header['Redshift']
-    Om0 = header['Omega0']
-    h = header['HubbleParam']
+    scale_factor = header["Time"]
+    redshift = header["Redshift"]
+    Om0 = header["Omega0"]
+    h = header["HubbleParam"]
 
     if verbose:
         print("Loading subhalo catalogue...")
 
     # Load subhalo properties (positions and stellar masses)
-    fields = ['SubhaloMassType', 'SubhaloPos']
+    fields = ["SubhaloMassType", "SubhaloPos"]
     output = il.groupcat.loadSubhalos(directory, snap_number, fields=fields)
 
     # Perform stellar mass masking
-    stellar_mass = output['SubhaloMassType'][:, 4]
+    stellar_mass = output["SubhaloMassType"][:, 4]
     subhalo_mask = (stellar_mass * 1e10) > stellar_mass_limit
 
-    subhalo_pos = output['SubhaloPos'][subhalo_mask]
+    subhalo_pos = output["SubhaloPos"][subhalo_mask]
 
     if verbose:
         print(
@@ -102,13 +102,8 @@ def load_IllustrisTNG(
         print("Loading particle information...")
 
     for i, (idx, pos) in tqdm(
-        enumerate(
-            zip(
-                np.where(subhalo_mask)[0],
-                subhalo_pos
-            )
-        ),
-        total=np.sum(subhalo_mask)
+        enumerate(zip(np.where(subhalo_mask)[0], subhalo_pos)),
+        total=np.sum(subhalo_mask),
     ):
         galaxies[i] = Galaxy(verbose=False)
         galaxies[i].redshift = redshift
@@ -120,38 +115,37 @@ def load_IllustrisTNG(
         galaxies[i].centre = pos * kpc
 
         star_fields = [
-            'GFM_StellarFormationTime',
-            'Coordinates',
-            'Masses',
-            'GFM_InitialMass',
-            'GFM_Metallicity',
-            'SubfindHsml',
+            "GFM_StellarFormationTime",
+            "Coordinates",
+            "Masses",
+            "GFM_InitialMass",
+            "GFM_Metallicity",
+            "SubfindHsml",
         ]
         if metals:
-            star_fields.append('GFM_Metals')
+            star_fields.append("GFM_Metals")
 
         output = il.snapshot.loadSubhalo(
-            directory, snap_number, idx, 'stars', fields=star_fields
+            directory, snap_number, idx, "stars", fields=star_fields
         )
 
-        if output['count'] > 0:
-
+        if output["count"] > 0:
             # Mask for wind particles
-            mask = output['GFM_StellarFormationTime'] <= 0.0
+            mask = output["GFM_StellarFormationTime"] <= 0.0
 
             # filter particle arrays
-            imasses = output['GFM_InitialMass'][~mask]
-            form_time = output['GFM_StellarFormationTime'][~mask]
-            coods = output['Coordinates'][~mask]
-            metallicities = output['GFM_Metallicity'][~mask]
-            masses = output['Masses'][~mask]
-            hsml = output['SubfindHsml'][~mask]
+            imasses = output["GFM_InitialMass"][~mask]
+            form_time = output["GFM_StellarFormationTime"][~mask]
+            coods = output["Coordinates"][~mask]
+            metallicities = output["GFM_Metallicity"][~mask]
+            masses = output["Masses"][~mask]
+            hsml = output["SubfindHsml"][~mask]
 
             masses = (masses * 1e10) / h
             imasses = (imasses * 1e10) / h
 
             if metals:
-                _metals = output['GFM_Metals'][~mask]
+                _metals = output["GFM_Metals"][~mask]
                 s_oxygen = _metals[:, 4]
                 s_hydrogen = 1.0 - np.sum(_metals[:, 1:], axis=1)
             else:
@@ -186,23 +180,22 @@ def load_IllustrisTNG(
             )
 
         gas_fields = [
-            'StarFormationRate',
-            'Coordinates',
-            'Masses',
-            'GFM_Metallicity',
-            'SubfindHsml',
+            "StarFormationRate",
+            "Coordinates",
+            "Masses",
+            "GFM_Metallicity",
+            "SubfindHsml",
         ]
         output = il.snapshot.loadSubhalo(
-            directory, snap_number, idx, 'gas', fields=gas_fields
+            directory, snap_number, idx, "gas", fields=gas_fields
         )
 
-        if output['count'] > 0:
-
-            g_masses = output['Masses']
-            g_sfr = output['StarFormationRate']
-            g_coods = output['Coordinates']
-            g_hsml = output['SubfindHsml']
-            g_metals = output['GFM_Metallicity']
+        if output["count"] > 0:
+            g_masses = output["Masses"]
+            g_sfr = output["StarFormationRate"]
+            g_coods = output["Coordinates"]
+            g_hsml = output["SubfindHsml"]
+            g_metals = output["GFM_Metallicity"]
 
             g_masses = (g_masses * 1e10) / h
             star_forming = g_sfr > 0.0  # star forming gas particles

--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -25,7 +25,6 @@ from synthesizer.base_galaxy import BaseGalaxy
 from synthesizer.imaging import Image, ImageCollection, SpectralCube
 from synthesizer.parametric import Stars as ParametricStars
 from synthesizer.particle import Gas, Stars
-from synthesizer.sed import Sed
 from synthesizer.warnings import warn
 
 

--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -25,7 +25,6 @@ from synthesizer.base_galaxy import BaseGalaxy
 from synthesizer.imaging import Image, ImageCollection, SpectralCube
 from synthesizer.parametric import Stars as ParametricStars
 from synthesizer.particle import Gas, Stars
-from synthesizer.sed import Sed
 
 
 class Galaxy(BaseGalaxy):
@@ -472,27 +471,14 @@ class Galaxy(BaseGalaxy):
         )
 
     def integrate_particle_spectra(self):
-        """
-        Integrates all particle spectra on any attached components.
-        """
-
+        """Integrate all particle spectra on any attached components."""
         # Handle stellar spectra
         if self.stars is not None:
-            # Loop over stellar particle spectra
-            for key, sed in self.stars.particle_spectra.items():
-                self.stars.spectra[key] = Sed(
-                    sed.lam,
-                    np.sum(sed._lnu, axis=0),
-                )
+            self.stars.integrate_particle_spectra()
 
         # Handle black hole spectra
         if self.black_holes is not None:
-            # Loop over stellar particle spectra
-            for key, sed in self.black_holes.particle_spectra.items():
-                self.black_holes.spectra[key] = Sed(
-                    sed.lam,
-                    np.sum(sed._lnu, axis=0),
-                )
+            self.black_holes.integrate_particle_spectra()
 
         # Handle gas spectra
         if self.gas is not None:

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -227,7 +227,7 @@ class Particles:
 
         return self.particle_photo_fluxes
 
-    def integate_particle_spectra(self):
+    def intergate_particle_spectra(self):
         """
         Integrate any particle spectra to get integrated spectra.
 

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -227,7 +227,7 @@ class Particles:
 
         return self.particle_photo_fluxes
 
-    def intergate_particle_spectra(self):
+    def integrate_particle_spectra(self):
         """
         Integrate any particle spectra to get integrated spectra.
 

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -227,6 +227,18 @@ class Particles:
 
         return self.particle_photo_fluxes
 
+    def integate_particle_spectra(self):
+        """
+        Integrate any particle spectra to get integrated spectra.
+
+        This will take all spectra in self.particle_spectra and call the sum
+        method on them, populating self.spectra with the results.
+        """
+        # Loop over the particle spectra
+        for key, sed in self.particle_spectra.items():
+            # Sum the spectra
+            self.spectra[key] = sed.sum()
+
 
 class CoordinateGenerator:
     """

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -155,7 +155,7 @@ class Sed:
         # Check that the lnu array is multidimensional
         if len(self._lnu.shape) > 1:
             # Define the axes to sum over to give only the final axis
-            sum_over = tuple(range(1, len(self._lnu.shape)))
+            sum_over = tuple(range(0, len(self._lnu.shape) - 1))
 
             # Create a new sed object with the first Lnu dimension collapsed
             new_sed = Sed(self.lam, np.sum(self._lnu, axis=sum_over))

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -154,12 +154,15 @@ class Sed:
 
         # Check that the lnu array is multidimensional
         if len(self._lnu.shape) > 1:
+            # Define the axes to sum over to give only the final axis
+            sum_over = tuple(range(1, len(self._lnu.shape)))
+
             # Create a new sed object with the first Lnu dimension collapsed
-            new_sed = Sed(self.lam, np.sum(self._lnu, axis=0))
+            new_sed = Sed(self.lam, np.sum(self._lnu, axis=sum_over))
 
             # If fnu exists, sum that too
             if self.fnu is not None:
-                new_sed.fnu = np.sum(self.fnu, axis=0)
+                new_sed.fnu = np.sum(self.fnu, axis=sum_over)
                 new_sed.obsnu = self.obsnu
                 new_sed.obslam = self.obslam
                 new_sed.redshift = self.redshift


### PR DESCRIPTION
Supercedes #618.

This PR moves the method for integrating all particle spectra from solely on a galaxy to the components. This allows a user only working with components to quickly integrate all spectra. 

`Galaxy.integrate_particle_spectra` is now just a wrapper around the component versions.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
