### PR TITLE
Remove multiple returns for non-reprocessed grid in PacmanEmission

### DIFF
--- a/src/synthesizer/emission_models/stellar/pacman_model.py
+++ b/src/synthesizer/emission_models/stellar/pacman_model.py
@@ -155,7 +155,6 @@ class PacmanEmission(StellarEmissionModel):
         self.nebular = self._make_nebular()
         self.reprocessed = self._make_reprocessed()
         if not self.grid_reprocessed:
-            print("We should pass though here")
             self.intrinsic = self._make_intrinsic_no_reprocessing()
         else:
             self.intrinsic = self._make_intrinsic_reprocessed()

--- a/src/synthesizer/emission_models/stellar/pacman_model.py
+++ b/src/synthesizer/emission_models/stellar/pacman_model.py
@@ -194,7 +194,7 @@ class PacmanEmission(StellarEmissionModel):
         """
         # No spectra if grid hasn't been reprocessed
         if not self.reprocessed:
-            return None, None, None
+            return None
 
         return TransmittedEmission(
             grid=self._grid, label="transmitted", fesc=self._fesc
@@ -220,11 +220,11 @@ class PacmanEmission(StellarEmissionModel):
         """
         # No spectra if grid hasn't been reprocessed
         if not self.reprocessed:
-            return None, None, None
+            return None
 
         # No escaped emission if fesc is zero
         if self._fesc == 0.0:
-            return None, None, None
+            return None
 
         return EscapedEmission(
             grid=self._grid, label="escaped", fesc=self._fesc
@@ -233,7 +233,7 @@ class PacmanEmission(StellarEmissionModel):
     def _make_nebular(self):
         # No spectra if grid hasn't been reprocessed
         if not self.reprocessed:
-            return None, None, None
+            return None
 
         return NebularEmission(
             grid=self._grid,
@@ -245,7 +245,7 @@ class PacmanEmission(StellarEmissionModel):
     def _make_reprocessed(self):
         # No spectra if grid hasn't been reprocessed
         if not self.reprocessed:
-            return None, None, None
+            return None
 
         return StellarEmissionModel(
             label="reprocessed",

--- a/src/synthesizer/emission_models/stellar/pacman_model.py
+++ b/src/synthesizer/emission_models/stellar/pacman_model.py
@@ -146,7 +146,7 @@ class PacmanEmission(StellarEmissionModel):
         self._fesc_ly_alpha = fesc_ly_alpha
 
         # Are we using a grid with reprocessing?
-        self.reprocessed = grid.reprocessed
+        self.grid_reprocessed = grid.reprocessed
 
         # Make the child emission models
         self.incident = self._make_incident()
@@ -154,7 +154,8 @@ class PacmanEmission(StellarEmissionModel):
         self.escaped = self._make_escaped()  # only if fesc > 0.0
         self.nebular = self._make_nebular()
         self.reprocessed = self._make_reprocessed()
-        if not self.reprocessed:
+        if not self.grid_reprocessed:
+            print("We should pass though here")
             self.intrinsic = self._make_intrinsic_no_reprocessing()
         else:
             self.intrinsic = self._make_intrinsic_reprocessed()
@@ -193,7 +194,7 @@ class PacmanEmission(StellarEmissionModel):
                 - transmitted
         """
         # No spectra if grid hasn't been reprocessed
-        if not self.reprocessed:
+        if not self.grid_reprocessed:
             return None
 
         return TransmittedEmission(
@@ -219,7 +220,7 @@ class PacmanEmission(StellarEmissionModel):
                 - escaped
         """
         # No spectra if grid hasn't been reprocessed
-        if not self.reprocessed:
+        if not self.grid_reprocessed:
             return None
 
         # No escaped emission if fesc is zero
@@ -232,7 +233,7 @@ class PacmanEmission(StellarEmissionModel):
 
     def _make_nebular(self):
         # No spectra if grid hasn't been reprocessed
-        if not self.reprocessed:
+        if not self.grid_reprocessed:
             return None
 
         return NebularEmission(
@@ -244,7 +245,7 @@ class PacmanEmission(StellarEmissionModel):
 
     def _make_reprocessed(self):
         # No spectra if grid hasn't been reprocessed
-        if not self.reprocessed:
+        if not self.grid_reprocessed:
             return None
 
         return StellarEmissionModel(
@@ -558,7 +559,7 @@ class BimodalPacmanEmission(StellarEmissionModel):
         self._fesc_ly_alpha = fesc_ly_alpha
 
         # Are we using a grid with reprocessing?
-        self.reprocessed = grid.reprocessed
+        self.grid_reprocessed = grid.reprocessed
 
         # Make the child emission models
         (
@@ -586,7 +587,7 @@ class BimodalPacmanEmission(StellarEmissionModel):
             self.old_reprocessed,
             self.reprocessed,
         ) = self._make_reprocessed()
-        if not self.reprocessed:
+        if not self.grid_reprocessed:
             (
                 self.young_intrinsic,
                 self.old_intrinsic,
@@ -675,7 +676,7 @@ class BimodalPacmanEmission(StellarEmissionModel):
                 - transmitted
         """
         # No spectra if grid hasn't been reprocessed
-        if not self.reprocessed:
+        if not self.grid_reprocessed:
             return None, None, None
 
         young_transmitted = TransmittedEmission(
@@ -722,7 +723,7 @@ class BimodalPacmanEmission(StellarEmissionModel):
                 - escaped
         """
         # No spectra if grid hasn't been reprocessed
-        if not self.reprocessed:
+        if not self.grid_reprocessed:
             return None, None, None
 
         # No escaped emission if fesc is zero
@@ -754,7 +755,7 @@ class BimodalPacmanEmission(StellarEmissionModel):
 
     def _make_nebular(self):
         # No spectra if grid hasn't been reprocessed
-        if not self.reprocessed:
+        if not self.grid_reprocessed:
             return None, None, None
 
         # Get the line continuum emission
@@ -824,7 +825,7 @@ class BimodalPacmanEmission(StellarEmissionModel):
 
     def _make_reprocessed(self):
         # No spectra if grid hasn't been reprocessed
-        if not self.reprocessed:
+        if not self.grid_reprocessed:
             return None, None, None
 
         young_reprocessed = StellarEmissionModel(

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -315,8 +315,8 @@ class Grid:
         if not self.lines_available:
             if not self.reprocessed:
                 raise exceptions.GridError(
-                    "Grid hasn't been reprocessed with cloudy and has no"
-                    "lines. Either pass `read_lines=False` or load a grid"
+                    "Grid hasn't been reprocessed with cloudy and has no "
+                    "lines. Either pass `read_lines=False` or load a grid "
                     "which has been run through cloudy."
                 )
 


### PR DESCRIPTION
`PacmanEmission` when provided a non reprocessed grid produced errors since the models that don't exist for a cloudy free grid were set erroneously to multiple `Nones`. However, the code should never have been able to get to this point. Turns out bad attribute naming meant the grid reprocessed flag got over written 😅 all fixed now.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
