### PR TITLE
Replace equivalent_width attribute with method

### DIFF
--- a/src/synthesizer/line.py
+++ b/src/synthesizer/line.py
@@ -651,14 +651,14 @@ class Line:
         self.element = [li.strip().split(" ")[0] for li in self.id.split(",")]
 
     @property
-    def continuum_lam(self):
+    def continuum_llam(self):
         """Return the continuum in units of Llam (erg/s/AA)."""
         return lnu_to_llam(self.wavelength, self.continuum)
 
     @property
     def equivalent_width(self):
         """Return the equivalent width."""
-        return self.luminosity / self.continuum_lam
+        return self.luminosity / self.continuum_llam
 
     def _make_line_from_values(
         self, line_id, wavelength, luminosity, continuum

--- a/src/synthesizer/line.py
+++ b/src/synthesizer/line.py
@@ -577,7 +577,6 @@ class Line:
     continuum = Quantity()
     luminosity = Quantity()
     flux = Quantity()
-    equivalent_width = Quantity()
 
     def __init__(
         self,
@@ -648,12 +647,22 @@ class Line:
         # Calculate the vacuum wavelength.
         self.vacuum_wavelength = standard_to_vacuum(self.wavelength)
 
-        # Continuum at line wavelength
-        self.continuum_lam = lnu_to_llam(self.wavelength, self.continuum)
-        self.equivalent_width = self.luminosity / self.continuum_lam
-
         # Element
         self.element = [li.strip().split(" ")[0] for li in self.id.split(",")]
+
+    @property
+    def continuum_lam(self):
+        """
+        Return the continuum in units of Llam (erg/s/AA).
+        """
+        return lnu_to_llam(self.wavelength, self.continuum)
+
+    @property
+    def equivalent_width(self):
+        """
+        Return the equivalent width.
+        """
+        return self.luminosity / self.continuum_lam
 
     def _make_line_from_values(
         self, line_id, wavelength, luminosity, continuum

--- a/src/synthesizer/line.py
+++ b/src/synthesizer/line.py
@@ -652,16 +652,12 @@ class Line:
 
     @property
     def continuum_lam(self):
-        """
-        Return the continuum in units of Llam (erg/s/AA).
-        """
+        """Return the continuum in units of Llam (erg/s/AA)."""
         return lnu_to_llam(self.wavelength, self.continuum)
 
     @property
     def equivalent_width(self):
-        """
-        Return the equivalent width.
-        """
+        """Return the equivalent width."""
         return self.luminosity / self.continuum_lam
 
     def _make_line_from_values(


### PR DESCRIPTION

At present the `equivalent_width` is calculated on initialisation of a `Line` object. However, if the line or continuum luminosity is updated it will then be wrong. 

Instead I've replaced the attribute with a method and added the `@property` decorator. 

Closes #590.  

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
