### PR TITLE
Removing automatic bolometric luminosity calculation

### DIFF
--- a/src/synthesizer/emission_models/agn/unified_agn.py
+++ b/src/synthesizer/emission_models/agn/unified_agn.py
@@ -39,6 +39,7 @@ def scale_by_incident_isotropic(emission, emitters, model):
     # Handle lines and spectra differently
     if isinstance(emission[list(emission.keys())[0]], Sed):
         # Get the isotropic bolometric luminosity
+        emission["disc_incident_isotropic"].measure_bolometric_luminosity()
         isotropic_bolo_lum = emission[
             "disc_incident_isotropic"
         ]._bolometric_luminosity

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -517,6 +517,10 @@ class Sed:
         """
         start = tic()
 
+        # Don't duplicate the calculation if we already have it
+        if self.bolometric_luminosity is not None:
+            return self.bolometric_luminosity
+
         # Calculate the bolometric luminosity
         # NOTE: the integration is done "backwards" when integrating over
         # frequency. It's faster to just multiply by -1 than to reverse the

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -118,7 +118,6 @@ class Sed:
         # lam.
         if lnu is None:
             self.lnu = np.zeros(self.lam.shape)
-            self.bolometric_luminosity = None
         else:
             if isinstance(lnu, (unyt_array, np.ndarray)):
                 self.lnu = lnu
@@ -132,8 +131,8 @@ class Sed:
                     )
                 )
 
-        # Measure bolometric luminosity
-        self.bolometric_luminosity = self.measure_bolometric_luminosity()
+        # Prepare for bolometric luminosity calculation
+        self.bolometric_luminosity = None
 
         # Redshift of the SED
         self.redshift = 0


### PR DESCRIPTION
When a `Sed` is instantiated it automatically calculates bolometric luminosity. For large N-dimensional `Seds` this is very expensive and in many cases pointless because bolometric luminosity will not be used downstream.

In fact, most places that needed bolometric luminosity already called the method to do, making this a pointless doubling of work!

This PR closes #657.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
