### PR TITLE
Fix age lookup

### DIFF
--- a/examples/cosmo/plot_test_age_lookup.py
+++ b/examples/cosmo/plot_test_age_lookup.py
@@ -40,6 +40,6 @@ for delta_a in [1e-2, 1e-3, 1e-4, 1e-5, 5e-6]:
         label=delta_a
     )
 
-ax.legend(title='$\Delta a$:')
+ax.legend(title=r'$\Delta a$:')
 ax.set_ylabel(r'$\Delta \mathrm{log_{10} \, age \;\; (Gyr)}$')
 plt.show()

--- a/examples/cosmo/plot_test_age_lookup.py
+++ b/examples/cosmo/plot_test_age_lookup.py
@@ -25,9 +25,9 @@ part_ages_proper = Planck15.age(1.0 / form_time - 1)
 fig, ax = plt.subplots(1, 1)
 
 # Loop over different look up grid resolutions
-for resolution in [100, 500, 1000, 2000, 4000]:
+for delta_a in [1e-2, 1e-3, 1e-4, 1e-5, 5e-6]:
     # create the lookup grid
-    scale_factors, ages = age_lookup_table(Planck15, resolution=resolution)
+    scale_factors, ages = age_lookup_table(Planck15, delta_a=delta_a)
 
     # Look up the ages for the particles
     part_ages = lookup_age(form_time, scale_factors, ages)
@@ -37,9 +37,9 @@ for resolution in [100, 500, 1000, 2000, 4000]:
         np.log10(np.abs((part_ages - part_ages_proper).value)),
         s=1,
         alpha=1,
-        label=resolution
+        label=delta_a
     )
 
-ax.legend(title='Resolution:')
+ax.legend(title='$\Delta a$:')
 ax.set_ylabel(r'$\Delta \mathrm{log_{10} \, age \;\; (Gyr)}$')
 plt.show()

--- a/src/synthesizer/load_data/load_camels.py
+++ b/src/synthesizer/load_data/load_camels.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import h5py
 import numpy as np
-from astropy.cosmology import Planck15, Planck18
+from astropy.cosmology import FlatLambdaCDM
 from unyt import Msun, kpc, yr
 
 from synthesizer.exceptions import UnmetDependency
@@ -124,7 +124,7 @@ def load_CAMELS_IllustrisTNG(
     dtm=0.3,
     physical=True,
     age_lookup=True,
-    age_lookup_resolution=2000,
+    age_lookup_delta_a=1e-4,
     **kwargs
 ):
     """
@@ -148,8 +148,8 @@ def load_CAMELS_IllustrisTNG(
             Should the coordinates be converted to physical?
         age_lookup (bool):
             Create a lookup table for ages
-        age_lookup_resolution (int):
-            Resolution of the age lookup
+        age_lookup_delta_a (float):
+            Scale factor resolution of the age lookup
 
     Returns:
         galaxies (object):
@@ -160,6 +160,7 @@ def load_CAMELS_IllustrisTNG(
         scale_factor = hf["Header"].attrs["Time"]
         redshift = 1.0 / scale_factor - 1
         h = hf["Header"].attrs["HubbleParam"]
+        Om0 = hf["Header"].attrs["Omega0"]
 
         form_time = hf["PartType4/GFM_StellarFormationTime"][:]
         coods = hf["PartType4/Coordinates"][:]  # kpc (comoving)
@@ -229,7 +230,7 @@ def load_CAMELS_IllustrisTNG(
         pos *= scale_factor
 
     # convert formation times to ages
-    cosmo = Planck15
+    cosmo = FlatLambdaCDM(H0=h * 100, Om0=Om0)
     universe_age = cosmo.age(redshift)
 
     # Are we creating a lookup table for ages?
@@ -237,7 +238,7 @@ def load_CAMELS_IllustrisTNG(
         # Create the lookup grid
         scale_factors, ages = age_lookup_table(
             cosmo,
-            resolution=age_lookup_resolution
+            delta_a=age_lookup_delta_a
         )
 
         # Look up the ages for the particles
@@ -278,7 +279,7 @@ def load_CAMELS_Astrid(
     dtm=0.3,
     physical=True,
     age_lookup=True,
-    age_lookup_resolution=2000,
+    age_lookup_delta_a=1e-4,
     **kwargs
 ):
     """
@@ -300,8 +301,8 @@ def load_CAMELS_Astrid(
             Should properties be converted to physical?
         age_lookup (bool):
             Create a lookup table for ages
-        age_lookup_resolution (int):
-            Resolution of the age lookup
+        age_lookup_delta_a (float):
+            Scale factor resolution of the age lookup
 
     Returns:
         galaxies (object):
@@ -312,6 +313,7 @@ def load_CAMELS_Astrid(
         redshift = hf["Header"].attrs["Redshift"].astype(np.float32)
         scale_factor = hf["Header"].attrs["Time"][0].astype(np.float32)
         h = hf["Header"].attrs["HubbleParam"][0]
+        Om0 = hf["Header"].attrs["Omega0"][0]
 
         form_time = hf["PartType4/GFM_StellarFormationTime"][:]
         coods = hf["PartType4/Coordinates"][:]  # kpc (comoving)
@@ -339,7 +341,7 @@ def load_CAMELS_Astrid(
     s_hydrogen = 1 - np.sum(_metals[:, 1:], axis=1)
 
     # convert formation times to ages
-    cosmo = Planck18
+    cosmo = FlatLambdaCDM(H0=h * 100, Om0=Om0)
     universe_age = cosmo.age(redshift)
 
     # Are we creating a lookup table for ages?
@@ -347,7 +349,7 @@ def load_CAMELS_Astrid(
         # Create the lookup grid
         scale_factors, ages = age_lookup_table(
             cosmo,
-            resolution=age_lookup_resolution
+            delta_a=age_lookup_delta_a
         )
 
         # Look up the ages for the particles
@@ -400,7 +402,7 @@ def load_CAMELS_Simba(
     dtm=0.3,
     physical=True,
     age_lookup=True,
-    age_lookup_resolution=2000,
+    age_lookup_delta_a=1e-4,
     **kwargs
 ):
     """
@@ -422,8 +424,8 @@ def load_CAMELS_Simba(
             Should properties be converted to physical?
         age_lookup (bool):
             Create a lookup table for ages
-        age_lookup_resolution (int):
-            Resolution of the age lookup
+        age_lookup_delta_a (float):
+            Scale factor resolution of the age lookup
 
     Returns:
         galaxies (object):
@@ -434,6 +436,7 @@ def load_CAMELS_Simba(
         redshift = hf["Header"].attrs["Redshift"]
         scale_factor = hf["Header"].attrs["Time"]
         h = hf["Header"].attrs["HubbleParam"]
+        Om0 = hf["Header"].attrs["Omega0"]
 
         form_time = hf["PartType4/StellarFormationTime"][:]
         coods = hf["PartType4/Coordinates"][:]  # kpc (comoving)
@@ -460,7 +463,7 @@ def load_CAMELS_Simba(
     metallicity = _metals[:, 0]
 
     # convert formation times to ages
-    cosmo = Planck15
+    cosmo = FlatLambdaCDM(H0=h * 100, Om0=Om0)
     universe_age = cosmo.age(redshift)
 
     # Are we creating a lookup table for ages?
@@ -468,7 +471,7 @@ def load_CAMELS_Simba(
         # Create the lookup grid
         scale_factors, ages = age_lookup_table(
             cosmo,
-            resolution=age_lookup_resolution
+            delta_a=age_lookup_delta_a
         )
 
         # Look up the ages for the particles
@@ -520,11 +523,10 @@ def load_CAMELS_SwiftEAGLE_subfind(
     group_dir=None,
     dtm=0.3,
     physical=True,
-    cosmo=Planck15,
     min_star_part=10,
     num_threads=-1,
     age_lookup=True,
-    age_lookup_resolution=2000,
+    age_lookup_delta_a=1e-4,
     **kwargs
 ):
     """
@@ -546,8 +548,6 @@ def load_CAMELS_SwiftEAGLE_subfind(
             dust-to-metals ratio to apply to all gas particles
         physical (bool):
             Should the coordinates be converted to physical?
-        cosmo (astropy cosmology):
-            cosmology object to use for age calculation
         min_star_part (int):
             minimum number of star particles required to load galaxy
         num_threads (int)
@@ -555,8 +555,8 @@ def load_CAMELS_SwiftEAGLE_subfind(
             Default is -1, i.e. use all available cores.
         age_lookup (bool):
             Create a lookup table for ages
-        age_lookup_resolution (int):
-            Resolution of the age lookup
+        age_lookup_delta_a (int):
+            Scale factor resolution of the age lookup
 
     Returns:
         galaxies (object):
@@ -585,8 +585,10 @@ def load_CAMELS_SwiftEAGLE_subfind(
 
     # Load cosmology information
     with h5py.File(f"{_dir}/{snap_name}", "r") as hf:
-        scale_factor = hf["Cosmology"].attrs["Scale-factor"]
-        redshift = hf["Cosmology"].attrs["Redshift"]
+        scale_factor = hf["Cosmology"].attrs["Scale-factor"][0]
+        redshift = hf["Cosmology"].attrs["Redshift"][0]
+        Om0 = hf["Cosmology"].attrs["Omega_m"][0]
+        h = hf["Cosmology"].attrs["h"][0]
 
     # get subfind particle info (lens and IDs) for subsetting snapshot info
     with h5py.File(f"{group_dir}/{group_name}", "r") as hf:
@@ -632,7 +634,7 @@ def load_CAMELS_SwiftEAGLE_subfind(
     mask = np.where(lentype[:, 4] > min_star_part)[0]
 
     # convert formation times to ages
-    cosmo = Planck18
+    cosmo = FlatLambdaCDM(H0=h * 100, Om0=Om0)
     universe_age = cosmo.age(redshift)
 
     # Are we creating a lookup table for ages?
@@ -640,7 +642,7 @@ def load_CAMELS_SwiftEAGLE_subfind(
         # Create the lookup grid
         scale_factors, ages = age_lookup_table(
             cosmo,
-            resolution=age_lookup_resolution
+            delta_a=age_lookup_delta_a
         )
 
         # Look up the ages for the particles

--- a/src/synthesizer/load_data/utils.py
+++ b/src/synthesizer/load_data/utils.py
@@ -3,6 +3,7 @@ Utilities for data loading methods
 """
 
 import numpy as np
+import math
 
 
 def get_len(Length):
@@ -44,6 +45,8 @@ def age_lookup_table(cosmo, delta_a=1e-3, low_lim=1e-4):
             array of ages (Gyr)
     """
     resolution = (1.0 - low_lim) / delta_a
+    resolution = math.ceil(resolution)
+
     scale_factor = np.linspace(low_lim, 1.0, resolution)
     ages = cosmo.age(1.0 / scale_factor - 1)
     return scale_factor, ages

--- a/src/synthesizer/load_data/utils.py
+++ b/src/synthesizer/load_data/utils.py
@@ -26,23 +26,24 @@ def get_len(Length):
     return begin, end
 
 
-def age_lookup_table(cosmo, low_lim=1e-4, resolution=2000):
+def age_lookup_table(cosmo, delta_a=1e-3, low_lim=1e-4):
     """
     Create a look-up table for age as a function of scale factor
 
     Args:
         cosmo (astropy.cosmology)
             astropy cosmology object
+        delta_a (int)
+            scale factor resolution to approximate
         low_lim (float)
             lower limit of scale factor
-        resolution (int)
-            number of scale factors to calculate
     Returns:
         scale_factor (array)
             array of scale factors
         age (array)
             array of ages (Gyr)
     """
+    resolution = (1.0 - low_lim) / delta_a
     scale_factor = np.linspace(low_lim, 1.0, resolution)
     ages = cosmo.age(1.0 / scale_factor - 1)
     return scale_factor, ages

--- a/src/synthesizer/load_data/utils.py
+++ b/src/synthesizer/load_data/utils.py
@@ -2,8 +2,9 @@
 Utilities for data loading methods
 """
 
-import numpy as np
 import math
+
+import numpy as np
 
 
 def get_len(Length):


### PR DESCRIPTION
Two changes:
- Bug fix in CAMELS loaders, where age lookup grid defined using fixed Planck+18 cosmology, rather than adopting cosmology from CAMELS sim.
- Changed from fixed resolution to a user defined $\Delta a$ (`delta_a`) in age lookup grid definition. Should make defining a grid resolution more 'physically motivated'

## Issue Type
- Bug
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
