### PR TITLE
Removing passing a `FilterCollection` to a `Grid` to limit wavelengths.

### DIFF
--- a/docs/source/grids/grids_example.ipynb
+++ b/docs/source/grids/grids_example.ipynb
@@ -105,14 +105,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ab95e88f",
-   "metadata": {},
-   "source": [
-    "You can also pass a `FilterCollection` to isolate the grid to the filter curves you care about. For more details see the the [filter docs](../filters/filters.rst)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "ae701e97-14bb-4abc-95ad-782751c5259f",
    "metadata": {},
    "source": [
@@ -278,44 +270,6 @@
     "\n",
     "# Measure the balmer break for all spectra in the grid (limiting the output)\n",
     "sed.measure_balmer_break()[5:10, 5:10]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4c159d2a",
-   "metadata": {},
-   "source": [
-    "## Unifying a `Grid` with a `FilterCollection`\n",
-    "\n",
-    "It's important when working with a `Grid` and any `Filter` objects (see the filter [docs](../filters/filters.rst)) to have a single wavelength array shared between the two to ensure filter transmission curves are applied correctly. Additionally, when using a fixed set of filters, limiting a `Grid`'s spectral range to that of the filters in question can drastically reduce the memory footprint of a calculation by avoiding carrying around wavelength elements that are not required.\n",
-    "\n",
-    "To enable this a `Grid` provides the `unify_with_filters` method. This method will take a `FilterCollection` as an argument and interpolate the `Grid` spectra onto the filters' wavelength array. You can also initialise a `Grid` by passing the filter collection via the `filters` keyword argument at instantiation.\n",
-    "\n",
-    "We demonstrate this below using a set of `UVJ` filters. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8ab7e7b1",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from synthesizer.filters import UVJ\n",
-    "\n",
-    "# Get the filter collection\n",
-    "fc = UVJ()\n",
-    "\n",
-    "print(\"Shape before:\", grid.spectra[\"incident\"].shape)\n",
-    "\n",
-    "# Unify the grid with this filter collection\n",
-    "grid.unify_with_filters(fc)\n",
-    "\n",
-    "print(\"Shape after:\", grid.spectra[\"incident\"].shape)\n",
-    "\n",
-    "# Or you can get the grid interpolated onto the filter wavelength\n",
-    "# at the point of initialisation\n",
-    "grid = Grid(grid_name, grid_dir=grid_dir, filters=fc)"
    ]
   }
  ],

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -106,7 +106,6 @@ class Grid:
         read_spectra=True,
         read_lines=True,
         new_lam=None,
-        filters=None,
         lam_lims=(),
     ):
         """
@@ -130,14 +129,10 @@ class Grid:
             new_lam (array-like, float)
                 An optional user defined wavelength array the spectra will be
                 interpolated onto, see Grid.interp_spectra.
-            filters (FilterCollection)
-                An optional FilterCollection object to unify the grids
-                wavelength grid with. If provided, this will override new_lam
-                whether passed or not.
             lam_lims (tuple, float)
                 A tuple of the lower and upper wavelength limits to truncate
-                the grid to (i.e. (lower_lam, upper_lam)). If new_lam or
-                filters are provided these limits will be ignored.
+                the grid to (i.e. (lower_lam, upper_lam)). If new_lam is
+                provided these limits will be ignored.
         """
         # Get the grid file path data
         self.grid_dir = ""
@@ -183,10 +178,10 @@ class Grid:
             self.lines = None
             self.available_lines = []
 
-        # Prepare the wavelength axis (if new_lam, lam_lims and filters are
+        # Prepare the wavelength axis (if new_lam and lam_lims are
         # all None, this will do nothing, leaving the grid's wavelength array
         # as it is in the HDF5 file)
-        self._prepare_lam_axis(new_lam, filters, lam_lims)
+        self._prepare_lam_axis(new_lam, lam_lims)
 
     def _parse_grid_path(self, grid_dir, grid_name):
         """Parse the grid path and set the grid directory and filename."""
@@ -360,23 +355,19 @@ class Grid:
     def _prepare_lam_axis(
         self,
         new_lam,
-        filters,
         lam_lims,
     ):
         """
         Modify the grid wavelength axis to adhere to user defined wavelengths.
 
-        This method will do nothing if the user has not provided new_lam,
-        filters, or lam_lims.
+        This method will do nothing if the user has not provided new_lam
+        or lam_lims.
 
         If the user has passed any of these the wavelength array will be
         limited and/or interpolated to match the user's input.
 
         - If new_lam is provided, the spectra will be interpolated onto this
           array.
-        - If filters are provided, the spectra will be limited wavelengths
-          with non-zero transmission and the filters will be interpolated
-          onto the grid's wavelength array in this non-zero range.
         - If lam_lims are provided, the grid will be truncated to these
           limits.
 
@@ -384,24 +375,21 @@ class Grid:
             new_lam (array-like, float)
                 An optional user defined wavelength array the spectra will be
                 interpolated onto.
-            filters (FilterCollection)
-                An optional FilterCollection object to unify the grids
-                wavelength grid with.
             lam_lims (tuple, float)
                 A tuple of the lower and upper wavelength limits to truncate
                 the grid to (i.e. (lower_lam, upper_lam)).
         """
-        # If we have both new_lam (or filters) and wavelength limits
+        # If we have both new_lam and wavelength limits
         # the limits become meaningless tell the user so.
-        if len(lam_lims) > 0 and (new_lam is not None or filters is not None):
+        if len(lam_lims) > 0 and (new_lam is not None):
             warn(
-                "Passing new_lam or filters and lam_lims is contradictory, "
+                "Passing new_lam and lam_lims is contradictory, "
                 "lam_lims will be ignored."
             )
 
         # Has a new wavelength grid been passed to interpolate
         # the spectra onto?
-        if new_lam is not None and filters is None:
+        if new_lam is not None:
             # Double check we aren't being asked to do something impossible.
             if self.spectra is None:
                 raise exceptions.InconsistentArguments(
@@ -412,28 +400,8 @@ class Grid:
             # Interpolate the spectra grid
             self.interp_spectra(new_lam)
 
-        # Are we unifying with a filter collection?
-        if filters is not None:
-            # Double check we aren't being asked to do something impossible.
-            if self.spectra is None:
-                raise exceptions.InconsistentArguments(
-                    "Can't interpolate spectra onto a FilterCollection "
-                    "wavelength array if no spectra have been read in! "
-                    "Set read_spectra=True."
-                )
-
-            # Warn the user the new_lam will be ignored
-            if new_lam is not None:
-                warn(
-                    "If a FilterCollection is defined alongside new_lam "
-                    "then FilterCollection.lam takes precedence and new_lam "
-                    "is ignored"
-                )
-
-            self.unify_with_filters(filters)
-
         # If we have been given wavelength limtis truncate the grid
-        if len(lam_lims) > 0 and filters is None and new_lam is None:
+        if len(lam_lims) > 0 and new_lam is None:
             self.truncate_grid_lam(*lam_lims)
 
     @property
@@ -936,33 +904,6 @@ class Grid:
             self.spectra[spectra_type] = self.spectra[spectra_type][
                 ..., okinds
             ]
-
-    def unify_with_filters(self, filters):
-        """
-        Unify the grid with a FilterCollection object.
-
-        This will:
-        - Find the Grid wavelengths at which transmission is non-zero.
-        - Limit the spectra and wavelengths to where transmision is non-zero.
-        - Interpolate the filters onto the Grid's new wavelength array.
-
-        Args:
-            filters (synthesizer.filter.FilterCollection)
-                The FilterCollection object to unify with this grid.
-        """
-        # Get the minimum and maximum wavelengths with non-zero transmission
-        min_lam, max_lam = filters.get_non_zero_lam_lims()
-
-        # Ensure we have at least 1 element with 0 transmission to solve
-        # any issues at the boundaries
-        min_lam -= 10 * angstrom
-        max_lam += 10 * angstrom
-
-        # Truncate the grid to these wavelength limits
-        self.truncate_grid_lam(min_lam, max_lam)
-
-        # Interpolate the filters onto this new wavelength range
-        filters.resample_filters(new_lam=self.lam)
 
     def animate_grid(
         self,


### PR DESCRIPTION
Removed the option to pass a FilterCollection to a grid that trancates the grid wavelength to the FilterCollection limits. This closes #681 
