### PR TITLE
BUGFIX: Removed broken args when compiling without openmp

### DIFF
--- a/src/synthesizer/extensions/column_density.c
+++ b/src/synthesizer/extensions/column_density.c
@@ -484,8 +484,7 @@ static void los_tree(struct cell *root, const double *pos_i,
   (void)nthreads;
 
   /* If we don't have OpenMP call the serial version. */
-  los_tree_serial(root, pos_i, smls, surf_den_vals, kernel, surf_dens, npart_i,
-                  kdim, threshold);
+  los_tree_serial(root, pos_i, kernel, surf_dens, npart_i, kdim, threshold);
 
 #endif
   toc("Recursive surface density calculation", start);


### PR DESCRIPTION
DWISOTT

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
