### PR TITLE
dust_to_metal_vijayan19 wouldn't necessarily update the dust masses

### DIFF
--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -753,7 +753,9 @@ class Galaxy(BaseGalaxy):
         self, stellar_mass_weighted_age=None, ism_metallicity=None
     ):
         """
-        Fitting function for the dust-to-metals ratio based on
+        Calculate the dust to metal ratio based on stellar age and metallicity.
+
+        This uses a fitting function for the dust-to-metals ratio based on
         galaxy properties, from L-GALAXIES dust modeling.
 
         Vijayan+19: https://arxiv.org/abs/1904.02196
@@ -762,12 +764,12 @@ class Galaxy(BaseGalaxy):
             stellar_mass_weighted_age (float)
                 Mass weighted age of stars in Myr. Defaults to None,
                 and uses value provided on this galaxy object (in Gyr)
-                ism_metallicity (float)
+            ism_metallicity (float)
                 Mass weighted gas-phase metallicity. Defaults to None,
                 and uses value provided on this galaxy object
                 (dimensionless)
         """
-
+        # Ensure we have what we need for the calculation
         if stellar_mass_weighted_age is None:
             if self.stellar_mass_weighted_age is None:
                 raise ValueError("No stellar_mass_weighted_age provided")

--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -760,6 +760,9 @@ class Galaxy(BaseGalaxy):
 
         Vijayan+19: https://arxiv.org/abs/1904.02196
 
+        Note this will recalculate the dust masses based on the new dust-to-
+        metal ratio.
+
         Args:
             stellar_mass_weighted_age (float)
                 Mass weighted age of stars in Myr. Defaults to None,
@@ -801,6 +804,13 @@ class Galaxy(BaseGalaxy):
 
         # Save under gas properties
         self.gas.dust_to_metal_ratio = dtm
+
+        # We need to recalculate the dust masses so things don't end up
+        # inconsistent (dust_masses are automatically calculated at
+        # intialisation). If the user handed dust masses and then called this
+        # function, they will be overwritten and it will be confusing but
+        # that's so unlikely and they'll work out when they see this comment.
+        self.gas.dust_masses = self.gas.masses * self.gas.dust_to_metal_ratio
 
         return dtm
 

--- a/src/synthesizer/particle/gas.py
+++ b/src/synthesizer/particle/gas.py
@@ -167,8 +167,8 @@ class Gas(Particles):
         else:  # if dust_masses is not None:
             self.dust_masses = dust_masses
 
-            # TODO: this should be removed when dust masses are
-            # properly propagated to LOS calculation
+            # Calculate the dust to metal ratio from the dust mass and
+            # metallicity
             self.dust_to_metal_ratio = self.dust_masses / (
                 self.masses * self.metallicities
             )


### PR DESCRIPTION
If the user provides no DTM then the DTM is assumed to be 0.3. If the user wants to use `dust_to_metal_vijayan19` to calculate the DTM they then call this but the dust mass computed at initialisation still exists and will be picked up during the LOS calculation, i.e. `dust_to_metal_vijayan19` only updated the DTM which had no effect on anything!

This PR fixes this by updating the `dust_masses`. I toyed with the idea of converting it to a property but that actually got quite messy, this is far simpler.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
