### PR TITLE
BUGFIX: `Stars.generate_particle_line` didn't handle entirely masked out arrays properly

### DIFF
--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -81,7 +81,7 @@ class Particles:
                 The redshift/s of the particles.
             softening_length (float)
                 The physical gravitational softening length.
-            nparticle (int)
+            nparticles (int)
                 How many particles are there?
             centre (array, float)
                 Centre of the particle distribution.

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1100,8 +1100,8 @@ class Stars(Particles, StarsComponent):
                     Line(
                         line_id=line_id_,
                         wavelength=grid.line_lams[line_id_] * angstrom,
-                        luminosity=0 * erg / s,
-                        continuum=0 * erg / s / Hz,
+                        luminosity=np.zeros(self.nparticles) * erg / s,
+                        continuum=np.zeros(self.nparticles) * erg / s / Hz,
                     )
                     for line_id_ in line_id.split(",")
                 ]


### PR DESCRIPTION
Instead of returning a `Line` containing arrays of zeros when all particles were masked out `Stars.generate_particle_line` returned a `Line` containing single zeros. This caused havoc downstream in the event this is ever triggered. Entertainingly this had already been addressed for black holes.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
