### PR TITLE
Fixed deprecated arguments

### DIFF
--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -567,7 +567,7 @@ class Galaxy(BaseGalaxy):
 
         return tau_v
 
-    @deprecated
+    @deprecated()
     def calculate_los_tau_v(
         self,
         kappa,

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -193,7 +193,7 @@ class Stars(Particles, StarsComponent):
             )
 
         if len(ages) > 0:
-            if ages.min() < 0.:
+            if ages.min() < 0.0:
                 raise exceptions.InconsistentArguments(
                     "Ages cannot be negative."
                 )

--- a/src/synthesizer/warnings.py
+++ b/src/synthesizer/warnings.py
@@ -36,7 +36,7 @@ def deprecation(message, category=FutureWarning):
     warnings.warn(message, category=category, stacklevel=3)
 
 
-def deprecated(func, message=None, category=FutureWarning):
+def deprecated(message=None, category=FutureWarning):
     """
     Decorate a function to mark it as deprecated.
 
@@ -54,24 +54,27 @@ def deprecated(func, message=None, category=FutureWarning):
 
     """
 
-    def wrapped(*args, **kwargs):
-        # Determine the specific deprecation message
-        if message is None:
-            _message = (
-                f"{func.__name__} is deprecated and "
-                "will be removed in a future version."
+    def _deprecated(func):
+        def wrapped(*args, **kwargs):
+            # Determine the specific deprecation message
+            if message is None:
+                _message = (
+                    f"{func.__name__} is deprecated and "
+                    "will be removed in a future version."
+                )
+            else:
+                _message = f"{func.__name__} {message}"
+
+            # Issue the warning
+            deprecation(
+                _message,
+                category=category,
             )
-        else:
-            _message = f"{func.__name__} {message}"
+            return func(*args, **kwargs)
 
-        # Issue the warning
-        deprecation(
-            _message,
-            category=category,
-        )
-        return func(*args, **kwargs)
+        return wrapped
 
-    return wrapped
+    return _deprecated
 
 
 def warn(message, category=RuntimeWarning, stacklevel=3):

--- a/src/synthesizer/warnings.py
+++ b/src/synthesizer/warnings.py
@@ -54,7 +54,7 @@ def deprecated(message=None, category=FutureWarning):
 
     """
 
-    def _deprecated(func):
+    def _deprecated(func, *args, **kwargs):
         def wrapped(*args, **kwargs):
             # Determine the specific deprecation message
             if message is None:

--- a/src/synthesizer/warnings.py
+++ b/src/synthesizer/warnings.py
@@ -7,9 +7,15 @@ Example usage::
 
     deprecation("x will have to be a unyt_array in future versions.")
 
-    @deprecated
+    @deprecated()
     def old_function():
         pass
+
+    @deprecated("will be removed in v2.0")
+    def old_function():
+        pass
+
+    warn("This is a warning message.")
 
 """
 
@@ -54,7 +60,7 @@ def deprecated(message=None, category=FutureWarning):
 
     """
 
-    def _deprecated(func, *args, **kwargs):
+    def _deprecated(func):
         def wrapped(*args, **kwargs):
             # Determine the specific deprecation message
             if message is None:


### PR DESCRIPTION
The `deprecated` decorator was incorrectly defined for use with the optional arguments. This is now fixed.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
