### PR TITLE
Removed conflicting Quantites from an Sed

### DIFF
--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -75,8 +75,6 @@ class Sed:
     fnu = Quantity()
     obsnu = Quantity()
     obslam = Quantity()
-    luminosity = Quantity()
-    llam = Quantity()
     bolometric_luminosity = Quantity()
 
     def __init__(self, lam, lnu=None, description=None):


### PR DESCRIPTION
This PR simply removes the `Quantities` which conflicted with the property methods designed to reduce the footprint of an `Sed`. Since these property methods use `Quantities` in their calculation they are already guaranteed to return the correct units.

Closes #649 

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
