### PR TITLE
Overlooked some places deprecation was needed and fixed typo in warning

### DIFF
--- a/src/synthesizer/base_galaxy.py
+++ b/src/synthesizer/base_galaxy.py
@@ -111,8 +111,8 @@ class BaseGalaxy:
                 The photometry luminosities.
         """
         deprecation(
-            "The `photo_fluxes` attribute is deprecated. Use "
-            "`photo_fnu` instead. Will be removed in v1.0.0"
+            "The `photo_luminosities` attribute is deprecated. Use "
+            "`photo_lnu` instead. Will be removed in v1.0.0"
         )
         return self.photo_lnu
 

--- a/src/synthesizer/components/blackhole.py
+++ b/src/synthesizer/components/blackhole.py
@@ -287,8 +287,8 @@ class BlackholesComponent:
                 The photometry luminosities.
         """
         deprecation(
-            "The `photo_fluxes` attribute is deprecated. Use "
-            "`photo_fnu` instead. Will be removed in v1.0.0"
+            "The `photo_luminosities` attribute is deprecated. Use "
+            "`photo_lnu` instead. Will be removed in v1.0.0"
         )
         return self.photo_lnu
 

--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -84,8 +84,8 @@ class StarsComponent:
                 The photometry luminosities.
         """
         deprecation(
-            "The `photo_fluxes` attribute is deprecated. Use "
-            "`photo_fnu` instead. Will be removed in v1.0.0"
+            "The `photo_luminosities` attribute is deprecated. Use "
+            "`photo_lnu` instead. Will be removed in v1.0.0"
         )
         return self.photo_lnu
 

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -12,6 +12,7 @@ from unyt import unyt_array, unyt_quantity
 from synthesizer import exceptions
 from synthesizer.units import Quantity
 from synthesizer.utils import TableFormatter
+from synthesizer.warnings import deprecation
 
 
 class Particles:
@@ -137,6 +138,36 @@ class Particles:
 
         # Attach the name of the particle type
         self.name = name
+
+    @property
+    def particle_photo_fluxes(self):
+        """
+        Get the particle photometry fluxes.
+
+        Returns:
+            dict
+                The photometry fluxes.
+        """
+        deprecation(
+            "The `particle_photo_fluxes` attribute is deprecated. Use "
+            "`particle_photo_fnu` instead. Will be removed in v1.0.0"
+        )
+        return self.photo_fnu
+
+    @property
+    def photo_luminosities(self):
+        """
+        Get the photometry luminosities.
+
+        Returns:
+            dict
+                The photometry luminosities.
+        """
+        deprecation(
+            "The `particle_photo_luminosities` attribute is deprecated. Use "
+            "`particle_photo_lnu` instead. Will be removed in v1.0.0"
+        )
+        return self.photo_lnu
 
     def _check_part_args(
         self, coordinates, velocities, masses, softening_length


### PR DESCRIPTION
I made a boo boo... forgot about `particle_photo_*` attributes. These are now deprecated in the same way instead of raising errors.

A couple of the deprecation warnings also had typos in them 😬 .

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
