### PR TITLE
BUGFIX: Fixed `PacmanEmission` intrinsic model

### DIFF
--- a/src/synthesizer/emission_models/stellar/pacman_model.py
+++ b/src/synthesizer/emission_models/stellar/pacman_model.py
@@ -281,7 +281,7 @@ class PacmanEmission(StellarEmissionModel):
         if self._fesc == 0.0:
             return StellarEmissionModel(
                 label="intrinsic",
-                combine=(self.reprocessed, self.transmitted),
+                combine=(self.nebular, self.transmitted),
             )
 
         # Otherwise, intrinsic = reprocessed + escaped


### PR DESCRIPTION
The intrinsic model was bugged in `PacmanEmission` when `fesc=0`. It now combines the correct models.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
