### PR TITLE
Improved the emission model docs to include emitter info and parameter overides

### DIFF
--- a/docs/source/emission_models/custom_models.ipynb
+++ b/docs/source/emission_models/custom_models.ipynb
@@ -10,8 +10,10 @@
     "\n",
     "In the sections below we will detail how to define each different type of emission operation, but there are a few arguments needed by an ``EmissionModel`` regardless of the operation:\n",
     "\n",
-    "- A **label** which identifies the model. These must be unique within a single emission model \"tree\".\n",
-    "- An emitter to act on. This is given by passing a string to the emitter argument. Currently the possible emitters are: ``\"stellar\"``, ``\"blackhole\"``, and ``\"galaxy\"``.\n"
+    "- A ***label*** which identifies the model. This is given by passing a string to the ``label`` argument. These must be unique within a single emission model \"tree\".\n",
+    "- An ***emitter*** to act on. This is given by passing a string to the ``emitter`` argument. Currently the possible emitters are: ``\"stellar\"``, ``\"blackhole\"``, and ``\"galaxy\"``.\n",
+    "\n",
+    "Before demonstrating anythign we first need to import the classes we'll need and set up a ``Grid`` (described [here](../grids/grids.rst))."
    ]
   },
   {
@@ -37,6 +39,90 @@
    "metadata": {},
    "source": [
     "\n",
+    "## Emitter specific models\n",
+    "\n",
+    "As well as the base `EmissionModel` classes there are 3 specialised model classes: `StellarEmissionModel`, `BlackHoleEmissionModel`, and `GalaxyEmissionModel`. These specialised classes are identical to the base `EmissionModel` class but automatically set the ``emitter`` argument to ``\"stellar\"``, ``\"blackhole\"``, and ``\"galaxy\"`` respectively.\n",
+    "\n",
+    "We'll cover the specifics of different operations below, but this means the following fake models:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transmitted = EmissionModel(\n",
+    "    \"transmitted\",\n",
+    "    grid=grid,\n",
+    "    extract=\"transmitted\",\n",
+    "    fesc=0.3,\n",
+    "    emitter=\"stellar\",\n",
+    ")\n",
+    "nlr = EmissionModel(\n",
+    "    \"nlr\",\n",
+    "    grid=grid,\n",
+    "    extract=\"nebular\",\n",
+    "    fesc=0.3,\n",
+    "    emitter=\"blackhole\",\n",
+    ")\n",
+    "total = EmissionModel(\n",
+    "    \"total\",\n",
+    "    combine=(transmitted, nlr),\n",
+    "    emitter=\"galaxy\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "are equivalent to:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from synthesizer.emission_models import (\n",
+    "    BlackHoleEmissionModel,\n",
+    "    GalaxyEmissionModel,\n",
+    "    StellarEmissionModel,\n",
+    ")\n",
+    "\n",
+    "transmitted = StellarEmissionModel(\n",
+    "    \"transmitted\",\n",
+    "    grid=grid,\n",
+    "    extract=\"transmitted\",\n",
+    "    fesc=0.3,\n",
+    ")\n",
+    "nlr = BlackHoleEmissionModel(\n",
+    "    \"nlr\",\n",
+    "    grid=grid,\n",
+    "    extract=\"nebular\",\n",
+    "    fesc=0.3,\n",
+    ")\n",
+    "total = GalaxyEmissionModel(\n",
+    "    \"total\",\n",
+    "    combine=(transmitted, nlr),\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "In the rest of this notebook we'll use these specialised classes rather than the base `EmissionModel`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
     "## Defining an extraction\n",
     "\n",
     "To define an extraction we simply need to pass a `Grid` to extract from and a key to extract (with the option of providing an escape fraction)."
@@ -48,8 +134,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "transmitted = EmissionModel(\n",
-    "    \"transmitted\", grid=grid, extract=\"transmitted\", fesc=0.3\n",
+    "transmitted = StellarEmissionModel(\n",
+    "    \"transmitted\",\n",
+    "    grid=grid,\n",
+    "    extract=\"transmitted\",\n",
+    "    fesc=0.3,\n",
     ")\n",
     "print(transmitted)"
    ]
@@ -70,7 +159,7 @@
    "outputs": [],
    "source": [
     "# Define models to combine\n",
-    "linecont = EmissionModel(\n",
+    "linecont = StellarEmissionModel(\n",
     "    \"linecont\",\n",
     "    grid=grid,\n",
     "    extract=\"linecont\",\n",
@@ -79,7 +168,7 @@
     "    mask_op=\"<\",\n",
     "    fesc=0.7,\n",
     ")\n",
-    "nebular_cont = EmissionModel(\n",
+    "nebular_cont = StellarEmissionModel(\n",
     "    \"nebular_continuum\",\n",
     "    grid=grid,\n",
     "    extract=\"nebular_continuum\",\n",
@@ -89,7 +178,7 @@
     ")\n",
     "\n",
     "# Define the combined model\n",
-    "nebular = EmissionModel(\"nebular\", combine=(linecont, nebular_cont))\n",
+    "nebular = StellarEmissionModel(\"nebular\", combine=(linecont, nebular_cont))\n",
     "print(nebular)"
    ]
   },
@@ -110,7 +199,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "attenuated = EmissionModel(\n",
+    "attenuated = StellarEmissionModel(\n",
     "    \"attenuated\",\n",
     "    dust_curve=PowerLaw(slope=-1),\n",
     "    apply_dust_to=nebular,\n",
@@ -136,7 +225,7 @@
    "source": [
     "from synthesizer.emission_models.dust.emission import Blackbody\n",
     "\n",
-    "bb_emission = EmissionModel(\n",
+    "bb_emission = StellarEmissionModel(\n",
     "    \"blackbody_emission\",\n",
     "    generator=Blackbody(50 * kelvin),\n",
     ")\n",
@@ -156,7 +245,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scaled_bb_emission = EmissionModel(\n",
+    "scaled_bb_emission = StellarEmissionModel(\n",
     "    \"blackbody_emission\",\n",
     "    generator=Blackbody(50 * kelvin),\n",
     "    lum_intrinsic_model=transmitted,\n",
@@ -177,7 +266,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dust_emission = EmissionModel(\n",
+    "dust_emission = GalaxyEmissionModel(\n",
     "    \"blackbody_emission\",\n",
     "    generator=Blackbody(50 * kelvin),\n",
     "    lum_intrinsic_model=transmitted,\n",
@@ -201,7 +290,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "masked_transmitted = EmissionModel(\n",
+    "masked_transmitted = StellarEmissionModel(\n",
     "    \"masked_transmitted\",\n",
     "    grid=grid,\n",
     "    extract=\"transmitted\",\n",
@@ -249,7 +338,7 @@
    "outputs": [],
    "source": [
     "# Define the combined model\n",
-    "nebular = EmissionModel(\n",
+    "nebular = StellarEmissionModel(\n",
     "    \"nebular\", combine=(linecont, nebular_cont), related_models=(transmitted)\n",
     ")\n",
     "print(nebular)"
@@ -277,7 +366,7 @@
     "# Get the NLR and BLR grids\n",
     "nlr_grid = Grid(\"test_grid_agn-nlr\", grid_dir=\"../../../tests/test_grid\")\n",
     "\n",
-    "nlr = EmissionModel(\n",
+    "nlr = BlackHoleEmissionModel(\n",
     "    label=\"nlr\",\n",
     "    extract=\"nebular\",\n",
     "    grid=nlr_grid,\n",
@@ -344,7 +433,7 @@
     "    return emission\n",
     "\n",
     "\n",
-    "nebular = EmissionModel(\n",
+    "nebular = StellarEmissionModel(\n",
     "    \"nebular\",\n",
     "    combine=(linecont, nebular_cont),\n",
     "    related_models=(transmitted),\n",
@@ -367,7 +456,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "throw_away = EmissionModel(\n",
+    "throw_away = StellarEmissionModel(\n",
     "    \"throw_away\",\n",
     "    combine=(linecont, nebular_cont),\n",
     "    save=False,\n",
@@ -380,8 +469,10 @@
    "source": [
     "## Putting it all together\n",
     "\n",
-    "In the example below we demonstrate how to construct a complex model.\n",
-    "We reconstruct the `TotalEmission` model with the [Charlot&Fall+2000](https://ui.adsabs.harvard.edu/abs/2000ApJ...539..718C/abstract) -- like attenuation operation explicitly."
+    "In the example below we demonstrate how to construct a complex model piece by piece. \n",
+    "This will construct the `TotalEmission` model with the [Charlot&Fall+2000](https://ui.adsabs.harvard.edu/abs/2000ApJ...539..718C/abstract) like attenuation operation explicitly.\n",
+    "\n",
+    "Here we'll use the base `EmissionModel` class to explictly show the setting of the `emitter` argument. Notice how we associate the dust emission and total emission on the galaxy rather than the stellar component."
    ]
   },
   {
@@ -469,12 +560,12 @@
     "    generator=Blackbody(temperature=100 * kelvin),\n",
     "    lum_intrinsic_model=reprocessed,\n",
     "    lum_attenuated_model=emergent[\"attenuated\"],\n",
-    "    emitter=\"stellar\",\n",
+    "    emitter=\"galaxy\",\n",
     ")\n",
     "\n",
     "# And bring everything together into the total emission\n",
     "total = EmissionModel(\n",
-    "    \"total\", combine=(emergent, dust_emission), emitter=\"stellar\"\n",
+    "    \"total\", combine=(emergent, dust_emission), emitter=\"galaxy\"\n",
     ")\n",
     "\n",
     "total.plot_emission_tree()\n",

--- a/docs/source/emission_models/custom_models.ipynb
+++ b/docs/source/emission_models/custom_models.ipynb
@@ -11,7 +11,7 @@
     "In the sections below we will detail how to define each different type of emission operation, but there are a few arguments needed by an ``EmissionModel`` regardless of the operation:\n",
     "\n",
     "- A ***label*** which identifies the model. This is given by passing a string to the ``label`` argument. These must be unique within a single emission model \"tree\".\n",
-    "- An ***emitter*** to act on. This is given by passing a string to the ``emitter`` argument. Currently the possible emitters are: ``\"stellar\"``, ``\"blackhole\"``, and ``\"galaxy\"``.\n",
+    "- An ***emitter*** to act on. This is given by passing a string to the ``emitter`` argument. Currently the possible emitters are: ``\"stellar\"``, ``\"blackhole\"``, and ``\"galaxy\"``. \n",
     "\n",
     "Before demonstrating anythign we first need to import the classes we'll need and set up a ``Grid`` (described [here](../grids/grids.rst))."
    ]
@@ -39,7 +39,15 @@
    "metadata": {},
    "source": [
     "\n",
-    "## Emitter specific models\n",
+    "## Emitters\n",
+    "\n",
+    "The emitter on a model defines: \n",
+    "\n",
+    "- Where any model independant attributes should be extracted from (e.g. ages and metallicites needed for stellar extractions).\n",
+    "- Where the resulting spectra/lines will be stored once generated. \n",
+    "- Where any model attributes set to attribute strings should be extracted from (e.g. optical depths when ``tau_v=\"tau_v\"``).\n",
+    "\n",
+    "`\"stellar\"` will cause the model to use a `Stars` object, `\"blackhole\"` will cause the model to use a `BlackHole/s` object, while `\"galaxy\"` will cause the model to use a `Galaxy` object. This mechanism is all performed behind the scenes, you should never have to interact directly with any of this beyond setting the emitter string on a model.\n",
     "\n",
     "As well as the base `EmissionModel` classes there are 3 specialised model classes: `StellarEmissionModel`, `BlackHoleEmissionModel`, and `GalaxyEmissionModel`. These specialised classes are identical to the base `EmissionModel` class but automatically set the ``emitter`` argument to ``\"stellar\"``, ``\"blackhole\"``, and ``\"galaxy\"`` respectively.\n",
     "\n",

--- a/docs/source/emission_models/custom_models.ipynb
+++ b/docs/source/emission_models/custom_models.ipynb
@@ -198,7 +198,7 @@
     "\n",
     "To define an attenuated emission model we need a dust curve, the model to apply the dust to, and an optical depth (once again along with a label).\n",
     "\n",
-    "Any property can also have strings passed instead of numbers. When a string is passed the spectra generator method will look for an attribute on an emitter using this string. This is only applicable for certain properties, e.g. `tau_v` and `fesc`."
+    "Some properties can also have strings passed instead of numbers. When a string is passed the spectra generator method will look for an attribute on an emitter using this string. This is only applicable for certain properties, e.g. `tau_v` and `fesc`."
    ]
   },
   {
@@ -212,6 +212,28 @@
     "    dust_curve=PowerLaw(slope=-1),\n",
     "    apply_dust_to=nebular,\n",
     "    tau_v=\"tau_v\",\n",
+    ")\n",
+    "print(attenuated)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The optical depth specifically (`tau_v`) can also take a tuple containing either strings or floats which will be combined into a single attenuation curve when used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "attenuated = StellarEmissionModel(\n",
+    "    \"attenuated\",\n",
+    "    dust_curve=PowerLaw(slope=-1),\n",
+    "    apply_dust_to=nebular,\n",
+    "    tau_v=(\"tau_v\", 0.33),\n",
     ")\n",
     "print(attenuated)"
    ]

--- a/docs/source/spectra/blackholes.ipynb
+++ b/docs/source/spectra/blackholes.ipynb
@@ -272,13 +272,81 @@
     "\n",
     "fig, ax = blackholes.plot_spectra(show=True, figsize=(6, 4))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Modifying `EmissionModel` parameters with `get_spectra`\n",
+    "\n",
+    "As well as modifying a model explicitly, it's also possible to overide the properties of a model at the point `get_spectra` is called. These modifications will not be remembered by the model afterwards. As it stands, this form of modification is supported for the `dust_curve`, `tau_v`, `covering_fraction` and `masks`.\n",
+    "\n",
+    "Here we'll demonstrate this by overiding the covering fractions to generate spectra for a range of `covering_fraction` values. This can either be done by passing a single number which will overide all covering fractions on every model (probably undesirable behaviour since this will set NLR and BLR covering fractions to be equal)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spectra = {}\n",
+    "for fesc in [0.1, 0.5, 0.9]:\n",
+    "    blackhole.get_spectra(dust_model, covering_fraction=fesc)\n",
+    "    spectra[r\"$f \" f\"=$ {fesc}\"] = blackhole.spectra[\"intrinsic\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or (more desirably) we can pass a dictionary mapping model labels to `fesc` values to target specific models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spectra = {}\n",
+    "for nlr_fesc in [0.1, 0.5, 0.9]:\n",
+    "    for blr_fesc in [0.1, 0.5, 0.9]:\n",
+    "        blackhole.get_spectra(\n",
+    "            dust_model,\n",
+    "            covering_fraction={\n",
+    "                \"disc_transmitted_nlr\": nlr_fesc,\n",
+    "                \"disc_transmitted_blr\": blr_fesc,\n",
+    "            },\n",
+    "        )\n",
+    "        spectra[\n",
+    "            r\"$f_\\mathrm{nlr} \"\n",
+    "            f\"=$ {nlr_fesc}, \"\n",
+    "            r\"$f_\\mathrm{blr} \"\n",
+    "            f\"=$ {blr_fesc},\"\n",
+    "        ] = blackhole.spectra[\"intrinsic\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To see the variation above we can pass the dictionary we populated with the varied spectra to the `plot_spectra` function (where the dictionary keys will be used as labels). \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from synthesizer.sed import plot_spectra\n",
+    "\n",
+    "plot_spectra(spectra, figsize=(8, 4))"
+   ]
   }
  ],
- "metadata": {
-  "language_info": {
-   "name": "python"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 2
 }

--- a/docs/source/spectra/galaxy.ipynb
+++ b/docs/source/spectra/galaxy.ipynb
@@ -259,6 +259,17 @@
    "source": [
     "galaxy.plot_observed_spectra(show=True, figsize=(8, 6))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Modifying `EmissionModel` parameters with `get_spectra`\n",
+    "\n",
+    "As well as modifying a model explicitly, it's also possible to overide the properties of a model at the point `get_spectra` is called. These modifications will not be remembered by the model afterwards. As it stands, this form of modification is supported for the `dust_curve`, `tau_v`, `fesc`, `covering_fraction` and `masks`.\n",
+    "\n",
+    "For more details on this see the [stars](stars.ipynb) and [blackhole](blackholes.ipynb) spectra docs where the modification is described and demonstrated in each context."
+   ]
   }
  ],
  "metadata": {},

--- a/docs/source/spectra/stars.ipynb
+++ b/docs/source/spectra/stars.ipynb
@@ -225,13 +225,69 @@
     "\n",
     "fig, ax = stars.plot_spectra(show=True, figsize=(6, 4))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Modifying `EmissionModel` parameters with `get_spectra`\n",
+    "\n",
+    "As well as modifying a model explicitly, it's also possible to overide the properties of a model at the point `get_spectra` is called. These modifications will not be remembered by the model afterwards. As it stands, this form of modifications is supported for the `dust_curve`, `tau_v`, `fesc` and `masks`.\n",
+    "\n",
+    "Here we'll demonstrate this by overiding the optical depths to generate spectra for a range of `tau_v` values. This can either be done by passing a single number which will overide all optical depths on every model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spectra = {}\n",
+    "for tau_v in [0.1, 0.5, 1.0]:\n",
+    "    stars.get_spectra(pacman, tau_v=tau_v)\n",
+    "    spectra[r\"$\\tau_v \" f\"= {tau_v}\"] = stars.spectra[\"attenuated\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or we can pass a dictionary mapping model labels to `tau_v` values to target specific models."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spectra = {}\n",
+    "for tau_v in [0.1, 0.5, 1.0]:\n",
+    "    stars.get_spectra(pacman, tau_v={\"attenuated\": tau_v})\n",
+    "    spectra[r\"$\\tau_v \" f\"=$ {tau_v}\"] = stars.spectra[\"attenuated\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To see the variation above we can pass the dictionary we populated with the varied spectra to the `plot_spectra` function (where the dictionary keys will be used as labels). "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from synthesizer.sed import plot_spectra\n",
+    "\n",
+    "plot_spectra(spectra, xlimits=(10**2.5, 10**5.5))"
+   ]
   }
  ],
- "metadata": {
-  "language_info": {
-   "name": "python"
-  }
- },
+ "metadata": {},
  "nbformat": 4,
  "nbformat_minor": 2
 }

--- a/src/synthesizer/emission_models/__init__.py
+++ b/src/synthesizer/emission_models/__init__.py
@@ -2,6 +2,7 @@ from synthesizer.emission_models.base_model import (
     EmissionModel,
     StellarEmissionModel,
     BlackHoleEmissionModel,
+    GalaxyEmissionModel,
 )
 from synthesizer.emission_models.models import (
     DustEmission,

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -2190,6 +2190,7 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
         dust_curves=None,
         tau_v=None,
         fesc=None,
+        covering_fraction=None,
         mask=None,
         verbose=True,
         lines=None,
@@ -2243,6 +2244,18 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                             {<label>: str(<attribute>)}
                       to use an attribute of the component as the escape
                       fraction.
+            covering_fraction (dict):
+                An overide to the emission model covering fraction. Either:
+                    - None, indicating the covering fraction defined on the
+                      emission model should be used.
+                    - A float to use as the covering fraction for all models.
+                    - A dictionary of the form:
+                            {<label>: float(<covering_fraction>)}
+                      to use a specific covering fraction with a particular
+                      model or
+                            {<label>: str(<attribute>)}
+                      to use an attribute of the component as the covering
+                      fraction.
             mask (dict):
                 An overide to the emission model mask. Either:
                     - None, indicating the mask defined on the emission model
@@ -2272,7 +2285,9 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
         emission_model = copy.copy(self)
 
         # Apply any overides we have
-        self._apply_overrides(emission_model, dust_curves, tau_v, fesc, mask)
+        self._apply_overrides(
+            emission_model, dust_curves, tau_v, fesc, covering_fraction, mask
+        )
 
         # If we haven't got a lines dictionary yet we'll make one
         if lines is None:

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -1864,18 +1864,34 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
         """
         # If we have dust curves to apply, apply them
         if dust_curves is not None:
-            for label, dust_curve in dust_curves.items():
-                emission_model._models[label]._dust_curve = dust_curve
+            if isinstance(dust_curves, dict):
+                for label, dust_curve in dust_curves.items():
+                    emission_model._models[label]._dust_curve = dust_curve
+            else:
+                for model in emission_model._models.values():
+                    model._dust_curve = dust_curves
 
         # If we have optical depths to apply, apply them
         if tau_v is not None:
-            for label, value in tau_v.items():
-                emission_model._models[label]._tau_v = value
+            if isinstance(tau_v, dict):
+                for label, value in tau_v.items():
+                    emission_model._models[label]._tau_v = (
+                        (value,)
+                        if isinstance(value, (float, "str"))
+                        else value
+                    )
+            else:
+                for model in emission_model._models.values():
+                    model._tau_v = (tau_v,)
 
         # If we have escape fractions to apply, apply them
         if fesc is not None:
-            for label, value in fesc.items():
-                emission_model._models[label]._fesc = value
+            if isinstance(fesc, dict):
+                for label, value in fesc.items():
+                    emission_model._models[label]._fesc = value
+            else:
+                for model in emission_model._models.values():
+                    model._fesc = fesc
 
         # If we have masks to apply, apply them
         if mask is not None:

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -1807,7 +1807,9 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
 
         return fig, ax
 
-    def _apply_overrides(self, emission_model, dust_curves, tau_v, fesc, mask):
+    def _apply_overrides(
+        self, emission_model, dust_curves, tau_v, fesc, covering_fraction, mask
+    ):
         """
         Apply overrides to an emission model copy.
 
@@ -1854,6 +1856,18 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                           {<label>: str(<attribute>)}
                       to use an attribute of the component as the escape
                       fraction.
+            covering_fraction (dict):
+                An overide to the emission model covering fraction. Either:
+                    - None, indicating the covering fraction defined on the
+                      emission model should be used.
+                    - A float to use as the covering fraction for all models.
+                    - A dictionary of the form:
+                          {<label>: float(<covering_fraction>)}
+                      to use a specific covering fraction with a particular
+                      model or
+                          {<label>: str(<attribute>)}
+                      to use an attribute of the component as the covering
+                      fraction.
             mask (dict):
                 An overide to the emission model mask. Either:
                     - None, indicating the mask defined on the emission model
@@ -1892,6 +1906,15 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
             else:
                 for model in emission_model._models.values():
                     model._fesc = fesc
+
+        # If we have covering fractions to apply, apply them
+        if covering_fraction is not None:
+            if isinstance(covering_fraction, dict):
+                for label, value in covering_fraction.items():
+                    emission_model._models[label]._covering_fraction = value
+            else:
+                for model in emission_model._models.values():
+                    model._covering_fraction = covering_fraction
 
         # If we have masks to apply, apply them
         if mask is not None:
@@ -2008,7 +2031,9 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                 )
 
         # Apply any overides we have
-        self._apply_overrides(emission_model, dust_curves, tau_v, fesc, mask)
+        self._apply_overrides(
+            emission_model, dust_curves, tau_v, fesc, covering_fraction, mask
+        )
 
         # Make a spectra dictionary if we haven't got one yet
         if spectra is None:

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -2413,9 +2413,8 @@ class GalaxyEmissionModel(EmissionModel):
         EmissionModel.__init__(self, *args, **kwargs)
         self._emitter = "galaxy"
 
-        # Ensure we are only combining
-        if not self._is_combining:
+        # Ensure we aren't extracting, this cannot be done for a galaxy.
+        if self._is_extracting:
             raise exceptions.InconsistentArguments(
-                "A GalaxyEmissionModel must be either combining or dust "
-                "attenuating."
+                "A GalaxyEmissionModel cannot be an extraction model."
             )

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -1449,8 +1449,9 @@ def plot_spectra(
 
         plt_spectra = getattr(sed, quantity_to_plot)
 
-        # Prettify the label
-        key = key.replace("_", " ").title()
+        # Prettify the label if not latex
+        if not any([c in key for c in ("$", "_")]):
+            key = key.replace("_", " ").title()
 
         # Plot this spectra
         ax.plot(lam, plt_spectra, lw=1, alpha=0.8, label=key)


### PR DESCRIPTION
The `EmissionModel` docs now discuss what the emitter argument is used for and demonstrates using the specialised `EmisisonModel` base classes for each emitter.

The docs also now demo using `get_spectra` to modify models for a single call. This is done specifically for optical depths on a stellar component and covering fractions on black holes although other possible modifications are discussed.

There's also a handful of very small fixes I came across in the process:
- `GalaxyEmissionModel` was missing from the `__init__.py` file.
- Latex legend labels weren't properly handled in `plot_spectra`.
- Covering fraction overriding wasn't fully implemented.
- Overides didn't actually handle the case where a float is passed, regardless of the fact the doc strings explicitly state they should be...

## Issue Type
<!-- delete options below as required -->
- Document

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
