### PR TITLE
Added a method to explicitly list spectra to save

### DIFF
--- a/docs/source/spectra/galaxy.ipynb
+++ b/docs/source/spectra/galaxy.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Galaxy Spectra\n",
     "\n",
-    "Unlike component spectra, galaxy level spectra are by definition integrated. These spectra can only be combinations of component spectra. To see how to define emission models for galaxy level spectra see the [combined emission](../emission_models/combined_models.ipynb) docs. Here we will demonstrate the usage of a combined model to generate spectra for a galaxy."
+    "Unlike component spectra, galaxy level spectra are by definition integrated. These spectra can only be combinations of component spectra. To see how to define emission models for galaxy level spectra see the [combined emission](../emission_models/combined_models.ipynb) docs. Here we will demonstrate the usage of a combined model to generate spectra for a galaxy. First we define that combined model."
    ]
   },
   {
@@ -100,8 +100,22 @@
     "    combine=(gal_attenuated, gal_dust),\n",
     "    related_models=(gal_intrinsic,),\n",
     "    emitter=\"galaxy\",\n",
-    ")\n",
-    "\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This emission model is going to produce a lot of spectra. In reality we probably don't want to carry around all these spectra on a galaxy or its components. Instead we can select exactly which spectra we want to save. This can either be done by setting the save flag to `False` on selected models like below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Discard some spectra\n",
     "gal_total[\"young_linecont\"].set_save(False)\n",
     "gal_total[\"young_nebular_continuum\"].set_save(False)\n",
@@ -111,6 +125,25 @@
     "gal_total[\"disc_transmitted_blr\"].set_save(False)\n",
     "gal_total[\"young_attenuated_nebular\"].set_save(False)\n",
     "\n",
+    "gal_total.plot_emission_tree(figsize=(10, 6), fontsize=8)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But if we only want a handful of spectra saved this is pretty cumbersome. We can instead state exactly which spectra we want saved using the `save_spectra` method which takes an arbitrary number of emission model labels as arguments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gal_total.save_spectra(\n",
+    "    \"total\", \"dust_emission\", \"total_attenuated\", \"total_intrinsic\"\n",
+    ")\n",
     "gal_total.plot_emission_tree(figsize=(10, 6), fontsize=8)"
    ]
   },

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -1133,6 +1133,21 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
         # Unpack the model now we're done
         self.unpack_model()
 
+    def save_spectra(self, *args):
+        """
+        Set the save flag to True for the given spectra.
+
+        Args:
+            args (str):
+                The spectra to save.
+        """
+        # First set all models to not save
+        self.set_save(False, set_all=True)
+
+        # Now set the given spectra to save
+        for arg in args:
+            self[arg].set_save(True)
+
     def add_mask(self, attr, op, thresh, set_all=False):
         """
         Add a mask.

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -2059,6 +2059,15 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
         if spectra is None:
             spectra = {}
 
+        # We need to make sure the root is being saved, otherwise this is a bit
+        # nonsensical.
+        if not _is_related and not self.save:
+            raise exceptions.InconsistentArguments(
+                f"{self.label} is not being saved. There's no point in "
+                "generating at the root if they are not saved. Maybe you "
+                "want to use a child model you are saving instead?"
+            )
+
         # Perform all extractions
         spectra = self._extract_spectra(
             emission_model,
@@ -2321,6 +2330,15 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
         # If we haven't got a lines dictionary yet we'll make one
         if lines is None:
             lines = {}
+
+        # We need to make sure the root is being saved, otherwise this is a bit
+        # nonsensical.
+        if not _is_related and not self.save:
+            raise exceptions.InconsistentArguments(
+                f"{self.label} is not being saved. There's no point in "
+                "generating at the root if they are not saved. Maybe you "
+                "want to use a child model you are saving instead?"
+            )
 
         # Perform all extractions
         lines = self._extract_lines(


### PR DESCRIPTION
Making it easier to control which spectra to save when the number of spectra is large.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
