### PR TITLE
Setting DTM=0.3 for None cases

### DIFF
--- a/src/synthesizer/extensions/los.c
+++ b/src/synthesizer/extensions/los.c
@@ -1,5 +1,5 @@
 /******************************************************************************
- * C extension to calculate line of sight metal surface densities for star
+ * C extension to calculate line of sight dust surface densities for star
 particles.
 /*****************************************************************************/
 #include <stdio.h>
@@ -47,7 +47,7 @@ struct cell {
 };
 
 /**
- * @brief Computes the line of sight metal surface densities when there are a
+ * @brief Computes the line of sight dust surface densities when there are a
  *        small number of gas particles. No point building a cell structure
  *        with all the overhead when looping is sub second!
  *
@@ -98,7 +98,7 @@ void low_mass_los_loop(const double *star_pos, const double *gas_pos, const doub
       int index = kdim * q;
       double kvalue = kernel[index];
 
-      /* Finally, compute the metal surface density itself. */
+      /* Finally, compute the dust surface density itself. */
       los_dustsds[istar] += dtm * mass * met / (sml * sml) * kvalue;
     }
   }
@@ -416,7 +416,7 @@ double calculate_los_recursive(struct cell *c,
       int index = kdim * q;
       double kvalue = kernel[index];
 
-      /* Finally, compute the metal surface density itself. */
+      /* Finally, compute the dust surface density itself. */
       los_dustsds += dtm * mass * met / (sml * sml) * kvalue;
       
     }
@@ -427,7 +427,7 @@ double calculate_los_recursive(struct cell *c,
 
 
 /**
- * @brief Computes the line of sight metal surface densities for each of the
+ * @brief Computes the line of sight dust surface densities for each of the
  *        stars passed to this function.
  *
  * @param 
@@ -599,7 +599,7 @@ PyObject *compute_dust_surface_dens(PyObject *self, PyObject *args) {
 /* Below is all the gubbins needed to make the module importable in Python. */
 static PyMethodDef LosMethods[] = {
   {"compute_dust_surface_dens", compute_dust_surface_dens, METH_VARARGS,
-   "Method for calculating line of sight metal surface densities."},
+   "Method for calculating line of sight dust surface densities."},
   {NULL, NULL, 0, NULL} 
 };
 
@@ -607,7 +607,7 @@ static PyMethodDef LosMethods[] = {
 static struct PyModuleDef moduledef = {
         PyModuleDef_HEAD_INIT,
         "los_dust_surface_dens",                                /* m_name */
-        "A module to calculate los metal surface densities",   /* m_doc */
+        "A module to calculate los dust surface densities",   /* m_doc */
         -1,                                                    /* m_size */
         LosMethods,                                            /* m_methods */
         NULL,                                                  /* m_reload */

--- a/src/synthesizer/particle/gas.py
+++ b/src/synthesizer/particle/gas.py
@@ -130,8 +130,12 @@ class Gas(Particles):
         # Set the smoothing lengths for these gas particles
         self.smoothing_lengths = smoothing_lengths
 
-        #
-        if (dust_to_metal_ratio is None) & (dust_masses is None):
+        # None metallicity warning already captured when loading gas
+        if (
+            (self.metallicities is not None)
+            & (dust_to_metal_ratio is None)
+            & (dust_masses is None)
+        ):
             warn(
                 "Neither dust mass nor dust to metal ratio "
                 "provided. Assuming dust to metal ratio = 0.3"


### PR DESCRIPTION
- Bug
Not necessarily a bug, just a logical choice of not setting a default DTM value when gas properties could be empty or None.
I have also modified los.c to state that we are calculating dust los surface density and not metal los surface density as stated before.

This closes issue #638 

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
