### PR TITLE
Added some extra defaults and controls to the installation process 

### DIFF
--- a/docs/source/advanced/config_options.rst
+++ b/docs/source/advanced/config_options.rst
@@ -9,6 +9,7 @@ Synthesizer uses C extensions for much of the heavy lifting done in the backgrou
 - ``ATOMIC_TIMINGS`` turns on low level timings for expensive computations. This is required to use time related profiling scripts. 
 - ``CFLAGS`` allows the user to override the flags passed to the C compiler. Simply pass your desired flags to this variable.
 - ``LDFLAGS`` allows the user to override the directories used during linking.
+- ``EXTRA_INCLUDES`` allows the user to provide any extra include directories that fail to be automatically picked up.
 
 These environment variables can either be defined globally or passed on the command line when invoking ``pip install``.
 To define them globally simply export them into your environment, e.g.

--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,6 @@ else:  # Unix-like systems (Linux)
     ]
     default_link_args = [
         "/usr/lib/",
-        "/usr/lib/x86_64-linux-gnu/",
         "/usr/lib64/",
     ]
     include_dirs = ["/usr/include"]

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ if sys.platform == "darwin":  # macOS
         "-ffast-math",
         "-g",
     ]
-    default_link_args = ["/usr/local/lib"]
+    default_link_args = ["-L/usr/local/lib"]
     include_dirs = ["/usr/local/include"]
 elif sys.platform == "win32":  # windows
     default_compile_flags = [
@@ -170,8 +170,8 @@ else:  # Unix-like systems (Linux)
         "-g",
     ]
     default_link_args = [
-        "/usr/lib/",
-        "/usr/lib64/",
+        "-L/usr/lib/",
+        "-L/usr/lib64/",
     ]
     include_dirs = ["/usr/include"]
 

--- a/setup.py
+++ b/setup.py
@@ -203,14 +203,12 @@ if RUTHLESS:
         default_compile_flags.append("-Wextra")
 
 # Get user specified flags
-compile_flags = CFLAGS.split()
-link_args = LDFLAGS.split()
+extra_compile_flags = CFLAGS.split()
+extra_link_args = LDFLAGS.split()
 
-# If no flags are specified, use the default flags
-if len(compile_flags) == 0:
-    compile_flags = default_compile_flags
-if len(link_args) == 0:
-    link_args = default_link_args
+# Set up the compile flags and link args we will use removing duplicates
+compile_flags = list(set(default_compile_flags + extra_compile_flags))
+link_args = list(set(default_link_args + extra_link_args))
 
 # Add preprocessor flags
 if WITH_DEBUGGING_CHECKS == "1":

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ if sys.platform == "darwin":  # macOS
         "-ffast-math",
         "-g",
     ]
-    default_link_args = []
+    default_link_args = ["/usr/local/lib"]
     include_dirs = ["/usr/local/include"]
 elif sys.platform == "win32":  # windows
     default_compile_flags = [
@@ -169,7 +169,11 @@ else:  # Unix-like systems (Linux)
         "-ffast-math",
         "-g",
     ]
-    default_link_args = []
+    default_link_args = [
+        "/usr/lib/",
+        "/usr/lib/x86_64-linux-gnu/",
+        "/usr/lib64/",
+    ]
     include_dirs = ["/usr/include"]
 
 # Add OpenMP flags if requested

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ def create_extension(
 # Get environment variables we'll need for optional features and flags
 CFLAGS = os.environ.get("CFLAGS", "")
 LDFLAGS = os.environ.get("LDFLAGS", "")
+INCLUDES = os.environ.get("EXTRA_INCLUDES", "")
 WITH_OPENMP = os.environ.get("WITH_OPENMP", "")
 WITH_DEBUGGING_CHECKS = "ENABLE_DEBUGGING_CHECKS" in os.environ
 RUTHLESS = "RUTHLESS" in os.environ
@@ -209,6 +210,9 @@ extra_link_args = LDFLAGS.split()
 # Set up the compile flags and link args we will use removing duplicates
 compile_flags = list(set(default_compile_flags + extra_compile_flags))
 link_args = list(set(default_link_args + extra_link_args))
+
+# Add the extra include directories
+include_dirs += INCLUDES.split()
 
 # Add preprocessor flags
 if WITH_DEBUGGING_CHECKS == "1":

--- a/setup.py
+++ b/setup.py
@@ -131,10 +131,11 @@ logger.info(
 # Log the system platform
 logger.info(f"### System platform: {sys.platform}")
 
-# Report the environment variables
+# Report the environment variable
 logger.info(f"### CFLAGS: {CFLAGS}")
 logger.info(f"### LDFLAGS: {LDFLAGS}")
 logger.info(f"### WITH_OPENMP: {WITH_OPENMP}")
+logger.info(f"### EXTRA_INCLUDES: {INCLUDES}")
 if WITH_DEBUGGING_CHECKS:
     logger.info(f"### WITH_DEBUGGING_CHECKS: {WITH_DEBUGGING_CHECKS}")
 
@@ -220,6 +221,10 @@ if WITH_DEBUGGING_CHECKS == "1":
 if ATOMIC_TIMING:
     compile_flags.append("-DATOMIC_TIMING")
 
+# Report the flags we will use
+logger.info(f"### Using compile flags: {compile_flags}")
+logger.info(f"### Using link args: {link_args}")
+logger.info(f"### Using include directories: {include_dirs}")
 
 # Define the extension modules
 extensions = [


### PR DESCRIPTION
Cosma's new OS gave rise to some installation issues when wanting to work with openMP. These are fixed by the introduction of `lib64` default library paths but I also added the ability to explicitly pass `include` directories.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
