### PR TITLE
BUGFIX: Fixed a bad error in line attenuation

### DIFF
--- a/src/synthesizer/line.py
+++ b/src/synthesizer/line.py
@@ -869,7 +869,7 @@ class Line:
         """
         # Ensure the mask is compatible with the spectra
         if mask is not None:
-            if self._luminosity.ndim < 2:
+            if self._luminosity.ndim < 1:
                 raise exceptions.InconsistentArguments(
                     "Masks are only applicable for Lines containing "
                     "multiple elements"
@@ -882,7 +882,7 @@ class Line:
 
         # If tau_v is an array it needs to match the spectra shape
         if isinstance(tau_v, np.ndarray):
-            if self._luminosity.ndim < 2:
+            if self._luminosity.ndim < 1:
                 raise exceptions.InconsistentArguments(
                     "Arrays of tau_v values are only applicable for Lines"
                     " containing multiple elements"


### PR DESCRIPTION
A bad error in attenuation checked the dimension of `line.luminosity` but erroneously tested this against a 2 (applicable for spectra) instead of a 1. This is now fixed.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
