### PR TITLE
BUGFIX: Cautionary tale in using ones in tests (aperture fix)

### DIFF
--- a/src/synthesizer/imaging/extensions/circular_aperture.c
+++ b/src/synthesizer/imaging/extensions/circular_aperture.c
@@ -236,7 +236,7 @@ static double calculate_overlap_serial(const double res, const double xmin,
         frac = 1.0 / (res * res);
       } else if (d < r + pixel_radius) {
         frac = circular_overlap_single_exact(pxmin, pymin, pxmax, pymax, r) /
-               (res * res);
+               (res * res) / (res * res);
       } else {
         /* Nothing to do, pixel is outside the aperture. */
         continue;
@@ -291,7 +291,7 @@ static double calculate_overlap_omp(const double res, const double xmin,
         frac = 1.0 / (res * res);
       } else if (d < r + pixel_radius) {
         frac = circular_overlap_single_exact(pxmin, pymin, pxmax, pymax, r) /
-               (res * res);
+               (res * res) / (res * res);
       } else {
         /* Nothing to do, pixel is outside the aperture. */
         continue;

--- a/src/synthesizer/imaging/extensions/circular_aperture.c
+++ b/src/synthesizer/imaging/extensions/circular_aperture.c
@@ -233,10 +233,10 @@ static double calculate_overlap_serial(const double res, const double xmin,
 
       double d = sqrt(pxcen * pxcen + pycen * pycen);
       if (d < r - pixel_radius) {
-        frac = 1.0 / (res * res);
+        frac = 1.0;
       } else if (d < r + pixel_radius) {
         frac = circular_overlap_single_exact(pxmin, pymin, pxmax, pymax, r) /
-               (res * res) / (res * res);
+               (res * res);
       } else {
         /* Nothing to do, pixel is outside the aperture. */
         continue;
@@ -288,10 +288,10 @@ static double calculate_overlap_omp(const double res, const double xmin,
 
       double d = sqrt(pxcen * pxcen + pycen * pycen);
       if (d < r - pixel_radius) {
-        frac = 1.0 / (res * res);
+        frac = 1.0;
       } else if (d < r + pixel_radius) {
         frac = circular_overlap_single_exact(pxmin, pymin, pxmax, pymax, r) /
-               (res * res) / (res * res);
+               (res * res);
       } else {
         /* Nothing to do, pixel is outside the aperture. */
         continue;
@@ -374,7 +374,7 @@ static PyObject *calculate_circular_overlap(PyObject *self, PyObject *args) {
   const double *cent = extract_data_double(np_cent, "cent");
 
   /* Is the aperture smaller than a pixel? */
-  if (r < 0.5) {
+  if (r < 0.5 * res) {
     /* Compute the areas. */
     const double app_area = M_PI * r * r;
     const double pix_area = res * res;
@@ -383,8 +383,7 @@ static PyObject *calculate_circular_overlap(PyObject *self, PyObject *args) {
     signal = app_area / pix_area * img[(int)cent[0] * ny + (int)cent[1]];
   }
 
-  /* Calculate the signal inside the aperture. (Only if we haven't just above
-   * ). Note that we need to divide by the area of the aperture.*/
+  /* Calculate the signal inside the aperture. */
   if (signal == 0) {
     signal = calculate_overlap(res, r, nx, ny, img, cent, nthreads);
   }

--- a/src/synthesizer/imaging/extensions/circular_aperture.c
+++ b/src/synthesizer/imaging/extensions/circular_aperture.c
@@ -296,7 +296,7 @@ static double calculate_overlap_omp(const double res, const double xmin,
         /* Nothing to do, pixel is outside the aperture. */
         continue;
       }
-      signal += frac / (res * res) * img[i * ny + j];
+      signal += frac * img[i * ny + j];
     }
   }
 
@@ -383,9 +383,11 @@ static PyObject *calculate_circular_overlap(PyObject *self, PyObject *args) {
     signal = app_area / pix_area * img[(int)cent[0] * ny + (int)cent[1]];
   }
 
-  /* Calculate the signal inside the aperture. */
+  /* Calculate the signal inside the aperture. (Only if we haven't just above
+   * ). Note that we need to divide by the area of the aperture.*/
   if (signal == 0) {
-    signal = calculate_overlap(res, r, nx, ny, img, cent, nthreads);
+    signal =
+        calculate_overlap(res, r, nx, ny, img, cent, nthreads) / (M_PI * r * r);
   }
 
   /* Construct the ouput. */

--- a/src/synthesizer/imaging/extensions/circular_aperture.c
+++ b/src/synthesizer/imaging/extensions/circular_aperture.c
@@ -233,7 +233,7 @@ static double calculate_overlap_serial(const double res, const double xmin,
 
       double d = sqrt(pxcen * pxcen + pycen * pycen);
       if (d < r - pixel_radius) {
-        frac = 1.0;
+        frac = 1.0 / (res * res);
       } else if (d < r + pixel_radius) {
         frac = circular_overlap_single_exact(pxmin, pymin, pxmax, pymax, r) /
                (res * res);
@@ -288,7 +288,7 @@ static double calculate_overlap_omp(const double res, const double xmin,
 
       double d = sqrt(pxcen * pxcen + pycen * pycen);
       if (d < r - pixel_radius) {
-        frac = 1.0;
+        frac = 1.0 / (res * res);
       } else if (d < r + pixel_radius) {
         frac = circular_overlap_single_exact(pxmin, pymin, pxmax, pymax, r) /
                (res * res);
@@ -386,8 +386,7 @@ static PyObject *calculate_circular_overlap(PyObject *self, PyObject *args) {
   /* Calculate the signal inside the aperture. (Only if we haven't just above
    * ). Note that we need to divide by the area of the aperture.*/
   if (signal == 0) {
-    signal =
-        calculate_overlap(res, r, nx, ny, img, cent, nthreads) / (M_PI * r * r);
+    signal = calculate_overlap(res, r, nx, ny, img, cent, nthreads);
   }
 
   /* Construct the ouput. */

--- a/src/synthesizer/imaging/image.py
+++ b/src/synthesizer/imaging/image.py
@@ -845,7 +845,7 @@ class Image:
                 The centre of the aperture (in pixel coordinates, i.e. the
                 centre is [npix/2, npix/2], top left is [0, 0], and bottom
                 right is [npix, npix]). If None then the centre is assumed to
-                be the centre of the image.
+                be the maximum pixel.
             nthreads (int)
                 The number of threads to use for the calculation. Default is 1.
 
@@ -856,10 +856,11 @@ class Image:
         # Convert the aperture radius to the correct units
         aperture_radius = aperture_radius.to(self.resolution.units).value
 
-        # If the aperture centre isn't passed, assume it's the centre of the
-        # image
+        # If the aperture centre isn't passed, assume it's the maximum
+        # pixel
         if aperture_cent is None:
-            aperture_cent = np.array(self.npix, dtype=np.float64) / 2
+            max_pixel = np.unravel_index(self.arr.argmax(), self.arr.shape)
+            aperture_cent = np.array(max_pixel) + 0.5
 
         from synthesizer.imaging.extensions.circular_aperture import (
             calculate_circular_overlap,


### PR DESCRIPTION
The aperture gave a perfect answer if the resolution was 1 and the image contained ones... like the test...

Turns out there was a bug left over from when I switched to using non-pixel coordinates that led to the summing being woefully incorrect if it was less than 0.5 🤦 

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
