### PR TITLE
Los orientation

### DIFF
--- a/src/synthesizer/extensions/los.c
+++ b/src/synthesizer/extensions/los.c
@@ -77,7 +77,7 @@ void low_mass_los_loop(const double *star_pos, const double *gas_pos, const doub
       double met = gas_met[igas];
 
       /* Skip straight away if the gas particle is behind the star. */
-      if (gas_z > star_z)
+      if (gas_z < star_z)
         continue;
 
       /* Calculate the x and y separations. */
@@ -395,7 +395,7 @@ double calculate_los_recursive(struct cell *c,
       double met = gas_met[igas];
 
       /* Skip straight away if the gas particle is behind the star. */
-      if (gas_z > star_z)
+      if (gas_z < star_z)
         continue;
 
       /* Calculate the x and y separations. */

--- a/src/synthesizer/kernel_functions.py
+++ b/src/synthesizer/kernel_functions.py
@@ -21,7 +21,7 @@ class Kernel:
     line-of-sight.
     """
 
-    def __init__(self, name="sph_anarchy", binsize=1000):
+    def __init__(self, name="sph_anarchy", binsize=10000):
         self.name = name
         self.binsize = binsize
 


### PR DESCRIPTION
The current implementation of the los calculation is in the -z direction as opposed to +z, which was giving a different result from previous FLARES calculation. This is not necessarily an issue, but for consistency sake I have switched to the +z direction. 

Also increased the resolution of the default kernel from 1000 -> 10000 bins as we had in FLARES.

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->

