### PR TITLE
Fix dtype issue for age calculations

### DIFF
--- a/src/synthesizer/load_data/load_camels.py
+++ b/src/synthesizer/load_data/load_camels.py
@@ -1,6 +1,6 @@
 import h5py
 import numpy as np
-from astropy.cosmology import FlatLambdaCDM
+from astropy.cosmology import FlatLambdaCDM, Planck15
 from unyt import Msun, kpc, yr
 
 from synthesizer.load_data.utils import get_len
@@ -220,8 +220,8 @@ def load_CAMELS_IllustrisTNG(
         pos *= scale_factor
 
     # convert formation times to ages
-    cosmo = FlatLambdaCDM(H0=h * 100, Om0=Om0)
-    universe_age = cosmo.age(1.0 / scale_factor - 1)
+    cosmo = Planck15
+    universe_age = cosmo.age(redshift)
     _ages = cosmo.age(1.0 / form_time - 1)
     ages = (universe_age - _ages).value * 1e9  # yr
 
@@ -276,8 +276,8 @@ def load_CAMELS_Astrid(
     """
 
     with h5py.File(f"{_dir}/{snap_name}", "r") as hf:
-        redshift = hf["Header"].attrs["Redshift"]
-        scale_factor = hf["Header"].attrs["Time"][0]
+        redshift = hf["Header"].attrs["Redshift"].astype(np.float32)
+        scale_factor = hf["Header"].attrs["Time"][0].astype(np.float32)
         Om0 = hf["Header"].attrs["Omega0"][0]
         h = hf["Header"].attrs["HubbleParam"][0]
 
@@ -307,8 +307,8 @@ def load_CAMELS_Astrid(
     s_hydrogen = 1 - np.sum(_metals[:, 1:], axis=1)
 
     # convert formation times to ages
-    cosmo = FlatLambdaCDM(H0=h * 100, Om0=Om0)
-    universe_age = cosmo.age(1.0 / scale_factor - 1)
+    cosmo = Planck15
+    universe_age = cosmo.age(redshift)
     _ages = cosmo.age(1.0 / form_time - 1)
     ages = (universe_age - _ages).value * 1e9  # yr
 

--- a/src/synthesizer/load_data/load_camels.py
+++ b/src/synthesizer/load_data/load_camels.py
@@ -1,6 +1,6 @@
 import h5py
 import numpy as np
-from astropy.cosmology import FlatLambdaCDM, Planck15
+from astropy.cosmology import Planck15, Planck18
 from unyt import Msun, kpc, yr
 
 from synthesizer.load_data.utils import get_len
@@ -149,7 +149,6 @@ def load_CAMELS_IllustrisTNG(
     with h5py.File(f"{_dir}/{snap_name}", "r") as hf:
         scale_factor = hf["Header"].attrs["Time"]
         redshift = 1.0 / scale_factor - 1
-        Om0 = hf["Header"].attrs["Omega0"]
         h = hf["Header"].attrs["HubbleParam"]
 
         form_time = hf["PartType4/GFM_StellarFormationTime"][:]
@@ -278,7 +277,6 @@ def load_CAMELS_Astrid(
     with h5py.File(f"{_dir}/{snap_name}", "r") as hf:
         redshift = hf["Header"].attrs["Redshift"].astype(np.float32)
         scale_factor = hf["Header"].attrs["Time"][0].astype(np.float32)
-        Om0 = hf["Header"].attrs["Omega0"][0]
         h = hf["Header"].attrs["HubbleParam"][0]
 
         form_time = hf["PartType4/GFM_StellarFormationTime"][:]
@@ -307,7 +305,7 @@ def load_CAMELS_Astrid(
     s_hydrogen = 1 - np.sum(_metals[:, 1:], axis=1)
 
     # convert formation times to ages
-    cosmo = Planck15
+    cosmo = Planck18
     universe_age = cosmo.age(redshift)
     _ages = cosmo.age(1.0 / form_time - 1)
     ages = (universe_age - _ages).value * 1e9  # yr
@@ -377,7 +375,6 @@ def load_CAMELS_Simba(
     with h5py.File(f"{_dir}/{snap_name}", "r") as hf:
         redshift = hf["Header"].attrs["Redshift"]
         scale_factor = hf["Header"].attrs["Time"]
-        Om0 = hf["Header"].attrs["Omega0"]
         h = hf["Header"].attrs["HubbleParam"]
 
         form_time = hf["PartType4/StellarFormationTime"][:]
@@ -405,7 +402,7 @@ def load_CAMELS_Simba(
     metallicity = _metals[:, 0]
 
     # convert formation times to ages
-    cosmo = FlatLambdaCDM(H0=h * 100, Om0=Om0)
+    cosmo = Planck15
     universe_age = cosmo.age(1.0 / scale_factor - 1)
     _ages = cosmo.age(1.0 / form_time - 1)
     ages = (universe_age - _ages).value * 1e9  # yr

--- a/src/synthesizer/load_data/load_illustris.py
+++ b/src/synthesizer/load_data/load_illustris.py
@@ -74,7 +74,6 @@ def load_IllustrisTNG(
     header = il.groupcat.loadHeader(directory, snap_number)
     scale_factor = header["Time"].astype(np.float32)
     redshift = header["Redshift"].astype(np.float32)
-    Om0 = header["Omega0"]
     h = header["HubbleParam"]
 
     if verbose:

--- a/src/synthesizer/load_data/load_illustris.py
+++ b/src/synthesizer/load_data/load_illustris.py
@@ -1,5 +1,5 @@
 import numpy as np
-from astropy.cosmology import FlatLambdaCDM
+from astropy.cosmology import Planck15
 from tqdm import tqdm
 from unyt import Msun, kpc, yr
 
@@ -72,8 +72,8 @@ def load_IllustrisTNG(
 
     # Get header information
     header = il.groupcat.loadHeader(directory, snap_number)
-    scale_factor = header["Time"]
-    redshift = header["Redshift"]
+    scale_factor = header["Time"].astype(np.float32)
+    redshift = header["Redshift"].astype(np.float32)
     Om0 = header["Omega0"]
     h = header["HubbleParam"]
 
@@ -158,7 +158,7 @@ def load_IllustrisTNG(
                 hsml *= scale_factor
 
             # convert formation times to ages
-            cosmo = FlatLambdaCDM(H0=h * 100, Om0=Om0)
+            cosmo = Planck15
             universe_age = cosmo.age(1.0 / scale_factor - 1)
             _ages = cosmo.age(1.0 / form_time - 1)
             ages = (universe_age - _ages).value * 1e9  # yr


### PR DESCRIPTION
Bug identified by @aliceemaffs where negative age star particles started appearing for certain CAMELS LH set simulations. Narrowed this down to a peculiar bug where the scale factor / redshift in the header is a 64 bit float, but formation times in the particle arrays are stored as 32 bit floats. This led to rounding errors when using astropy to convert to ages for non-zero redshift snapshots.

This PR fixes this bug for the TNG and Simba CAMELS simulations, as well as the TNG load data module. It is unclear what other simulations might be affected by this issue. 

## Issue Type
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
