### PR TITLE
Age grid updates and check added

### DIFF
--- a/src/synthesizer/load_data/load_camels.py
+++ b/src/synthesizer/load_data/load_camels.py
@@ -238,7 +238,9 @@ def load_CAMELS_IllustrisTNG(
         # Create the lookup grid
         scale_factors, ages = age_lookup_table(
             cosmo,
-            delta_a=age_lookup_delta_a
+            redshift=redshift,
+            delta_a=age_lookup_delta_a,
+            low_lim=1e-4,
         )
 
         # Look up the ages for the particles
@@ -349,6 +351,7 @@ def load_CAMELS_Astrid(
         # Create the lookup grid
         scale_factors, ages = age_lookup_table(
             cosmo,
+            redshift=redshift,
             delta_a=age_lookup_delta_a
         )
 
@@ -471,6 +474,7 @@ def load_CAMELS_Simba(
         # Create the lookup grid
         scale_factors, ages = age_lookup_table(
             cosmo,
+            redshift=redshift,
             delta_a=age_lookup_delta_a
         )
 
@@ -642,6 +646,7 @@ def load_CAMELS_SwiftEAGLE_subfind(
         # Create the lookup grid
         scale_factors, ages = age_lookup_table(
             cosmo,
+            redshift=redshift,
             delta_a=age_lookup_delta_a
         )
 

--- a/src/synthesizer/load_data/utils.py
+++ b/src/synthesizer/load_data/utils.py
@@ -28,13 +28,19 @@ def get_len(Length):
     return begin, end
 
 
-def age_lookup_table(cosmo, delta_a=1e-3, low_lim=1e-4):
+def age_lookup_table(cosmo, redshift=0., delta_a=1e-3, low_lim=1e-4):
     """
-    Create a look-up table for age as a function of scale factor
+    Create a look-up table for age as a function of scale factor.
+
+    Defaults to start at the lower resolution limit (`delta_a`),
+    and proceeds in steps of `delta-a` until the scale factor given
+    by the input `redshift` minus the `low_lim`.
 
     Args:
         cosmo (astropy.cosmology)
             astropy cosmology object
+        redshift (float)
+            redshift of the snapshot
         delta_a (int)
             scale factor resolution to approximate
         low_lim (float)
@@ -45,17 +51,30 @@ def age_lookup_table(cosmo, delta_a=1e-3, low_lim=1e-4):
         age (array)
             array of ages (Gyr)
     """
-    resolution = (1.0 - low_lim) / delta_a
+
+    # Find the scale factor for the input snapshot
+    root_scale_factor = 1. / (1. + redshift)
+
+    # Find the (integer) resolution of the grid
+    resolution = (root_scale_factor - low_lim) / delta_a
     resolution = math.ceil(resolution)
 
-    scale_factor = np.linspace(low_lim, 1.0, resolution)
+    # Create the (linear) scale factor array
+    scale_factor = np.linspace(
+        delta_a,
+        root_scale_factor - low_lim,
+        resolution
+    )
+
+    # Find the ages at these scale factors
     ages = cosmo.age(1.0 / scale_factor - 1)
+
     return scale_factor, ages
 
 
 def lookup_age(scale_factor, scale_factors, ages):
     """
-    Look up the age of a galaxy given its scale factor
+    Look up the age given a scale factor
 
     Args:
         scale_factor (array.float)

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -192,6 +192,12 @@ class Stars(Particles, StarsComponent):
                 "Initial mass should be numpy or unyt array."
             )
 
+        if len(ages) > 0:
+            if ages.min() < 0.:
+                raise exceptions.InconsistentArguments(
+                    "Ages cannot be negative."
+                )
+
         # Set always required stellar particle properties
         self.initial_masses = initial_masses
         self.ages = ages


### PR DESCRIPTION
Fixes a small interpolation issue by locking the base of the grid on the scale factor of the snapshot being loaded.

Adds a check and error when loading ages into a particle stars object if those ages are negative.

## Issue Type
- Bug
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
