### PR TITLE
Ensuring Synthesizer behaves predictably for galaxy with empty components

### DIFF
--- a/src/synthesizer/components/blackhole.py
+++ b/src/synthesizer/components/blackhole.py
@@ -351,6 +351,11 @@ class BlackholesComponent:
                 f"The Grid does not contain the key '{spectra_name}'"
             )
 
+        # If we have have 0 particles (regardless of mask) just return an
+        # array of zeros
+        if self.nbh == 0:
+            return np.zeros(len(grid.lam))
+
         # If the mask is False (parametric case) or contains only
         # 0 (particle case) just return an array of zeros
         if isinstance(mask, bool) and not mask:
@@ -427,6 +432,21 @@ class BlackholesComponent:
         # Ensure line_id is a string
         if not isinstance(line_id, str):
             raise exceptions.InconsistentArguments("line_id must be a string")
+
+        # If we have have 0 particles (regardless of mask) just return a line
+        # containing zeros
+        if self.nbh == 0:
+            return Line(
+                *[
+                    Line(
+                        line_id=line_id_,
+                        wavelength=grid.line_lams[line_id_] * angstrom,
+                        luminosity=0 * erg / s,
+                        continuum=0 * erg / s / Hz,
+                    )
+                    for line_id_ in line_id.split(",")
+                ]
+            )
 
         # Ensure and warn that the masking hasn't removed everything
         if mask is not None and np.sum(mask) == 0:

--- a/src/synthesizer/components/blackhole.py
+++ b/src/synthesizer/components/blackhole.py
@@ -353,7 +353,7 @@ class BlackholesComponent:
 
         # If we have have 0 particles (regardless of mask) just return an
         # array of zeros
-        if self.nbh == 0:
+        if hasattr(self, "nbh") and self.nbh == 0:
             return np.zeros(len(grid.lam))
 
         # If the mask is False (parametric case) or contains only
@@ -435,7 +435,7 @@ class BlackholesComponent:
 
         # If we have have 0 particles (regardless of mask) just return a line
         # containing zeros
-        if self.nbh == 0:
+        if hasattr(self, "nbh") and self.nbh == 0:
             return Line(
                 *[
                     Line(

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -225,6 +225,8 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
         # Attach the wavelength array and store it on the model
         if grid is not None:
             self.lam = grid.lam
+        elif generator is not None and hasattr(generator, "lam"):
+            self.lam = generator.lam
         else:
             self.lam = None
 

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -315,6 +315,14 @@ class Generation:
         # Unpack what we need for dust emission
         generator = this_model.generator
 
+        # If we have an empty emitter we can just return zeros (only applicable
+        # when nparticles exists in the emitter)
+        if getattr(emitter, "nparticles", 1) == 0:
+            spectra[this_model.label] = Sed(
+                lam, np.zeros(emitter.nparticles, lam.size)
+            )
+            return spectra
+
         # Handle the dust emission case
         if this_model._is_dust_emitting:
             intrinsic = spectra[this_model.lum_intrinsic_model.label]
@@ -390,6 +398,24 @@ class Generation:
                 "To generate a line using a generator the corresponding "
                 "spectra must be generated first."
             )
+
+        # If the emitter is empty we can just return zeros. This is only
+        # applicable when nparticles exists in the emitter
+        if getattr(emitter, "nparticles", 1) == 0:
+            lines[this_model.label] = {}
+            for line_id in line_ids:
+                # Get the emission at this lines wavelength
+                lam = lines[this_model.lum_intrinsic_model.label][
+                    line_id
+                ].wavelength
+
+                lines[this_model.label][line_id] = Line(
+                    line_id=line_id,
+                    wavelength=lam * Hz,
+                    luminosity=np.zeros(emitter.nparticles),
+                    continuum=np.zeros(emitter.nparticles),
+                )
+            return lines
 
         # Now we have the spectra we can get the emission at each line
         # and include it

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -319,7 +319,7 @@ class Generation:
         # when nparticles exists in the emitter)
         if getattr(emitter, "nparticles", 1) == 0:
             spectra[this_model.label] = Sed(
-                lam, np.zeros(emitter.nparticles, lam.size)
+                lam, np.zeros(emitter.nparticles, emission_model.lam.size)
             )
             return spectra
 

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -319,7 +319,7 @@ class Generation:
         # when nparticles exists in the emitter)
         if getattr(emitter, "nparticles", 1) == 0:
             spectra[this_model.label] = Sed(
-                lam, np.zeros(emitter.nparticles, emission_model.lam.size)
+                lam, np.zeros((emitter.nparticles, emission_model.lam.size))
             )
             return spectra
 

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -319,7 +319,7 @@ class Generation:
         # when nparticles exists in the emitter)
         if getattr(emitter, "nparticles", 1) == 0:
             spectra[this_model.label] = Sed(
-                lam, np.zeros((emitter.nparticles, emission_model.lam.size))
+                lam, np.zeros((emitter.nparticles, lam.size))
             )
             return spectra
 

--- a/src/synthesizer/imaging/image.py
+++ b/src/synthesizer/imaging/image.py
@@ -256,6 +256,13 @@ class Image:
             self.units = signal.units
             signal = signal.value
 
+        # Return an empty image if there are no particles
+        if signal.size == 0:
+            self.arr = np.zeros(self.npix)
+            return (
+                self.arr * self.units if self.units is not None else self.arr
+            )
+
         # Convert coordinates and smoothing lengths to the correct units and
         # strip them off
         coordinates = coordinates.to(self.resolution.units).value
@@ -356,6 +363,13 @@ class Image:
             # Multiply the density grid by the sed to get the IFU
             self.arr = density_grid[:, :] * signal
 
+            return (
+                self.arr * self.units if self.units is not None else self.arr
+            )
+
+        # Return an empty image if there are no particles
+        if signal.size == 0:
+            self.arr = np.zeros(self.npix)
             return (
                 self.arr * self.units if self.units is not None else self.arr
             )

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -168,7 +168,7 @@ class BlackHoles(Particles, BlackholesComponent):
             masses=masses,
             redshift=redshift,
             softening_length=softening_length,
-            nparticles=masses.shape[0],
+            nparticles=masses.size,
             centre=centre,
             tau_v=tau_v,
             name="Black Holes",

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -217,8 +217,6 @@ class BlackHoles(Particles, BlackholesComponent):
         # Set the smoothing lengths
         self.smoothing_lengths = smoothing_lengths
 
-        print(self)
-
         # Check the arguments we've been given
         self._check_bh_args()
 

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -239,6 +239,7 @@ class BlackHoles(Particles, BlackholesComponent):
             attr = getattr(self, key)
             if isinstance(attr, np.ndarray):
                 if attr.shape[0] != self.nparticles:
+                    print(key, attr.shape, self.nparticles)
                     raise exceptions.InconsistentArguments(
                         "Inconsistent black hole array sizes! (nparticles=%d, "
                         "%s=%d)" % (self.nparticles, key, attr.shape[0])

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -217,6 +217,8 @@ class BlackHoles(Particles, BlackholesComponent):
         # Set the smoothing lengths
         self.smoothing_lengths = smoothing_lengths
 
+        print(self)
+
         # Check the arguments we've been given
         self._check_bh_args()
 
@@ -239,7 +241,6 @@ class BlackHoles(Particles, BlackholesComponent):
             attr = getattr(self, key)
             if isinstance(attr, np.ndarray):
                 if attr.shape[0] != self.nparticles:
-                    print(key, attr.shape, self.nparticles)
                     raise exceptions.InconsistentArguments(
                         "Inconsistent black hole array sizes! (nparticles=%d, "
                         "%s=%d)" % (self.nparticles, key, attr.shape[0])

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -168,7 +168,7 @@ class BlackHoles(Particles, BlackholesComponent):
             masses=masses,
             redshift=redshift,
             softening_length=softening_length,
-            nparticles=len(masses),
+            nparticles=masses.size,
             centre=centre,
             tau_v=tau_v,
             name="Black Holes",

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -168,7 +168,7 @@ class BlackHoles(Particles, BlackholesComponent):
             masses=masses,
             redshift=redshift,
             softening_length=softening_length,
-            nparticles=masses.size,
+            nparticles=masses.shape[0],
             centre=centre,
             tau_v=tau_v,
             name="Black Holes",

--- a/src/synthesizer/particle/gas.py
+++ b/src/synthesizer/particle/gas.py
@@ -131,7 +131,7 @@ class Gas(Particles):
             masses=masses,
             redshift=redshift,
             softening_length=softening_length,
-            nparticles=len(masses),
+            nparticles=masses.shape[0],
             centre=centre,
             metallicity_floor=metallicity_floor,
             tau_v=tau_v,

--- a/src/synthesizer/particle/gas.py
+++ b/src/synthesizer/particle/gas.py
@@ -131,7 +131,7 @@ class Gas(Particles):
             masses=masses,
             redshift=redshift,
             softening_length=softening_length,
-            nparticles=masses.shape[0],
+            nparticles=masses.size,
             centre=centre,
             metallicity_floor=metallicity_floor,
             tau_v=tau_v,

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -726,6 +726,14 @@ class Particles:
             compute_column_density,
         )
 
+        # If have no particles return 0
+        if self.nparticles == 0:
+            return np.zeros(self.nparticles)
+
+        # If the other particles have no particles return 0
+        if other_parts.nparticles == 0:
+            return np.zeros(self.nparticles)
+
         # If we don't have a mask make a fake one for consistency
         if mask is None:
             mask = np.ones(self.nparticles, dtype=bool)

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -461,6 +461,10 @@ class Stars(Particles, StarsComponent):
                 "The Grid does not contain the key '%s'" % spectra_name
             )
 
+        # If we have no stars just return zeros
+        if self.nstars == 0:
+            return np.zeros(len(grid.lam))
+
         # Are we checking the particles are consistent with the grid?
         if do_grid_check:
             # How many particles lie below the grid limits?
@@ -819,6 +823,20 @@ class Stars(Particles, StarsComponent):
         if not isinstance(line_id, str):
             raise exceptions.InconsistentArguments("line_id must be a string")
 
+        # If we have no stars just return zeros
+        if self.nstars == 0:
+            return Line(
+                *[
+                    Line(
+                        line_id=line_id_,
+                        wavelength=grid.line_lams[line_id_] * angstrom,
+                        luminosity=np.zeros(self.nparticles) * erg / s,
+                        continuum=np.zeros(self.nparticles) * erg / s / Hz,
+                    )
+                    for line_id_ in line_id.split(",")
+                ]
+            )
+
         # Ensure and warn that the masking hasn't removed everything
         if mask is not None and np.sum(mask) == 0:
             warn("Age mask has filtered out all particles")
@@ -935,6 +953,10 @@ class Stars(Particles, StarsComponent):
             raise exceptions.MissingSpectraType(
                 f"The Grid does not contain the key '{spectra_name}'"
             )
+
+        # If we have no stars just return zeros
+        if self.nstars == 0:
+            return np.zeros((self.nstars, len(grid.lam)))
 
         # Are we checking the particles are consistent with the grid?
         if do_grid_check:
@@ -1090,6 +1112,20 @@ class Stars(Particles, StarsComponent):
         # Ensure line_id is a string
         if not isinstance(line_id, str):
             raise exceptions.InconsistentArguments("line_id must be a string")
+
+        # If we have no stars just return zeros
+        if self.nstars == 0:
+            return Line(
+                *[
+                    Line(
+                        line_id=line_id_,
+                        wavelength=grid.line_lams[line_id_] * angstrom,
+                        luminosity=np.zeros(self.nparticles) * erg / s,
+                        continuum=np.zeros(self.nparticles) * erg / s / Hz,
+                    )
+                    for line_id_ in line_id.split(",")
+                ]
+            )
 
         # Ensure and warn that the masking hasn't removed everything
         if np.sum(mask) == 0:

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -177,7 +177,7 @@ class Stars(Particles, StarsComponent):
             masses=current_masses,
             redshift=redshift,
             softening_length=softening_length,
-            nparticles=len(initial_masses),
+            nparticles=initial_masses.shape[0],
             centre=centre,
             metallicity_floor=metallicity_floor,
             tau_v=tau_v,

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -177,7 +177,7 @@ class Stars(Particles, StarsComponent):
             masses=current_masses,
             redshift=redshift,
             softening_length=softening_length,
-            nparticles=initial_masses.shape[0],
+            nparticles=initial_masses.size,
             centre=centre,
             metallicity_floor=metallicity_floor,
             tau_v=tau_v,


### PR DESCRIPTION
It's not uncommon when running a full simulation to find galaxies with no black holes (or even no stars or no gas depending on what analysis is being done). Previously Synthesizer would error in a bunch of strange ways in this eventuality. This PR adds a bunch of catches to ensure observables are still returned for empty components ensuring all downstream observables will be generated regardless.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
