### PR TITLE
Ensure masked lines remain the same shape.

### DIFF
--- a/src/synthesizer/parametric/blackholes.py
+++ b/src/synthesizer/parametric/blackholes.py
@@ -324,6 +324,164 @@ class BlackHole(BlackholesComponent):
             nthreads,
         )
 
+    def _prepare_line_args(
+        self,
+        grid,
+        line_id,
+        fesc,
+        mask,
+        grid_assignment_method,
+        nthreads,
+    ):
+        """
+        Generate the arguments for the C extension to compute lines.
+
+        Args:
+            grid (Grid)
+                The AGN grid object to extract lines from.
+            line_id (str)
+                The id of the line to extract.
+            fesc (float/array-like, float)
+                Fraction of stellar emission that escapes unattenuated from
+                the birth cloud. Can either be a single value
+                or an value per star (defaults to 0.0).
+            mask (bool)
+                A mask to be applied to the stars. Spectra will only be
+                computed and returned for stars with True in the mask.
+            grid_assignment_method (string)
+                The type of method used to assign particles to a SPS grid
+                point. Allowed methods are cic (cloud in cell) or nearest
+                grid point (ngp) or there uppercase equivalents (CIC, NGP).
+                Defaults to cic.
+            nthreads (int)
+                The number of threads to use in the C extension. If -1 then
+                all available threads are used.
+        """
+        # Which line region is this for?
+        if "nlr" in grid.grid_name:
+            line_region = "nlr"
+        elif "blr" in grid.grid_name:
+            line_region = "blr"
+        else:
+            raise exceptions.InconsistentArguments(
+                "Grid used for blackholes does not appear to be for"
+                " a line region (nlr or blr)."
+            )
+
+        # Handle the case where mask is None
+        if mask is None:
+            mask = np.ones(self.nbh, dtype=bool)
+
+        # Set up the inputs to the C function.
+        grid_props = [
+            np.ascontiguousarray(getattr(grid, axis), dtype=np.float64)
+            for axis in grid.axes
+        ]
+        props = []
+        for axis in grid.axes:
+            # Parameters that need to be provided from the black hole
+            prop = getattr(self, axis, None)
+
+            # We might be trying to get a Quanitity, in which case we need
+            # a leading _
+            if prop is None:
+                prop = getattr(self, f"_{axis}", None)
+
+            # We might be missing a line region suffix, if prop is
+            # None we need to try again with the suffix
+            if prop is None:
+                prop = getattr(self, f"{axis}_{line_region}", None)
+
+            # We could also be tripped up by plurals (TODO: stop this from
+            # happening!)
+            elif prop is None and axis == "mass":
+                prop = getattr(self, "masses", None)
+            elif prop is None and axis == "accretion_rate":
+                prop = getattr(self, "accretion_rates", None)
+            elif prop is None and axis == "metallicity":
+                prop = getattr(self, "metallicities", None)
+
+            # If we still have None here then our blackhole component doesn't
+            # have the required parameter
+            if prop is None:
+                raise exceptions.InconsistentArguments(
+                    f"Could not find {axis} or {axis}_{line_region} "
+                    f"on {type(self)}"
+                )
+
+            props.append(prop)
+
+        # Calculate npart from the mask
+        npart = np.sum(mask)
+
+        # Remove units from any unyt_arrays
+        props = [
+            prop.value if isinstance(prop, unyt_array) else prop
+            for prop in props
+        ]
+
+        # Ensure any parameters inherited from the emission model have
+        # as many values as particles
+        for ind, prop in enumerate(props):
+            if isinstance(prop, float):
+                props[ind] = np.full(self.nbh, prop)
+            elif prop.size == 1:
+                props[ind] = np.full(self.nbh, prop)
+
+        # Apply the mask to each property and make contiguous
+        props = [
+            np.ascontiguousarray(prop[mask], dtype=np.float64)
+            for prop in props
+        ]
+
+        # For black holes mass is a grid parameter but we still need to
+        # multiply by mass in the extensions so just multiply by 1
+        part_mass = np.ones(npart, dtype=np.float64)
+
+        # Make sure we set the number of particles to the size of the mask
+        npart = np.int32(np.sum(mask))
+
+        # Get the line grid and continuum
+        grid_line = np.ascontiguousarray(
+            grid.lines[line_id]["luminosity"],
+            np.float64,
+        )
+        grid_continuum = np.ascontiguousarray(
+            grid.lines[line_id]["continuum"],
+            np.float64,
+        )
+
+        # Get the grid dimensions after slicing what we need
+        grid_dims = np.zeros(len(grid_props) + 1, dtype=np.int32)
+        for ind, g in enumerate(grid_props):
+            grid_dims[ind] = len(g)
+
+        # If fesc isn't an array make it one
+        if not isinstance(fesc, np.ndarray):
+            fesc = np.ascontiguousarray(np.full(npart, fesc))
+
+        # Convert inputs to tuples
+        grid_props = tuple(grid_props)
+        part_props = tuple(props)
+
+        # If nthreads is -1 then use all available threads
+        if nthreads == -1:
+            nthreads = os.cpu_count()
+
+        return (
+            grid_line,
+            grid_continuum,
+            grid_props,
+            part_props,
+            part_mass,
+            fesc,
+            grid_dims,
+            len(grid_props),
+            npart,
+            grid_assignment_method,
+            nthreads,
+        )
+
     def __str__(self):
         """
         Return a string representation of the particle object.

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -24,6 +24,7 @@ from synthesizer.line import Line
 from synthesizer.particle.particles import Particles
 from synthesizer.units import Quantity
 from synthesizer.utils import TableFormatter, value_to_array
+from synthesizer.warnings import warn
 
 
 class BlackHoles(Particles, BlackholesComponent):
@@ -534,6 +535,23 @@ class BlackHoles(Particles, BlackholesComponent):
         # Ensure line_id is a string
         if not isinstance(line_id, str):
             raise exceptions.InconsistentArguments("line_id must be a string")
+
+        # Ensure and warn that the masking hasn't removed everything
+        if mask is not None and np.sum(mask) == 0:
+            warn("Age mask has filtered out all particles")
+
+            return Line(
+                *[
+                    Line(
+                        line_id=line_id_,
+                        wavelength=grid.lines[line_id_]["wavelength"]
+                        * angstrom,
+                        luminosity=np.zeros(self.nparticles) * erg / s,
+                        continuum=np.zeros(self.nparticles) * erg / s / Hz,
+                    )
+                    for line_id_ in line_id.split(",")
+                ]
+            )
 
         # Set up a list to hold each individual Line
         lines = []

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -16,10 +16,11 @@ Example usages:
 import os
 
 import numpy as np
-from unyt import cm, deg, km, rad, s, unyt_array
+from unyt import Hz, angstrom, cm, deg, erg, km, rad, s, unyt_array
 
 from synthesizer import exceptions
 from synthesizer.components import BlackholesComponent
+from synthesizer.line import Line
 from synthesizer.particle.particles import Particles
 from synthesizer.units import Quantity
 from synthesizer.utils import TableFormatter, value_to_array
@@ -481,6 +482,109 @@ class BlackHoles(Particles, BlackholesComponent):
         spec = np.zeros((self.nbh, masked_spec.shape[-1]))
         spec[mask] = masked_spec
         return spec
+
+    def generate_particle_line(
+        self,
+        grid,
+        line_id,
+        fesc,
+        mask=None,
+        method="cic",
+        nthreads=0,
+        verbose=False,
+    ):
+        """
+        Calculate rest frame line luminosity and continuum from an AGN Grid.
+
+        This is a flexible base method which extracts the rest frame line
+        luminosity of this blackhole population based on the
+        passed arguments and calculate the luminosity and continuum for
+        each individual particle.
+
+        Args:
+            grid (Grid):
+                A Grid object.
+            line_id (list/str):
+                A list of line_ids or a str denoting a single line.
+                Doublets can be specified as a nested list or using a
+                comma (e.g. 'OIII4363,OIII4959').
+            fesc (float/array-like, float)
+                Fraction of blackhole emission that escapes unattenuated from
+                the birth cloud. Can either be a single value
+                or an value per star (defaults to 0.0).
+            mask (array)
+                A mask to apply to the particles (only applicable to particle)
+            method (str)
+                The method to use for the interpolation. Options are:
+                'cic' - Cloud in cell
+                'ngp' - Nearest grid point
+            nthreads (int)
+                The number of threads to use in the C extension. If -1 then
+                all available threads are used.
+
+        Returns:
+            Line
+                An instance of Line contain this lines wavelenth, luminosity,
+                and continuum.
+        """
+        from synthesizer.extensions.particle_line import (
+            compute_particle_line,
+        )
+
+        # Ensure line_id is a string
+        if not isinstance(line_id, str):
+            raise exceptions.InconsistentArguments("line_id must be a string")
+
+        # Set up a list to hold each individual Line
+        lines = []
+
+        # Loop over the ids in this container
+        for line_id_ in line_id.split(","):
+            # Strip off any whitespace (can be left by split)
+            line_id_ = line_id_.strip()
+
+            # Get this line's wavelength
+            # TODO: The units here should be extracted from the grid but aren't
+            # yet stored.
+            lam = grid.lines[line_id_]["wavelength"] * angstrom
+
+            # Get the luminosity and continuum
+            _lum, _cont = compute_particle_line(
+                *self._prepare_line_args(
+                    grid,
+                    line_id_,
+                    fesc,
+                    mask=mask,
+                    grid_assignment_method=method,
+                    nthreads=nthreads,
+                )
+            )
+
+            # Account for the mask
+            if mask is not None:
+                lum = np.zeros(self.nparticles)
+                cont = np.zeros(self.nparticles)
+                lum[mask] = _lum
+                cont[mask] = _cont
+            else:
+                lum = _lum
+                cont = _cont
+
+            # Append this lines values to the containers
+            lines.append(
+                Line(
+                    line_id=line_id_,
+                    wavelength=lam,
+                    luminosity=lum * erg / s,
+                    continuum=cont * erg / s / Hz,
+                )
+            )
+
+        # Don't init another line if there was only 1 in the first place
+        if len(lines) == 1:
+            return lines[0]
+        else:
+            return Line(*lines)
 
     def get_particle_spectra(
         self,

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -418,6 +418,164 @@ class BlackHoles(Particles, BlackholesComponent):
             nthreads,
         )
 
+    def _prepare_line_args(
+        self,
+        grid,
+        line_id,
+        fesc,
+        mask,
+        grid_assignment_method,
+        nthreads,
+    ):
+        """
+        Generate the arguments for the C extension to compute lines.
+
+        Args:
+            grid (Grid)
+                The AGN grid object to extract lines from.
+            line_id (str)
+                The id of the line to extract.
+            fesc (float/array-like, float)
+                Fraction of stellar emission that escapes unattenuated from
+                the birth cloud. Can either be a single value
+                or an value per star (defaults to 0.0).
+            mask (bool)
+                A mask to be applied to the stars. Spectra will only be
+                computed and returned for stars with True in the mask.
+            grid_assignment_method (string)
+                The type of method used to assign particles to a SPS grid
+                point. Allowed methods are cic (cloud in cell) or nearest
+                grid point (ngp) or there uppercase equivalents (CIC, NGP).
+                Defaults to cic.
+            nthreads (int)
+                The number of threads to use in the C extension. If -1 then
+                all available threads are used.
+        """
+        # Which line region is this for?
+        if "nlr" in grid.grid_name:
+            line_region = "nlr"
+        elif "blr" in grid.grid_name:
+            line_region = "blr"
+        else:
+            raise exceptions.InconsistentArguments(
+                "Grid used for blackholes does not appear to be for"
+                " a line region (nlr or blr)."
+            )
+
+        # Handle the case where mask is None
+        if mask is None:
+            mask = np.ones(self.nbh, dtype=bool)
+
+        # Set up the inputs to the C function.
+        grid_props = [
+            np.ascontiguousarray(getattr(grid, axis), dtype=np.float64)
+            for axis in grid.axes
+        ]
+        props = []
+        for axis in grid.axes:
+            # Parameters that need to be provided from the black hole
+            prop = getattr(self, axis, None)
+
+            # We might be trying to get a Quanitity, in which case we need
+            # a leading _
+            if prop is None:
+                prop = getattr(self, f"_{axis}", None)
+
+            # We might be missing a line region suffix, if prop is
+            # None we need to try again with the suffix
+            if prop is None:
+                prop = getattr(self, f"{axis}_{line_region}", None)
+
+            # We could also be tripped up by plurals (TODO: stop this from
+            # happening!)
+            elif prop is None and axis == "mass":
+                prop = getattr(self, "masses", None)
+            elif prop is None and axis == "accretion_rate":
+                prop = getattr(self, "accretion_rates", None)
+            elif prop is None and axis == "metallicity":
+                prop = getattr(self, "metallicities", None)
+
+            # If we still have None here then our blackhole component doesn't
+            # have the required parameter
+            if prop is None:
+                raise exceptions.InconsistentArguments(
+                    f"Could not find {axis} or {axis}_{line_region} "
+                    f"on {type(self)}"
+                )
+
+            props.append(prop)
+
+        # Calculate npart from the mask
+        npart = np.sum(mask)
+
+        # Remove units from any unyt_arrays
+        props = [
+            prop.value if isinstance(prop, unyt_array) else prop
+            for prop in props
+        ]
+
+        # Ensure any parameters inherited from the emission model have
+        # as many values as particles
+        for ind, prop in enumerate(props):
+            if isinstance(prop, float):
+                props[ind] = np.full(self.nbh, prop)
+            elif prop.size == 1:
+                props[ind] = np.full(self.nbh, prop)
+
+        # Apply the mask to each property and make contiguous
+        props = [
+            np.ascontiguousarray(prop[mask], dtype=np.float64)
+            for prop in props
+        ]
+
+        # For black holes mass is a grid parameter but we still need to
+        # multiply by mass in the extensions so just multiply by 1
+        part_mass = np.ones(npart, dtype=np.float64)
+
+        # Make sure we set the number of particles to the size of the mask
+        npart = np.int32(np.sum(mask))
+
+        # Get the line grid and continuum
+        grid_line = np.ascontiguousarray(
+            grid.lines[line_id]["luminosity"],
+            np.float64,
+        )
+        grid_continuum = np.ascontiguousarray(
+            grid.lines[line_id]["continuum"],
+            np.float64,
+        )
+
+        # Get the grid dimensions after slicing what we need
+        grid_dims = np.zeros(len(grid_props) + 1, dtype=np.int32)
+        for ind, g in enumerate(grid_props):
+            grid_dims[ind] = len(g)
+
+        # If fesc isn't an array make it one
+        if not isinstance(fesc, np.ndarray):
+            fesc = np.ascontiguousarray(np.full(npart, fesc))
+
+        # Convert inputs to tuples
+        grid_props = tuple(grid_props)
+        part_props = tuple(props)
+
+        # If nthreads is -1 then use all available threads
+        if nthreads == -1:
+            nthreads = os.cpu_count()
+
+        return (
+            grid_line,
+            grid_continuum,
+            grid_props,
+            part_props,
+            part_mass,
+            fesc,
+            grid_dims,
+            len(grid_props),
+            npart,
+            grid_assignment_method,
+            nthreads,
+        )
+
     def generate_particle_lnu(
         self,
         grid,

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1110,7 +1110,7 @@ class Stars(Particles, StarsComponent):
             lam = grid.lines[line_id_]["wavelength"] * angstrom
 
             # Get the luminosity and continuum
-            lum, cont = compute_particle_line(
+            _lum, _cont = compute_particle_line(
                 *self._prepare_line_args(
                     grid,
                     line_id_,
@@ -1120,6 +1120,16 @@ class Stars(Particles, StarsComponent):
                     nthreads=nthreads,
                 )
             )
+
+            # Account for the mask
+            if mask is not None:
+                lum = np.zeros(self.nparticles)
+                cont = np.zeros(self.nparticles)
+                lum[mask] = _lum
+                cont[mask] = _cont
+            else:
+                lum = _lum
+                cont = _cont
 
             # Append this lines values to the containers
             lines.append(

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -845,6 +845,23 @@ class Stars(Particles, StarsComponent):
         if not isinstance(line_id, str):
             raise exceptions.InconsistentArguments("line_id must be a string")
 
+        # Ensure and warn that the masking hasn't removed everything
+        if mask is not None and np.sum(mask) == 0:
+            warn("Age mask has filtered out all particles")
+
+            return Line(
+                *[
+                    Line(
+                        line_id=line_id_,
+                        wavelength=grid.lines[line_id_]["wavelength"]
+                        * angstrom,
+                        luminosity=np.zeros(self.nparticles) * erg / s,
+                        continuum=np.zeros(self.nparticles) * erg / s / Hz,
+                    )
+                    for line_id_ in line_id.split(",")
+                ]
+            )
+
         # Set up a list to hold each individual Line
         lines = []
 
@@ -1095,6 +1112,23 @@ class Stars(Particles, StarsComponent):
         # Ensure line_id is a string
         if not isinstance(line_id, str):
             raise exceptions.InconsistentArguments("line_id must be a string")
+
+        # Ensure and warn that the masking hasn't removed everything
+        if np.sum(mask) == 0:
+            warn("Age mask has filtered out all particles")
+
+            return Line(
+                *[
+                    Line(
+                        line_id=line_id_,
+                        wavelength=grid.lines[line_id_]["wavelength"]
+                        * angstrom,
+                        luminosity=0 * erg / s,
+                        continuum=0 * erg / s / Hz,
+                    )
+                    for line_id_ in line_id.split(",")
+                ]
+            )
 
         # Set up a list to hold each individual Line
         lines = []


### PR DESCRIPTION
This PR fixes the fact per particle lines that included a mask did not maintain the same shape across all models. It also addresses the fact AGN lines had been forgotten and no generate lines method existed.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [ ] I have read the [CONTRIBUTING.md]() -->
- [ ] I have added docstrings to all methods
- [ ] I have added sufficient comments to all lines
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no pep8 errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
