### PR TITLE
Making per particle spectra an emission model attribute not a method choice

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -40,6 +40,9 @@ jobs:
         # Output the compilation report so it can be viewed in an action log
         cat build_synth.log
     - uses: chartboost/ruff-action@v1  # Lint with Ruff
+      with:
+        version: 0.6.0
+        changed-files: 'true'
     - name: Download test data
       run: |
         # Download test grid data

--- a/docs/source/emission_models/combined_models.ipynb
+++ b/docs/source/emission_models/combined_models.ipynb
@@ -171,6 +171,40 @@
     ")\n",
     "total.plot_emission_tree(fontsize=6, figsize=(12, 8))"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Combining integrated and per particle emission\n",
+    "\n",
+    "You may want to have a model with per particle emission for the components and integrated emission for the galaxy (since per particle emission is nonsensical when talking about the combined emission from the whole galaxy). This can be achieved either by passing ``per_particle=True`` at instantiation of the component level models (see the [usage section](model_usage.ipynb)) or by calling the setter method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "total.set_per_particle(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calling this setter method will set all child models to have per_particle=True while respecting that galaxy level models should have per_particle=False. We can see this in the emission model plot."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "total.plot_emission_tree(fontsize=6, figsize=(12, 8))"
+   ]
   }
  ],
  "metadata": {},

--- a/docs/source/emission_models/model_usage.ipynb
+++ b/docs/source/emission_models/model_usage.ipynb
@@ -177,6 +177,70 @@
     "sub_model = total[\"reprocessed\"]\n",
     "sub_model.plot_emission_tree()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generating spectra and lines\n",
+    "\n",
+    "We'll cover this in greater detail in the [spectra docs](../spectra/spectra.rst) and the [lines docs](../lines/lines.rst), but to generate an emission from an ``EmissionModel`` you need to:\n",
+    "\n",
+    "- Set up your model as shown in the other ``EmissionModel`` docs.\n",
+    "- Set up an \"emitter\" (e.g. a component or galaxy containing components) as shown in the [component docs](../components/components.rst.\n",
+    "- Call the emitter's ``get_spectra`` method passing in your model.\n",
+    "\n",
+    "This will return the spectra/lines at the root of your emission model and store all generated spectra in the emitter.\n",
+    "\n",
+    "### Generating emissions for each particle\n",
+    "\n",
+    "To generate spectra for each particle in a component/galaxy we follow the exact same steps as above, but we need to set ``per_particle=True`` on our model. This can be done at model instantiation...\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a model for per particle emission\n",
+    "total = TotalEmission(\n",
+    "    grid=grid,\n",
+    "    label=\"total\",\n",
+    "    dust_curve=PowerLaw(slope=-1),\n",
+    "    tau_v=0.67,\n",
+    "    per_particle=True,\n",
+    ")\n",
+    "total.plot_emission_tree()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or by using the ``set_per_particle`` method on the model. This will set the model it is called from and any child models to generate spectra for each particle in the emitter. Below we'll demonstrate this by making every model in the ``total`` model we made above to be integrated (``per_particle=False``) and then set some of the children to be per particle."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "total.set_per_particle(False)\n",
+    "total[\"reprocessed\"].set_per_particle(True)\n",
+    "total[\"escaped\"].set_per_particle(True)\n",
+    "total.plot_emission_tree()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice how now the ``\"total\"`` and ``\"attenuated\"`` models don't mention per particle emission while all others (which are children of ``\"reprocessed\"``) have ``Per particle emission: True`` in their summary.\n",
+    "\n",
+    "When ``per_particle=True`` the model will generate a spectrum for each particle in the component/galaxy, for each individual model in your ``EmissionModel``, and store these in the ``particle_spectra`` attribute. Note that integrated spectra will automatically be generated too and will be stored in the ``spectra`` attribute."
+   ]
   }
  ],
  "metadata": {},

--- a/docs/source/imaging/particle_data_cube.ipynb
+++ b/docs/source/imaging/particle_data_cube.ipynb
@@ -43,8 +43,8 @@
     ")[0]\n",
     "\n",
     "# Calculate the stellar rest frame SEDs for all particles in erg / s / Hz\n",
-    "model = IntrinsicEmission(grid, fesc=0.1)\n",
-    "sed = gal.stars.get_particle_spectra(model)\n",
+    "model = IntrinsicEmission(grid, fesc=0.1, per_particle=True)\n",
+    "sed = gal.stars.get_spectra(model)\n",
     "\n",
     "# Calculate the observed SED in nJy\n",
     "sed.get_fnu(cosmo, gal.redshift)"

--- a/docs/source/imaging/particle_imaging.ipynb
+++ b/docs/source/imaging/particle_imaging.ipynb
@@ -56,7 +56,7 @@
    "source": [
     "### Getting the photometry\n",
     "\n",
-    "To make an image we need to generate spectra for each individual star particle. To do this we use the galaxy's in built `generate_particle_spectra` method, and create `\"total\"` SEDs with both stellar and nebular contributions. \n",
+    "To make an image we need to generate spectra for each individual star particle. To do this we use the galaxy's in built `get_spectra` method and pass a `per_particle` model. This will generate a spectrum for each particle in the galaxy.\n",
     "\n",
     "We can then calculate the photometry on these spectra by defining a filter collection, and calculating the luminosities.\n"
    ]
@@ -69,8 +69,8 @@
    "outputs": [],
    "source": [
     "# Calculate the stellar rest frame SEDs for all particles in erg / s / Hz\n",
-    "model = IncidentEmission(grid)\n",
-    "sed = gal.stars.get_particle_spectra(model)\n",
+    "model = IncidentEmission(grid, per_particle=True)\n",
+    "sed = gal.stars.get_spectra(model)\n",
     "\n",
     "# Calculate the observed SED in nJy\n",
     "sed.get_fnu(cosmo, gal.redshift, igm=None)\n",

--- a/docs/source/lines/galaxy_lines.ipynb
+++ b/docs/source/lines/galaxy_lines.ipynb
@@ -71,7 +71,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the case of a particle based galaxy you can either get the integrated line emission (``get_lines``) or per-particle line emission (``get_particle_lines``)."
+    "In the case of a particle based galaxy you can either get the integrated line emission or per-particle line emission (by using a per particle model) the  with ``get_lines`` method."
    ]
   },
   {
@@ -99,17 +99,15 @@
     "    dust_emission=Blackbody(temperature=50 * kelvin),\n",
     "    fesc=0.5,\n",
     "    fesc_ly_alpha=1.0,\n",
+    "    per_particle=True,\n",
     ")\n",
     "\n",
     "# Get the spectra and lines\n",
-    "stars.get_spectra(model)\n",
-    "stars.get_lines((line_ratios.Hb, line_ratios.O3r, line_ratios.O3b), model)\n",
-    "print(stars.lines[\"emergent\"])\n",
-    "\n",
     "stars.get_particle_spectra(model)\n",
-    "stars.get_particle_lines(\n",
+    "stars.get_lines(\n",
     "    (line_ratios.Hb, line_ratios.O3r, line_ratios.O3b), model\n",
     ")\n",
+    "print(stars.lines[\"emergent\"])\n",
     "print(stars.particle_lines[\"emergent\"])"
    ]
   },

--- a/docs/source/lines/galaxy_lines.ipynb
+++ b/docs/source/lines/galaxy_lines.ipynb
@@ -104,9 +104,7 @@
     "\n",
     "# Get the spectra and lines\n",
     "stars.get_spectra(model)\n",
-    "stars.get_lines(\n",
-    "    (line_ratios.Hb, line_ratios.O3r, line_ratios.O3b), model\n",
-    ")\n",
+    "stars.get_lines((line_ratios.Hb, line_ratios.O3r, line_ratios.O3b), model)\n",
     "print(stars.lines[\"emergent\"])\n",
     "print(stars.particle_lines[\"emergent\"])"
    ]

--- a/docs/source/lines/galaxy_lines.ipynb
+++ b/docs/source/lines/galaxy_lines.ipynb
@@ -103,7 +103,7 @@
     ")\n",
     "\n",
     "# Get the spectra and lines\n",
-    "stars.get_particle_spectra(model)\n",
+    "stars.get_spectra(model)\n",
     "stars.get_lines(\n",
     "    (line_ratios.Hb, line_ratios.O3r, line_ratios.O3b), model\n",
     ")\n",

--- a/docs/source/photometry/galaxy_phot.ipynb
+++ b/docs/source/photometry/galaxy_phot.ipynb
@@ -300,7 +300,8 @@
    "outputs": [],
    "source": [
     "# Get the particle spectra\n",
-    "gal.stars.get_particle_spectra(pc_model)\n",
+    "pc_model.set_per_particle(True)\n",
+    "gal.stars.get_spectra(pc_model)\n",
     "\n",
     "# Get the particle photometry\n",
     "gal.stars.get_particle_photo_lnu(filters)\n",

--- a/docs/source/spectra/blackholes.ipynb
+++ b/docs/source/spectra/blackholes.ipynb
@@ -307,8 +307,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Since we now want integrated spectra lets remove the per\n",
-    "# particle flag\n",
+    "# Since we now want integrated spectra lets remove the per particle flag\n",
     "dust_model.set_per_particle(False)\n",
     "\n",
     "blackhole.clear_all_spectra()\n",

--- a/docs/source/spectra/blackholes.ipynb
+++ b/docs/source/spectra/blackholes.ipynb
@@ -206,7 +206,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To generate a spectra for each black hole (per--particle) we use the same emission model, but swap out the ``get_spectra`` method (used for integrated spectra) with the ``get_particle_spectra`` method (only particle components have this method)."
+    "To generate a spectra for each black hole (per particle) we use the same emission model, but we need to tell the model to produce a spectrum for each particle. This is done by setting the ``per_particle`` flag to ``True`` on the model."
    ]
   },
   {
@@ -215,7 +215,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spectra = blackholes.get_particle_spectra(dust_model, verbose=True)"
+    "dust_model.set_per_particle(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With that done we just call the same ``get_spectra`` method on the component, and the particle spectra will be stored in the ``particle_spectra`` attribute of the component."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spectra = blackholes.get_spectra(dust_model, verbose=True)"
    ]
   },
   {
@@ -256,7 +272,7 @@
    "source": [
     "### Integrating spectra\n",
     "\n",
-    "To get integrated spectra from the particle spectra we just generated, we can call the ``integrate_particle_spectra`` method. This method will sum the individual spectra and populate the ``spectra`` dictionary.\n",
+    "The integrated spectra are automatically produced alongside per particle spectra. However, if we wanted to explictly get the integrated spectra from the particle spectra we just generated (for instance if we had made some modification after generation), we can call the ``integrate_particle_spectra`` method. This method will sum the individual spectra and populate the ``spectra`` dictionary.\n",
     "\n",
     "Note, we can also integrate individual spectra using the ``Sed.sum()`` method."
    ]
@@ -291,6 +307,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Since we now want integrated spectra lets remove the per \n",
+    "# particle flag\n",
+    "dust_model.set_per_particle(False)\n",
+    "\n",
     "blackhole.clear_all_spectra()\n",
     "spectra = {}\n",
     "for fesc in [0.1, 0.5, 0.9]:\n",

--- a/docs/source/spectra/blackholes.ipynb
+++ b/docs/source/spectra/blackholes.ipynb
@@ -307,7 +307,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Since we now want integrated spectra lets remove the per \n",
+    "# Since we now want integrated spectra lets remove the per\n",
     "# particle flag\n",
     "dust_model.set_per_particle(False)\n",
     "\n",

--- a/docs/source/spectra/stars.ipynb
+++ b/docs/source/spectra/stars.ipynb
@@ -259,8 +259,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Since we now want integrated spectra lets remove the per\n",
-    "# particle flag\n",
+    "# Since we now want integrated spectra lets remove the per particle flag\n",
     "pacman.set_per_particle(False)\n",
     "\n",
     "stars.clear_all_spectra()\n",

--- a/docs/source/spectra/stars.ipynb
+++ b/docs/source/spectra/stars.ipynb
@@ -259,7 +259,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Since we now want integrated spectra lets remove the per \n",
+    "# Since we now want integrated spectra lets remove the per\n",
     "# particle flag\n",
     "pacman.set_per_particle(False)\n",
     "\n",

--- a/docs/source/spectra/stars.ipynb
+++ b/docs/source/spectra/stars.ipynb
@@ -157,8 +157,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To generate a spectra for each star particle we use the same model, but swap out the ``get_spectra`` method we used for integrated spectra with the ``get_particle_spectra`` method.\n",
-    "Only particle components have this latter method."
+    "To generate a spectra for each star particle we use the same model, but we need to tell the model to produce a spectrum for each particle. This is done by setting the ``per_particle`` flag to ``True`` on the model."
    ]
   },
   {
@@ -167,7 +166,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spectra = stars.get_particle_spectra(pacman, verbose=True)"
+    "pacman.set_per_particle(True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With that done we just call the same ``get_spectra`` method on the component, and the particle spectra will be stored in the ``particle_spectra`` attribute of the component."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spectra = stars.get_spectra(pacman, verbose=True)"
    ]
   },
   {
@@ -208,7 +223,7 @@
    "source": [
     "### Integrating spectra\n",
     "\n",
-    "To get integrated spectra from the particle spectra we just generated, we can call the ``integrate_particle_spectra`` method.\n",
+    "The integrated spectra are automatically produced alongside per particle spectra. However, if we wanted to explictly get the integrated spectra from the particle spectra we just generated (for instance if we had made some modification after generation), we can call the ``integrate_particle_spectra`` method.\n",
     "This method will sum the individual spectra, and populate the ``spectra`` dictionary.\n",
     "\n",
     "Note that we can also integrate individual spectra using the [``Sed.sum()`` method](../sed/sed.ipynb)."
@@ -244,6 +259,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Since we now want integrated spectra lets remove the per \n",
+    "# particle flag\n",
+    "pacman.set_per_particle(False)\n",
+    "\n",
     "stars.clear_all_spectra()\n",
     "spectra = {}\n",
     "for tau_v in [0.1, 0.5, 1.0]:\n",

--- a/examples/blackholes/plot_single_bh_test.py
+++ b/examples/blackholes/plot_single_bh_test.py
@@ -42,8 +42,8 @@ part_bh = BlackHoles(
 )
 
 # Define the emission model
-nlr_grid = Grid("test_grid_agn-nlr", grid_dir="../../../tests/test_grid")
-blr_grid = Grid("test_grid_agn-blr", grid_dir="../../../tests/test_grid")
+nlr_grid = Grid("test_grid_agn-nlr", grid_dir="../../tests/test_grid")
+blr_grid = Grid("test_grid_agn-blr", grid_dir="../../tests/test_grid")
 model = UnifiedAGN(
     nlr_grid,
     blr_grid,
@@ -57,20 +57,17 @@ ngp_para_spectra = para_bh.get_spectra(
     model,
     grid_assignment_method="ngp",
 )
-ngp_part_spectra = part_bh.get_particle_spectra(
+ngp_part_spectra = part_bh.get_spectra(
     model,
     grid_assignment_method="ngp",
 )
-
-for key in part_bh.particle_spectra:
-    ngp_part_spectra[key]._lnu = ngp_part_spectra[key]._lnu[0, :]
 
 # Now plot spectra each comparison
 for key in para_bh.spectra:
     # Create spectra dict for plotting
     spectra = {
-        "Parametric (NGP)" + key: ngp_para_spectra[key],
-        "Particle (NGP)" + key: ngp_part_spectra[key],
+        "Parametric (NGP)" + key: ngp_para_spectra,
+        "Particle (NGP)" + key: ngp_part_spectra,
     }
 
     plot_spectra(spectra, show=True, quantity_to_plot="luminosity")

--- a/examples/particle/plot_los_spectra.py
+++ b/examples/particle/plot_los_spectra.py
@@ -63,6 +63,7 @@ model = TotalEmission(
     tau_v="tau_v",
     dust_curve=PowerLaw(slope=-1),
     fesc=0.1,
+    per_particle=True,
 )
 
 # Define the grid (normally this would be defined by an SPS grid)
@@ -132,7 +133,7 @@ sph_kernel = Kernel()
 kernel_data = sph_kernel.get_kernel()
 
 # Calculate the tau_vs
-galaxy.calculate_los_tau_v(
+galaxy.get_stellar_los_tau_v(
     kappa=0.07,
     kernel=kernel_data,
     force_loop=False,
@@ -140,7 +141,7 @@ galaxy.calculate_los_tau_v(
 
 # Get the spectra (this will automatically use the tau_vs we just calculated
 # since the emission model has tau_v="tau_v")
-galaxy.stars.get_particle_spectra(model)
+galaxy.stars.get_spectra(model)
 
 # Integrate the particle spectra
 galaxy.integrate_particle_spectra()

--- a/profiling/image_strong_scaling.py
+++ b/profiling/image_strong_scaling.py
@@ -118,8 +118,8 @@ def image_strong_scaling(
     print(gal.stars.radii.max())
 
     # Calculate the stellar rest frame SEDs for all particles in erg / s / Hz
-    model = IncidentEmission(grid)
-    sed = gal.stars.get_particle_spectra(model)
+    model = IncidentEmission(grid, per_particle=True)
+    sed = gal.stars.get_spectra(model)
 
     # Calculate the observed SED in nJy
     sed.get_fnu(cosmo, gal.redshift, igm=None)

--- a/profiling/spectral_cube_strong_scaling.py
+++ b/profiling/spectral_cube_strong_scaling.py
@@ -119,8 +119,8 @@ def cube_strong_scaling(
     print(gal.stars.radii.max())
 
     # Calculate the stellar rest frame SEDs for all particles in erg / s / Hz
-    model = IncidentEmission(grid)
-    sed = gal.stars.get_particle_spectra(model)
+    model = IncidentEmission(grid, per_particle=True)
+    sed = gal.stars.get_spectra(model)
 
     # Calculate the observed SED in nJy
     sed.get_fnu(cosmo, gal.redshift, igm=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ dependencies = [
 [project.optional-dependencies]
 # Development
 dev = [
-    "ruff>=0.3.0",
+    "ruff==0.6.0",
 ]
 # Testing
 test = [

--- a/src/synthesizer/base_galaxy.py
+++ b/src/synthesizer/base_galaxy.py
@@ -808,9 +808,8 @@ class BaseGalaxy:
                 The combined spectra for the galaxy.
         """
         # Get the spectra
-        spectra = emission_model._get_spectra(
+        spectra, particle_spectra = emission_model._get_spectra(
             emitters={"stellar": self.stars, "blackhole": self.black_holes},
-            per_particle=False,
             dust_curves=dust_curves,
             tau_v=tau_v,
             covering_fraction=covering_fraction,
@@ -834,6 +833,23 @@ class BaseGalaxy:
                 raise KeyError(
                     f"Unknown emitter in emission model. ({model.emitter})"
                 )
+
+            # If the model is particle based then we need to save the particle
+            # spectra
+            if model.per_particle:
+                if model.emitter == "stellar":
+                    self.stars.particle_spectra[model.label] = (
+                        particle_spectra[model.label]
+                    )
+                elif model.emitter == "blackhole":
+                    self.black_holes.particle_spectra[model.label] = (
+                        particle_spectra[model.label]
+                    )
+                else:
+                    raise KeyError(
+                        "Unknown emitter in per particle "
+                        f"emission model. ({model.emitter})"
+                    )
 
         return self.spectra[emission_model.label]
 
@@ -901,10 +917,9 @@ class BaseGalaxy:
                 The combined lines for the galaxy.
         """
         # Get the lines
-        lines = emission_model._get_lines(
+        lines, particle_lines = emission_model._get_lines(
             line_ids=line_ids,
             emitters={"stellar": self.stars, "blackhole": self.black_holes},
-            per_particle=False,
             dust_curves=dust_curves,
             tau_v=tau_v,
             covering_fraction=covering_fraction,
@@ -928,6 +943,23 @@ class BaseGalaxy:
                 raise KeyError(
                     f"Unknown emitter in emission model. ({model.emitter})"
                 )
+
+            # If the model is particle based then we need to save the particle
+            # lines
+            if model.per_particle:
+                if model.emitter == "stellar":
+                    self.stars.particle_lines[model.label] = particle_lines[
+                        model.label
+                    ]
+                elif model.emitter == "blackhole":
+                    self.black_holes.particle_lines[model.label] = (
+                        particle_lines[model.label]
+                    )
+                else:
+                    raise KeyError(
+                        "Unknown emitter in per particle "
+                        f"emission model. ({model.emitter})"
+                    )
 
         return self.lines[emission_model.label]
 

--- a/src/synthesizer/components/blackhole.py
+++ b/src/synthesizer/components/blackhole.py
@@ -822,9 +822,8 @@ class BlackholesComponent:
                 (spectra/particle_spectra)
         """
         # Get the spectra
-        spectra = emission_model._get_spectra(
+        spectra, particle_spectra = emission_model._get_spectra(
             emitters={"blackhole": self},
-            per_particle=False,
             dust_curves=dust_curves,
             tau_v=tau_v,
             fesc=covering_fraction,
@@ -835,6 +834,11 @@ class BlackholesComponent:
 
         # Update the spectra dictionary
         self.spectra.update(spectra)
+
+        # If we have particle spectra update the particle_spectra dictionary
+        # too
+        if hasattr(self, "particle_spectra"):
+            self.particle_spectra.update(particle_spectra)
 
         return self.spectra[emission_model.label]
 
@@ -903,10 +907,9 @@ class BlackholesComponent:
                 root model.
         """
         # Get the lines
-        lines = emission_model._get_lines(
+        lines, particle_lines = emission_model._get_lines(
             line_ids=line_ids,
             emitters={"blackhole": self},
-            per_particle=False,
             dust_curves=dust_curves,
             tau_v=tau_v,
             fesc=covering_fraction,
@@ -917,6 +920,10 @@ class BlackholesComponent:
 
         # Update the lines dictionary
         self.lines.update(lines)
+
+        # Update the particle lines dictionary if it exists
+        if hasattr(self, "particle_lines"):
+            self.particle_lines.update(particle_lines)
 
         return self.lines[emission_model.label]
 

--- a/src/synthesizer/components/blackhole.py
+++ b/src/synthesizer/components/blackhole.py
@@ -840,6 +840,9 @@ class BlackholesComponent:
         if hasattr(self, "particle_spectra"):
             self.particle_spectra.update(particle_spectra)
 
+        # Return the spectra the user wants
+        if emission_model.per_particle:
+            return self.particle_spectra[emission_model.label]
         return self.spectra[emission_model.label]
 
     def get_lines(
@@ -925,6 +928,9 @@ class BlackholesComponent:
         if hasattr(self, "particle_lines"):
             self.particle_lines.update(particle_lines)
 
+        # Return the lines the user wants
+        if emission_model.per_particle:
+            return self.particle_lines[emission_model.label]
         return self.lines[emission_model.label]
 
     def clear_all_spectra(self):

--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -381,9 +381,8 @@ class StarsComponent:
                 (spectra/particle_spectra)
         """
         # Get the spectra
-        spectra = emission_model._get_spectra(
+        spectra, particle_spectra = emission_model._get_spectra(
             emitters={"stellar": self},
-            per_particle=False,
             dust_curves=dust_curves,
             tau_v=tau_v,
             fesc=fesc,
@@ -394,6 +393,10 @@ class StarsComponent:
 
         # Update the spectra dictionary
         self.spectra.update(spectra)
+
+        # Update the particle_spectra dictionary if it exists
+        if hasattr(self, "particle_spectra"):
+            self.particle_spectra.update(particle_spectra)
 
         return self.spectra[emission_model.label]
 
@@ -462,10 +465,9 @@ class StarsComponent:
                 root model.
         """
         # Get the lines
-        lines = emission_model._get_lines(
+        lines, particle_lines = emission_model._get_lines(
             line_ids=line_ids,
             emitters={"stellar": self},
-            per_particle=False,
             dust_curves=dust_curves,
             tau_v=tau_v,
             fesc=fesc,
@@ -476,6 +478,10 @@ class StarsComponent:
 
         # Update the lines dictionary
         self.lines.update(lines)
+
+        # Update the particle_lines dictionary if it exists
+        if hasattr(self, "particle_lines"):
+            self.particle_lines.update(particle_lines)
 
         return self.lines[emission_model.label]
 

--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -398,6 +398,9 @@ class StarsComponent:
         if hasattr(self, "particle_spectra"):
             self.particle_spectra.update(particle_spectra)
 
+        # Return the spectra the user wants
+        if emission_model.per_particle:
+            return self.particle_spectra[emission_model.label]
         return self.spectra[emission_model.label]
 
     def get_lines(
@@ -483,6 +486,9 @@ class StarsComponent:
         if hasattr(self, "particle_lines"):
             self.particle_lines.update(particle_lines)
 
+        # Return the lines the user wants
+        if emission_model.per_particle:
+            return self.particle_lines[emission_model.label]
         return self.lines[emission_model.label]
 
     def clear_all_spectra(self):

--- a/src/synthesizer/components/unified_agn.py
+++ b/src/synthesizer/components/unified_agn.py
@@ -1,0 +1,1 @@
+#!/usr/bin/env python3

--- a/src/synthesizer/emission_models/agn/unified_agn.py
+++ b/src/synthesizer/emission_models/agn/unified_agn.py
@@ -139,6 +139,7 @@ class UnifiedAGN(BlackHoleEmissionModel):
         covering_fraction_blr,
         torus_emission_model,
         label="intrinsic",
+        **kwargs,
     ):
         """
         Initialize the UnifiedAGN model.
@@ -150,14 +151,18 @@ class UnifiedAGN(BlackHoleEmissionModel):
             covering_fraction_blr (float): The covering fraction of the BLR.
             torus_emission_model (synthesizer.dust.EmissionModel): The dust
                 emission model to use for the torus.
+            label (str): The label for the model.
+            **kwargs: Any additional keyword arguments to pass to the
+                BlackHoleEmissionModel.
         """
         # Get the incident istropic disc emission model
         self.disc_incident_isotropic = self._make_disc_incident_isotropic(
             nlr_grid,
+            **kwargs,
         )
 
         # Get the incident model accounting for the geometry but unmasked
-        self.disc_incident = self._make_disc_incident(nlr_grid)
+        self.disc_incident = self._make_disc_incident(nlr_grid, **kwargs)
 
         # Get the transmitted disc emission models
         (
@@ -169,6 +174,7 @@ class UnifiedAGN(BlackHoleEmissionModel):
             blr_grid,
             covering_fraction_nlr,
             covering_fraction_blr,
+            **kwargs,
         )
 
         # Get the escaped disc emission model
@@ -176,10 +182,11 @@ class UnifiedAGN(BlackHoleEmissionModel):
             nlr_grid,
             covering_fraction_nlr,
             covering_fraction_blr,
+            **kwargs,
         )
 
         # Get the disc emission model
-        self.disc = self._make_disc()
+        self.disc = self._make_disc(**kwargs)
 
         # Get the line regions
         self.nlr, self.blr = self._make_line_regions(
@@ -187,10 +194,11 @@ class UnifiedAGN(BlackHoleEmissionModel):
             blr_grid,
             covering_fraction_nlr,
             covering_fraction_blr,
+            **kwargs,
         )
 
         # Get the torus emission model
-        self.torus = self._make_torus(torus_emission_model)
+        self.torus = self._make_torus(torus_emission_model, **kwargs)
 
         # Create the final model
         BlackHoleEmissionModel.__init__(
@@ -207,20 +215,22 @@ class UnifiedAGN(BlackHoleEmissionModel):
                 self.disc_incident,
             ),
             post_processing=(scale_by_incident_isotropic,),
+            **kwargs,
         )
 
-    def _make_disc_incident_isotropic(self, grid):
+    def _make_disc_incident_isotropic(self, grid, **kwargs):
         """Make the disc spectra assuming isotropic emission."""
         model = BlackHoleEmissionModel(
             grid=grid,
             label="disc_incident_isotropic",
             extract="incident",
             fixed_parameters={"cosine_inclination": 0.5},
+            **kwargs,
         )
 
         return model
 
-    def _make_disc_incident(self, grid):
+    def _make_disc_incident(self, grid, **kwargs):
         """Make the disc spectra."""
         model = BlackHoleEmissionModel(
             grid=grid,
@@ -229,6 +239,7 @@ class UnifiedAGN(BlackHoleEmissionModel):
             mask_attr="_torus_edgeon_cond",
             mask_thresh=90 * deg,
             mask_op="<",
+            **kwargs,
         )
 
         return model
@@ -239,6 +250,7 @@ class UnifiedAGN(BlackHoleEmissionModel):
         blr_grid,
         covering_fraction_nlr,
         covering_fraction_blr,
+        **kwargs,
     ):
         """Make the disc transmitted spectra."""
         # Make the line regions
@@ -250,6 +262,7 @@ class UnifiedAGN(BlackHoleEmissionModel):
             mask_attr="_torus_edgeon_cond",
             mask_thresh=90 * deg,
             mask_op="<",
+            **kwargs,
         )
         blr = BlackHoleEmissionModel(
             grid=blr_grid,
@@ -259,6 +272,7 @@ class UnifiedAGN(BlackHoleEmissionModel):
             mask_attr="_torus_edgeon_cond",
             mask_thresh=90 * deg,
             mask_op="<",
+            **kwargs,
         )
 
         # Combine the models
@@ -268,6 +282,7 @@ class UnifiedAGN(BlackHoleEmissionModel):
             mask_attr="_torus_edgeon_cond",
             mask_thresh=90 * deg,
             mask_op="<",
+            **kwargs,
         )
 
         return nlr, blr, model
@@ -277,6 +292,7 @@ class UnifiedAGN(BlackHoleEmissionModel):
         grid,
         covering_fraction_nlr,
         covering_fraction_blr,
+        **kwargs,
     ):
         """
         Make the disc escaped spectra.
@@ -289,11 +305,12 @@ class UnifiedAGN(BlackHoleEmissionModel):
             label="disc_escaped",
             extract="incident",
             fesc=(covering_fraction_nlr + covering_fraction_blr),
+            **kwargs,
         )
 
         return model
 
-    def _make_disc(self):
+    def _make_disc(self, **kwargs):
         """Make the disc spectra."""
         return BlackHoleEmissionModel(
             label="disc",
@@ -301,6 +318,7 @@ class UnifiedAGN(BlackHoleEmissionModel):
             mask_attr="_torus_edgeon_cond",
             mask_thresh=90 * deg,
             mask_op="<",
+            **kwargs,
         )
 
     def _make_line_regions(
@@ -309,6 +327,7 @@ class UnifiedAGN(BlackHoleEmissionModel):
         blr_grid,
         covering_fraction_nlr,
         covering_fraction_blr,
+        **kwargs,
     ):
         """Make the line regions."""
         # Make the line regions with fixed inclination
@@ -321,6 +340,7 @@ class UnifiedAGN(BlackHoleEmissionModel):
             mask_attr="_torus_edgeon_cond",
             mask_thresh=90 * deg,
             mask_op="<",
+            **kwargs,
         )
         blr = BlackHoleEmissionModel(
             grid=blr_grid,
@@ -331,14 +351,16 @@ class UnifiedAGN(BlackHoleEmissionModel):
             mask_attr="_torus_edgeon_cond",
             mask_thresh=90 * deg,
             mask_op="<",
+            **kwargs,
         )
         return nlr, blr
 
-    def _make_torus(self, torus_emission_model):
+    def _make_torus(self, torus_emission_model, **kwargs):
         """Make the torus spectra."""
         return BlackHoleEmissionModel(
             label="torus",
             generator=torus_emission_model,
             lum_intrinsic_model=self.disc_incident_isotropic,
             scale_by="torus_fraction",
+            **kwargs,
         )

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -581,6 +581,10 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
             # Report if the resulting emission will be saved
             parts.append(f"  Save emission: {model._save}")
 
+            # Report if the resulting emission will be per particle
+            if model._per_particle:
+                parts.append("  Per particle emission: True")
+
             # Print any fixed parameters if there are any
             if len(model.fixed_parameters) > 0:
                 parts.append("  Fixed parameters:")

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -1806,7 +1806,7 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                 tx, ty = pos[target]
                 ax.plot(
                     [sx, tx],
-                    [-sy - 1, -ty + 1],  # Invert y-axis for bottom-to-top
+                    [-sy, -ty],  # Invert y-axis for bottom-to-top
                     linestyle=linestyle,
                     color="black",
                     lw=1,

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -985,9 +985,11 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
         """Get the per particle flag."""
         return self._per_particle
 
-    def set_per_particle(self, per_particle, set_all=False):
+    def set_per_particle(self, per_particle):
         """
         Set the per particle flag.
+
+        For per particle spectra we need all children to also be per particle.
 
         Args:
             per_particle (bool):
@@ -995,15 +997,14 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
             set_all (bool):
                 Whether to set the per particle flag on all models.
         """
-        # Set the per particle flag
-        if not set_all:
+        # Set the per particle flag (but we don't want to set it on a
+        # galaxy model since they are never per particle by definition)
+        if self.emitter != "galaxy":
             self._per_particle = per_particle
-        else:
-            for model in self._models.values():
-                # Galaxy models are never per particle by definition
-                if model.emitter == "galaxy":
-                    continue
-                model.set_per_particle(per_particle)
+
+        # Set the per particle flag on all children
+        for model in self._children:
+            model.set_per_particle(per_particle)
 
         # Unpack the model now we're done
         self.unpack_model()

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -1000,6 +1000,9 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
             self._per_particle = per_particle
         else:
             for model in self._models.values():
+                # Galaxy models are never per particle by definition
+                if model.emitter == "galaxy":
+                    continue
                 model.set_per_particle(per_particle)
 
         # Unpack the model now we're done

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -2175,20 +2175,24 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
             # tree
             for related_model in this_model.related_models:
                 if related_model.label not in spectra:
-                    spectra.update(
-                        related_model._get_spectra(
-                            emitters,
-                            dust_curves=dust_curves,
-                            tau_v=tau_v,
-                            fesc=fesc,
-                            mask=mask,
-                            verbose=verbose,
-                            spectra=spectra,
-                            particle_spectra=particle_spectra,
-                            _is_related=True,
-                            **kwargs,
-                        )
+                    (
+                        rel_spectra,
+                        rel_particle_spectra,
+                    ) = related_model._get_spectra(
+                        emitters,
+                        dust_curves=dust_curves,
+                        tau_v=tau_v,
+                        fesc=fesc,
+                        mask=mask,
+                        verbose=verbose,
+                        spectra=spectra,
+                        particle_spectra=particle_spectra,
+                        _is_related=True,
+                        **kwargs,
                     )
+
+                    spectra.update(rel_particle_spectra)
+                    particle_spectra.update(rel_particle_spectra)
 
             # Skip models for a different emitters
             if (
@@ -2470,21 +2474,22 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
             # tree
             for related_model in this_model.related_models:
                 if related_model.label not in lines:
-                    lines.update(
-                        related_model._get_lines(
-                            line_ids,
-                            emitters,
-                            dust_curves=dust_curves,
-                            tau_v=tau_v,
-                            fesc=fesc,
-                            mask=mask,
-                            verbose=verbose,
-                            lines=lines,
-                            particle_lines=particle_lines,
-                            _is_related=True,
-                            **kwargs,
-                        )
+                    rel_lines, rel_particle_lines = related_model._get_lines(
+                        line_ids,
+                        emitters,
+                        dust_curves=dust_curves,
+                        tau_v=tau_v,
+                        fesc=fesc,
+                        mask=mask,
+                        verbose=verbose,
+                        lines=lines,
+                        particle_lines=particle_lines,
+                        _is_related=True,
+                        **kwargs,
                     )
+
+                    lines.update(rel_lines)
+                    particle_lines.update(rel_particle_lines)
 
             # Skip models for a different emitters
             if (

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -2319,7 +2319,7 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                     if model.per_particle and model.label in particle_spectra:
                         del particle_spectra[model.label]
 
-        return spectra
+        return spectra, particle_spectra
 
     def _get_lines(
         self,
@@ -2589,7 +2589,7 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                     if model.per_particle and model.label in particle_lines:
                         del particle_lines[model.label]
 
-        return lines
+        return lines, particle_lines
 
 
 class StellarEmissionModel(EmissionModel):

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -2574,7 +2574,7 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                 # conversion
                 if isinstance(lines[label], dict):
                     lines[label] = LineCollection(lines[label])
-                if this_model.per_particle and isinstance(
+                if self.models[label].per_particle and isinstance(
                     particle_lines[label], dict
                 ):
                     particle_lines[label] = LineCollection(

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -2591,3 +2591,9 @@ class GalaxyEmissionModel(EmissionModel):
             raise exceptions.InconsistentArguments(
                 "A GalaxyEmissionModel cannot be an extraction model."
             )
+
+        # Ensure we aren't trying to make a per particle galaxy emission
+        if self.per_particle:
+            raise exceptions.InconsistentArguments(
+                "A GalaxyEmissionModel cannot be a per particle model."
+            )

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -1724,6 +1724,9 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
         # know whether to include it in the legend
         some_discarded = False
 
+        # Define a flag for whether there are per_particle models
+        some_per_particle = False
+
         # Plot the tree using Matplotlib
         fig, ax = plt.subplots(figsize=figsize)
 
@@ -1739,7 +1742,7 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
 
             # If the model isn't saved apply some transparency
             if not self[node].save:
-                alpha = 0.6
+                alpha = 0.7
                 some_discarded = True
             else:
                 alpha = 1.0
@@ -1752,13 +1755,38 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                 bbox=dict(
                     facecolor=color,
                     edgecolor="black",
-                    boxstyle="round,pad=0.3"
+                    boxstyle="round,pad=0.5"
                     if node not in extract_labels
-                    else "square,pad=0.3",
+                    else "square,pad=0.5",
+                    alpha=alpha,
                 ),
                 fontsize=fontsize,
-                alpha=alpha,
+                zorder=1,
             )
+
+            # If we have a per particle model overlay a hatched box. To make]
+            # this readable we need to overlay a box with a transparent face
+            if self[node].per_particle:
+                some_per_particle = True
+                ax.text(
+                    x,
+                    -y,  # Invert y-axis for bottom-to-top
+                    node,
+                    ha="center",
+                    va="center",
+                    bbox=dict(
+                        facecolor=color,
+                        edgecolor="black",
+                        boxstyle="round,pad=0.5"
+                        if node not in extract_labels
+                        else "square,pad=0.5",
+                        hatch="//",
+                        alpha=0.3,
+                    ),
+                    fontsize=fontsize,
+                    alpha=1.0,
+                    zorder=2,
+                )
 
             # Used a dashed outline for masked nodes
             bbox = text.get_bbox_patch()
@@ -1778,10 +1806,11 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                 tx, ty = pos[target]
                 ax.plot(
                     [sx, tx],
-                    [-sy, -ty],  # Invert y-axis for bottom-to-top
+                    [-sy - 1, -ty + 1],  # Invert y-axis for bottom-to-top
                     linestyle=linestyle,
                     color="black",
                     lw=1,
+                    zorder=0,
                 )
 
         # Create legend elements
@@ -1823,7 +1852,7 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                     facecolor="gold",
                     edgecolor="black",
                     label="Stellar",
-                    boxstyle="round,pad=0.3",
+                    boxstyle="round,pad=0.5",
                 )
             )
         if "blackhole" in components:
@@ -1835,7 +1864,7 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                     facecolor="royalblue",
                     edgecolor="black",
                     label="Black Hole",
-                    boxstyle="round,pad=0.3",
+                    boxstyle="round,pad=0.5",
                 )
             )
         if "galaxy" in components:
@@ -1847,7 +1876,7 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                     facecolor="forestgreen",
                     edgecolor="black",
                     label="Galaxy",
-                    boxstyle="round,pad=0.3",
+                    boxstyle="round,pad=0.5",
                 )
             )
 
@@ -1862,7 +1891,7 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                     edgecolor="black",
                     label="Masked",
                     linestyle="dashed",
-                    boxstyle="round,pad=0.3",
+                    boxstyle="round,pad=0.5",
                 )
             )
 
@@ -1876,7 +1905,7 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                     facecolor="grey",
                     edgecolor="black",
                     label="Saved",
-                    boxstyle="round,pad=0.3",
+                    boxstyle="round,pad=0.5",
                 )
             )
             handles.append(
@@ -1888,7 +1917,23 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                     edgecolor="black",
                     label="Discarded",
                     alpha=0.6,
-                    boxstyle="round,pad=0.3",
+                    boxstyle="round,pad=0.5",
+                )
+            )
+
+        # If we have per particle models include them in the legend
+        if some_per_particle:
+            handles.append(
+                mpatches.FancyBboxPatch(
+                    (0.1, 0.1),
+                    width=0.5,
+                    height=0.1,
+                    facecolor="none",
+                    edgecolor="black",
+                    label="Per Particle",
+                    hatch="//",
+                    alpha=0.3,
+                    boxstyle="round,pad=0.5",
                 )
             )
 

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -1006,6 +1006,11 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
         for model in self._children:
             model.set_per_particle(per_particle)
 
+        # If this model also has related spectra we'd better make those
+        # per particle too or bad things will happen downstream
+        for model in self.related_models:
+            model.set_per_particle(per_particle)
+
         # Unpack the model now we're done
         self.unpack_model()
 

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -2574,7 +2574,9 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                 # conversion
                 if isinstance(lines[label], dict):
                     lines[label] = LineCollection(lines[label])
-                if isinstance(particle_lines[label], dict):
+                if this_model.per_particle and isinstance(
+                    particle_lines[label], dict
+                ):
                     particle_lines[label] = LineCollection(
                         particle_lines[label]
                     )

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -2574,7 +2574,7 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                 # conversion
                 if isinstance(lines[label], dict):
                     lines[label] = LineCollection(lines[label])
-                if self.models[label].per_particle and isinstance(
+                if self._models[label].per_particle and isinstance(
                     particle_lines[label], dict
                 ):
                     particle_lines[label] = LineCollection(

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -54,8 +54,8 @@ class Extraction:
         self,
         emission_model,
         emitters,
-        per_particle,
         spectra,
+        particle_spectra,
         verbose,
         **kwargs,
     ):
@@ -67,10 +67,10 @@ class Extraction:
                 The emission model to extract from.
             emitters (dict):
                 The emitters to extract the spectra for.
-            per_particle (bool):
-                Are we extracting per particle?
             spectra (dict):
                 The dictionary to store the extracted spectra in.
+            particle_spectra (dict):
+                The dictionary to store the extracted particle spectra in.
             verbose (bool):
                 Are we talking?
             kwargs (dict):
@@ -108,13 +108,13 @@ class Extraction:
                 setattr(emitter, prop, this_model.fixed_parameters[prop])
 
             # Get the generator function
-            if per_particle:
+            if this_model.per_particle:
                 generator_func = emitter.generate_particle_lnu
             else:
                 generator_func = emitter.generate_lnu
 
             # Get this base spectra
-            spectra[label] = Sed(
+            sed = Sed(
                 emission_model.lam,
                 generator_func(
                     this_model.grid,
@@ -128,19 +128,27 @@ class Extraction:
                 ),
             )
 
+            # Store the spectra in the right place (integrating if we
+            # need to)
+            if this_model.per_particle:
+                particle_spectra[label] = sed
+                spectra[label] = sed.sum()
+            else:
+                spectra[label] = sed
+
             # Replace any fixed parameters
             for prop in prev_properties:
                 setattr(emitter, prop, prev_properties[prop])
 
-        return spectra
+        return spectra, particle_spectra
 
     def _extract_lines(
         self,
         line_ids,
         emission_model,
         emitters,
-        per_particle,
         lines,
+        particle_lines,
         verbose,
         **kwargs,
     ):
@@ -158,6 +166,8 @@ class Extraction:
                 Are we generating lines per particle?
             lines (dict):
                 The dictionary to store the extracted lines in.
+            particle_lines (dict):
+                The dictionary to store the extracted particle lines in.
             verbose (bool):
                 Are we talking?
             kwargs (dict):
@@ -196,18 +206,18 @@ class Extraction:
                 setattr(emitter, prop, this_model.fixed_parameters[prop])
 
             # Get the generator function
-            if per_particle:
+            if this_model.per_particle:
                 generator_func = emitter.generate_particle_line
             else:
                 generator_func = emitter.generate_line
 
             # Initialise the lines dictionary for this label
-            lines[label] = {}
+            out_lines = {}
 
             # Loop over the line ids
             for line_id in line_ids:
                 # Get this base lines
-                lines[label][line_id] = generator_func(
+                out_lines[line_id] = generator_func(
                     grid=this_model.grid,
                     line_id=line_id,
                     line_type=this_model.extract,
@@ -219,11 +229,20 @@ class Extraction:
                     **kwargs,
                 )
 
+            # Store the lines in the right place (integrating if we need to)
+            if this_model.per_particle:
+                particle_lines[label] = out_lines
+                lines[label] = {
+                    line_id: line.sum() for line_id, line in out_lines.items()
+                }
+            else:
+                lines[label] = out_lines
+
             # Replace any fixed parameters
             for prop in prev_properties:
                 setattr(emitter, prop, prev_properties[prop])
 
-        return lines
+        return lines, particle_lines
 
     def _extract_summary(self):
         """Return a summary of an extraction model."""
@@ -287,8 +306,8 @@ class Generation:
         this_model,
         emission_model,
         spectra,
+        particle_spectra,
         lam,
-        per_particle,
         emitter,
     ):
         """
@@ -301,10 +320,10 @@ class Generation:
                 The root emission model.
             spectra (dict):
                 The dictionary of spectra.
+            particle_spectra (dict):
+                The dictionary of particle
             lam (ndarray):
                 The wavelength grid to generate the spectra on.
-            per_particle (bool):
-                Are we generating per particle?
             emitter (dict):
                 The emitter to generate the spectra for.
 
@@ -314,38 +333,57 @@ class Generation:
         """
         # Unpack what we need for dust emission
         generator = this_model.generator
+        per_particle = this_model.per_particle
 
         # Handle the dust emission case
         if this_model._is_dust_emitting:
-            intrinsic = spectra[this_model.lum_intrinsic_model.label]
-            attenuated = spectra[this_model.lum_attenuated_model.label]
+            # Get the right spectra
+            if per_particle:
+                intrinsic = particle_spectra[
+                    this_model.lum_intrinsic_model.label
+                ]
+                attenuated = particle_spectra[
+                    this_model.lum_attenuated_model.label
+                ]
+            else:
+                intrinsic = spectra[this_model.lum_intrinsic_model.label]
+                attenuated = spectra[this_model.lum_attenuated_model.label]
 
             # Apply the dust emission model
-            spectra[this_model.label] = generator.get_spectra(
+            sed = generator.get_spectra(
                 lam,
                 intrinsic,
                 attenuated,
             )
         elif this_model.lum_intrinsic_model is not None:
             # otherwise we are scaling by a single spectra
-            spectra[this_model.label] = generator.get_spectra(
+            sed = generator.get_spectra(
                 lam,
-                spectra[this_model.lum_intrinsic_model.label],
+                particle_spectra[this_model.lum_intrinsic_model.label]
+                if per_particle
+                else spectra[this_model.lum_intrinsic_model.label],
             )
         elif isinstance(generator, Template):
             # If we have a template we need to generate the spectra
             # for each model
-            spectra[this_model.label] = generator.get_spectra(
+            sed = generator.get_spectra(
                 emitter.bolometric_luminosity,
             )
 
         else:
             # Otherwise we have a bog standard generation
-            spectra[this_model.label] = generator.get_spectra(
+            sed = generator.get_spectra(
                 lam,
             )
 
-        return spectra
+        # Store the spectra in the right place (integrating if we need to)
+        if per_particle:
+            particle_spectra[this_model.label] = sed
+            spectra[this_model.label] = sed.sum()
+        else:
+            spectra[this_model.label] = sed
+
+        return spectra, particle_spectra
 
     def _generate_lines(
         self,
@@ -353,7 +391,7 @@ class Generation:
         this_model,
         emission_model,
         lines,
-        per_particle,
+        particle_lines,
         emitter,
     ):
         """
@@ -371,8 +409,8 @@ class Generation:
                 The root emission model.
             lines (dict):
                 The dictionary of lines.
-            per_particle (bool):
-                Are we generating lines per particle?
+            particle_lines (dict):
+                The dictionary of particle lines.
             emitter (Stars/BlackHoles/Galaxy):
                 The emitter to generate the lines for.
 
@@ -380,6 +418,9 @@ class Generation:
             dict:
                 The dictionary of lines.
         """
+        # Unpack what we need for dust emission
+        per_particle = this_model.per_particle
+
         # Do we already have the spectra?
         if per_particle and this_model.label in emitter.particle_spectra:
             spectra = emitter.particle_spectra[this_model.label]
@@ -393,7 +434,7 @@ class Generation:
 
         # Now we have the spectra we can get the emission at each line
         # and include it
-        lines[this_model.label] = {}
+        out_lines = {}
         for line_id in line_ids:
             # Get the emission at this lines wavelength
             lam = lines[this_model.lum_intrinsic_model.label][
@@ -404,14 +445,23 @@ class Generation:
             cont = spectra.get_lnu_at_lam(lam)
 
             # Create the line (luminoisty = continuum)
-            lines[this_model.label][line_id] = Line(
+            out_lines[line_id] = Line(
                 line_id=line_id,
                 wavelength=lam,
                 luminosity=0 * erg / s,
                 continuum=cont,
             )
 
-        return lines
+        # Store the lines in the right place (integrating if we need to)
+        if per_particle:
+            particle_lines[this_model.label] = out_lines
+            lines[this_model.label] = {
+                line_id: line.sum() for line_id, line in out_lines.items()
+            }
+        else:
+            lines[this_model.label] = out_lines
+
+        return lines, particle_lines
 
     def _generate_summary(self):
         """Return a summary of a generation model."""
@@ -482,6 +532,7 @@ class DustAttenuation:
         self,
         this_model,
         spectra,
+        particle_spectra,
         emitter,
         this_mask,
     ):
@@ -493,6 +544,8 @@ class DustAttenuation:
                 The model defining the dust attenuation.
             spectra (dict):
                 The dictionary of spectra.
+            particle_spectra (dict):
+                The dictionary of particle spectra.
             emitter (Stars/BlackHoles):
                 The emitter to dust attenuate the spectra for.
             this_mask (dict):
@@ -510,23 +563,34 @@ class DustAttenuation:
             tau_v *= getattr(emitter, tv) if isinstance(tv, str) else tv
 
         # Get the spectra to apply dust to
-        apply_dust_to = spectra[this_model.apply_dust_to.label]
+        if this_model.per_particle:
+            apply_dust_to = particle_spectra[this_model.apply_dust_to.label]
+        else:
+            apply_dust_to = spectra[this_model.apply_dust_to.label]
 
         # Otherwise, we are applying a dust curve (there's no
         # alternative)
-        spectra[this_model.label] = apply_dust_to.apply_attenuation(
+        sed = apply_dust_to.apply_attenuation(
             tau_v,
             dust_curve=this_model.dust_curve,
             mask=this_mask,
         )
 
-        return spectra
+        # Store the spectra in the right place (integrating if we need to)
+        if this_model.per_particle:
+            particle_spectra[this_model.label] = sed
+            spectra[this_model.label] = sed.sum()
+        else:
+            spectra[this_model.label] = sed
+
+        return spectra, particle_spectra
 
     def _dust_attenuate_lines(
         self,
         line_ids,
         this_model,
         lines,
+        particle_lines,
         emitter,
         this_mask,
     ):
@@ -540,6 +604,8 @@ class DustAttenuation:
                 The model defining the dust attenuation.
             lines (dict):
                 The dictionary of lines.
+            particle_lines (dict):
+                The dictionary of particle lines.
             emitter (Stars/BlackHoles):
                 The emitter to dust attenuate the lines for.
             this_mask (dict):
@@ -557,24 +623,34 @@ class DustAttenuation:
             tau_v *= getattr(emitter, tv) if isinstance(tv, str) else tv
 
         # Get the lines to apply dust to
-        apply_dust_to = lines[this_model.apply_dust_to.label]
+        if this_model.per_particle:
+            apply_dust_to = particle_lines[this_model.apply_dust_to.label]
+        else:
+            apply_dust_to = lines[this_model.apply_dust_to.label]
 
         # Create dictionary to hold the dust attenuated lines
-        lines[this_model.label] = {}
+        out_lines = {}
 
         # Loop over the line ids
         for line_id in line_ids:
             # Otherwise, we are applying a dust curve (there's no
             # alternative)
-            lines[this_model.label][line_id] = apply_dust_to[
-                line_id
-            ].apply_attenuation(
+            out_lines[line_id] = apply_dust_to[line_id].apply_attenuation(
                 tau_v,
                 dust_curve=this_model.dust_curve,
                 mask=this_mask,
             )
 
-        return lines
+        # Store the lines in the right place (integrating if we need to)
+        if this_model.per_particle:
+            particle_lines[this_model.label] = out_lines
+            lines[this_model.label] = {
+                line_id: line.sum() for line_id, line in out_lines.items()
+            }
+        else:
+            lines[this_model.label] = out_lines
+
+        return lines, particle_lines
 
     def _attenuate_summary(self):
         """Return a summary of a dust attenuation model."""
@@ -610,7 +686,13 @@ class Combination:
         # Attach the models to combine
         self._combine = list(combine) if combine is not None else combine
 
-    def _combine_spectra(self, emission_model, spectra, this_model):
+    def _combine_spectra(
+        self,
+        emission_model,
+        spectra,
+        particle_spectra,
+        this_model,
+    ):
         """
         Combine the extracted spectra.
 
@@ -620,6 +702,8 @@ class Combination:
                 wavelength grid.
             spectra (dict):
                 The dictionary of spectra.
+            particle_spectra (dict):
+                The dictionary of particle spectra.
             this_model (EmissionModel):
                 The model defining the combination.
 
@@ -628,18 +712,40 @@ class Combination:
                 The dictionary of spectra.
         """
         # Create an empty spectra to add to
-        spectra[this_model.label] = Sed(
-            emission_model.lam,
-            lnu=np.zeros_like(spectra[this_model.combine[0].label]._lnu),
-        )
+        if this_model.per_particle:
+            particle_spectra[this_model.label] = Sed(
+                emission_model.lam,
+                lnu=np.zeros_like(
+                    particle_spectra[this_model.combine[0].label]._lnu
+                ),
+            )
+        else:
+            spectra[this_model.label] = Sed(
+                emission_model.lam,
+                lnu=np.zeros_like(spectra[this_model.combine[0].label]._lnu),
+            )
 
         # Combine the spectra
         for combine_model in this_model.combine:
-            spectra[this_model.label]._lnu += spectra[combine_model.label]._lnu
+            if this_model.per_particle:
+                particle_spectra[this_model.label]._lnu += particle_spectra[
+                    combine_model.label
+                ]._lnu
+            else:
+                spectra[this_model.label]._lnu += spectra[
+                    combine_model.label
+                ]._lnu
 
-        return spectra
+        return spectra, particle_spectra
 
-    def _combine_lines(self, line_ids, emission_model, lines, this_model):
+    def _combine_lines(
+        self,
+        line_ids,
+        emission_model,
+        lines,
+        particle_lines,
+        this_model,
+    ):
         """
         Combine the extracted lines.
 
@@ -651,6 +757,8 @@ class Combination:
                 wavelength grid.
             lines (dict):
                 The dictionary of lines.
+            particle_lines (dict):
+                The dictionary of particle lines.
             this_model (EmissionModel):
                 The model defining the combination.
 
@@ -658,8 +766,14 @@ class Combination:
             dict:
                 The dictionary of lines.
         """
-        # Create dictionary to hold the combined lines
-        lines[this_model.label] = {}
+        # Get the right out lines dict and create the right entry
+        out_lines = {}
+
+        # Get the right exist lines dict
+        if this_model.per_particle:
+            in_lines = particle_lines
+        else:
+            in_lines = lines
 
         # Loop over lines copying over the first set of lines
         for line_id in line_ids:
@@ -668,22 +782,31 @@ class Combination:
             cont = 0
 
             # Get the wavelength of the line
-            lam = lines[this_model.combine[0].label][line_id].wavelength
+            lam = in_lines[this_model.combine[0].label][line_id].wavelength
 
             # Combine the lines
             for combine_model in this_model.combine:
-                lum += lines[combine_model.label][line_id]._luminosity
-                cont += lines[combine_model.label][line_id]._continuum
+                lum += in_lines[combine_model.label][line_id]._luminosity
+                cont += in_lines[combine_model.label][line_id]._continuum
 
             # Add the line to the dictionary
-            lines[this_model.label][line_id] = Line(
+            out_lines[line_id] = Line(
                 line_id=line_id,
                 wavelength=lam,
                 luminosity=lum * erg / s,
                 continuum=cont * erg / s / Hz,
             )
 
-        return lines
+        # Store the lines in the right place (integrating if we need to)
+        if this_model.per_particle:
+            particle_lines[this_model.label] = out_lines
+            lines[this_model.label] = {
+                line_id: line.sum() for line_id, line in out_lines.items()
+            }
+        else:
+            lines[this_model.label] = out_lines
+
+        return lines, particle_lines
 
     def _combine_summary(self):
         """Return a summary of a combination model."""

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -736,6 +736,13 @@ class Combination:
                     combine_model.label
                 ]._lnu
 
+        # If we made a per particle spectra we need to sum it and get the
+        # integrated spectra
+        if this_model.per_particle:
+            spectra[this_model.label] = particle_spectra[
+                this_model.label
+            ].sum()
+
         return spectra, particle_spectra
 
     def _combine_lines(

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -776,7 +776,7 @@ class BlackHoles(Particles, BlackholesComponent):
             return Line(*lines)
 
     @deprecated(
-        message="get_particle_spectra is now just a wrapper "
+        message="is now just a wrapper "
         "around get_spectra. It will be removed by v1.0.0."
     )
     def get_particle_spectra(
@@ -855,7 +855,7 @@ class BlackHoles(Particles, BlackholesComponent):
         return spectra
 
     @deprecated(
-        message="get_particle_lines is now just a wrapper "
+        message="is now just a wrapper "
         "around get_lines. It will be removed by v1.0.0."
     )
     def get_particle_lines(

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -841,7 +841,7 @@ class BlackHoles(Particles, BlackholesComponent):
                 (spectra/particle_spectra)
         """
         previous_per_part = emission_model.per_particle
-        emission_model.set_per_particle(True, set_all=True)
+        emission_model.set_per_particle(True)
         spectra = self.get_spectra(
             emission_model=emission_model,
             dust_curves=dust_curves,
@@ -851,7 +851,7 @@ class BlackHoles(Particles, BlackholesComponent):
             verbose=verbose,
             **kwargs,
         )
-        emission_model.set_per_particle(previous_per_part, set_all=True)
+        emission_model.set_per_particle(previous_per_part)
         return spectra
 
     @deprecated(
@@ -923,7 +923,7 @@ class BlackHoles(Particles, BlackholesComponent):
                 root model.
         """
         previous_per_part = emission_model.per_particle
-        emission_model.set_per_particle(True, set_all=True)
+        emission_model.set_per_particle(True)
         lines = self.get_lines(
             line_ids=line_ids,
             emission_model=emission_model,
@@ -934,5 +934,5 @@ class BlackHoles(Particles, BlackholesComponent):
             verbose=verbose,
             **kwargs,
         )
-        emission_model.set_per_particle(previous_per_part, set_all=True)
+        emission_model.set_per_particle(previous_per_part)
         return lines

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -840,6 +840,7 @@ class BlackHoles(Particles, BlackholesComponent):
                 appropriate spectra attribute of the component
                 (spectra/particle_spectra)
         """
+        emission_model.set_per_particle(True, set_all=True)
         return self.get_spectra(
             emission_model=emission_model,
             dust_curves=dust_curves,
@@ -918,6 +919,7 @@ class BlackHoles(Particles, BlackholesComponent):
                 A LineCollection object containing the lines defined by the
                 root model.
         """
+        emission_model.set_per_particle(True, set_all=True)
         return self.get_lines(
             line_ids=line_ids,
             emission_model=emission_model,

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -24,7 +24,7 @@ from synthesizer.line import Line
 from synthesizer.particle.particles import Particles
 from synthesizer.units import Quantity
 from synthesizer.utils import TableFormatter, value_to_array
-from synthesizer.warnings import warn
+from synthesizer.warnings import deprecated, warn
 
 
 class BlackHoles(Particles, BlackholesComponent):
@@ -775,6 +775,10 @@ class BlackHoles(Particles, BlackholesComponent):
         else:
             return Line(*lines)
 
+    @deprecated(
+        message="get_particle_spectra is now just a wrapper "
+        "around get_spectra. It will be removed by v1.0.0."
+    )
     def get_particle_spectra(
         self,
         emission_model,
@@ -836,23 +840,20 @@ class BlackHoles(Particles, BlackholesComponent):
                 appropriate spectra attribute of the component
                 (spectra/particle_spectra)
         """
-        # Get the spectra
-        spectra = emission_model._get_spectra(
-            emitters={"blackhole": self},
-            per_particle=True,
+        return self.get_spectra(
+            emission_model=emission_model,
             dust_curves=dust_curves,
             tau_v=tau_v,
-            fesc=covering_fraction,
+            covering_fraction=covering_fraction,
             mask=mask,
             verbose=verbose,
             **kwargs,
         )
 
-        # Update the spectra dictionary
-        self.particle_spectra.update(spectra)
-
-        return self.particle_spectra[emission_model.label]
-
+    @deprecated(
+        message="get_particle_lines is now just a wrapper "
+        "around get_lines. It will be removed by v1.0.0."
+    )
     def get_particle_lines(
         self,
         line_ids,
@@ -917,11 +918,9 @@ class BlackHoles(Particles, BlackholesComponent):
                 A LineCollection object containing the lines defined by the
                 root model.
         """
-        # Get the lines
-        lines = emission_model._get_lines(
+        return self.get_lines(
             line_ids=line_ids,
-            emitters={"blackhole": self},
-            per_particle=True,
+            emission_model=emission_model,
             dust_curves=dust_curves,
             tau_v=tau_v,
             covering_fraction=covering_fraction,
@@ -929,8 +928,3 @@ class BlackHoles(Particles, BlackholesComponent):
             verbose=verbose,
             **kwargs,
         )
-
-        # Update the lines dictionary
-        self.particle_lines.update(lines)
-
-        return self.particle_lines[emission_model.label]

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -840,8 +840,9 @@ class BlackHoles(Particles, BlackholesComponent):
                 appropriate spectra attribute of the component
                 (spectra/particle_spectra)
         """
+        previous_per_part = emission_model.per_particle
         emission_model.set_per_particle(True, set_all=True)
-        return self.get_spectra(
+        spectra = self.get_spectra(
             emission_model=emission_model,
             dust_curves=dust_curves,
             tau_v=tau_v,
@@ -850,6 +851,8 @@ class BlackHoles(Particles, BlackholesComponent):
             verbose=verbose,
             **kwargs,
         )
+        emission_model.set_per_particle(previous_per_part, set_all=True)
+        return spectra
 
     @deprecated(
         message="get_particle_lines is now just a wrapper "
@@ -919,8 +922,9 @@ class BlackHoles(Particles, BlackholesComponent):
                 A LineCollection object containing the lines defined by the
                 root model.
         """
+        previous_per_part = emission_model.per_particle
         emission_model.set_per_particle(True, set_all=True)
-        return self.get_lines(
+        lines = self.get_lines(
             line_ids=line_ids,
             emission_model=emission_model,
             dust_curves=dust_curves,
@@ -930,3 +934,5 @@ class BlackHoles(Particles, BlackholesComponent):
             verbose=verbose,
             **kwargs,
         )
+        emission_model.set_per_particle(previous_per_part, set_all=True)
+        return lines

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -36,7 +36,7 @@ from synthesizer.particle.particles import Particles
 from synthesizer.units import Quantity
 from synthesizer.utils import TableFormatter
 from synthesizer.utils.plt import single_histxy
-from synthesizer.warnings import warn
+from synthesizer.warnings import deprecated, warn
 
 
 class Stars(Particles, StarsComponent):
@@ -1568,6 +1568,10 @@ class Stars(Particles, StarsComponent):
 
         return fig, ax
 
+    @deprecated(
+        message="get_particle_spectra is now just a wrapper "
+        "around get_spectra. It will be removed by v1.0.0."
+    )
     def get_particle_spectra(
         self,
         emission_model,
@@ -1580,6 +1584,9 @@ class Stars(Particles, StarsComponent):
     ):
         """
         Generate stellar spectra as described by the emission model.
+
+        Note: Now deprecated in favour of get_spectra and emission models
+        knowing which spectra should be per particle.
 
         Args:
             emission_model (EmissionModel):
@@ -1628,10 +1635,8 @@ class Stars(Particles, StarsComponent):
             appropriate spectra attribute of the component
             (spectra/particle_spectra).
         """
-        # Get the spectra
-        spectra = emission_model._get_spectra(
-            emitters={"stellar": self},
-            per_particle=True,
+        return self.get_spectra(
+            emission_model,
             dust_curves=dust_curves,
             tau_v=tau_v,
             fesc=fesc,
@@ -1640,11 +1645,10 @@ class Stars(Particles, StarsComponent):
             **kwargs,
         )
 
-        # Update the spectra dictionary
-        self.particle_spectra.update(spectra)
-
-        return self.particle_spectra[emission_model.label]
-
+    @deprecated(
+        message="get_particle_lines is now just a wrapper "
+        "around get_lines. It will be removed by v1.0.0."
+    )
     def get_particle_lines(
         self,
         line_ids,
@@ -1658,6 +1662,9 @@ class Stars(Particles, StarsComponent):
     ):
         """
         Generate stellar lines as described by the emission model.
+
+        Note: Now deprecated in favour of get_lines and emission models
+        knowing which lines should be per particle.
 
         Args:
             line_ids (list):
@@ -1709,11 +1716,9 @@ class Stars(Particles, StarsComponent):
                 A LineCollection object containing the lines defined by the
                 root model.
         """
-        # Get the lines
-        lines = emission_model._get_lines(
-            line_ids=line_ids,
-            emitters={"stellar": self},
-            per_particle=True,
+        return self.get_lines(
+            line_ids,
+            emission_model,
             dust_curves=dust_curves,
             tau_v=tau_v,
             fesc=fesc,
@@ -1721,11 +1726,6 @@ class Stars(Particles, StarsComponent):
             verbose=verbose,
             **kwargs,
         )
-
-        # Update the lines dictionary
-        self.particle_lines.update(lines)
-
-        return self.particle_lines[emission_model.label]
 
 
 def sample_sfhz(

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1635,8 +1635,9 @@ class Stars(Particles, StarsComponent):
             appropriate spectra attribute of the component
             (spectra/particle_spectra).
         """
+        previous_per_part = emission_model.per_particle
         emission_model.set_per_particle(True, set_all=True)
-        return self.get_spectra(
+        spectra = self.get_spectra(
             emission_model,
             dust_curves=dust_curves,
             tau_v=tau_v,
@@ -1645,6 +1646,8 @@ class Stars(Particles, StarsComponent):
             verbose=verbose,
             **kwargs,
         )
+        emission_model.set_per_particle(previous_per_part, set_all=True)
+        return spectra
 
     @deprecated(
         message="get_particle_lines is now just a wrapper "
@@ -1717,8 +1720,9 @@ class Stars(Particles, StarsComponent):
                 A LineCollection object containing the lines defined by the
                 root model.
         """
+        previous_per_part = emission_model.per_particle
         emission_model.set_per_particle(True, set_all=True)
-        return self.get_lines(
+        lines = self.get_lines(
             line_ids,
             emission_model,
             dust_curves=dust_curves,
@@ -1728,6 +1732,8 @@ class Stars(Particles, StarsComponent):
             verbose=verbose,
             **kwargs,
         )
+        emission_model.set_per_particle(previous_per_part, set_all=True)
+        return lines
 
 
 def sample_sfhz(

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1635,6 +1635,7 @@ class Stars(Particles, StarsComponent):
             appropriate spectra attribute of the component
             (spectra/particle_spectra).
         """
+        emission_model.set_per_particle(True, set_all=True)
         return self.get_spectra(
             emission_model,
             dust_curves=dust_curves,
@@ -1716,6 +1717,7 @@ class Stars(Particles, StarsComponent):
                 A LineCollection object containing the lines defined by the
                 root model.
         """
+        emission_model.set_per_particle(True, set_all=True)
         return self.get_lines(
             line_ids,
             emission_model,

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1569,7 +1569,7 @@ class Stars(Particles, StarsComponent):
         return fig, ax
 
     @deprecated(
-        message="get_particle_spectra is now just a wrapper "
+        message="is now just a wrapper "
         "around get_spectra. It will be removed by v1.0.0."
     )
     def get_particle_spectra(
@@ -1650,7 +1650,7 @@ class Stars(Particles, StarsComponent):
         return spectra
 
     @deprecated(
-        message="get_particle_lines is now just a wrapper "
+        message="is now just a wrapper "
         "around get_lines. It will be removed by v1.0.0."
     )
     def get_particle_lines(

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -1636,7 +1636,7 @@ class Stars(Particles, StarsComponent):
             (spectra/particle_spectra).
         """
         previous_per_part = emission_model.per_particle
-        emission_model.set_per_particle(True, set_all=True)
+        emission_model.set_per_particle(True)
         spectra = self.get_spectra(
             emission_model,
             dust_curves=dust_curves,
@@ -1646,7 +1646,7 @@ class Stars(Particles, StarsComponent):
             verbose=verbose,
             **kwargs,
         )
-        emission_model.set_per_particle(previous_per_part, set_all=True)
+        emission_model.set_per_particle(previous_per_part)
         return spectra
 
     @deprecated(
@@ -1721,7 +1721,7 @@ class Stars(Particles, StarsComponent):
                 root model.
         """
         previous_per_part = emission_model.per_particle
-        emission_model.set_per_particle(True, set_all=True)
+        emission_model.set_per_particle(True)
         lines = self.get_lines(
             line_ids,
             emission_model,
@@ -1732,7 +1732,7 @@ class Stars(Particles, StarsComponent):
             verbose=verbose,
             **kwargs,
         )
-        emission_model.set_per_particle(previous_per_part, set_all=True)
+        emission_model.set_per_particle(previous_per_part)
         return lines
 
 


### PR DESCRIPTION
This PR introduces the `per_particle` flag to an `EmissionModel`. 

- Models that are per particle will now generate per particle emissions and then integrate them for all operations (e.g. extraction, combination, generation and attenuation).
- `EmissionModel._get_spectra` and the lines equivalent now carry a dictionary for integrated and per particle spectra to make later attachment easier.
- `get_particle_spectra` methods are now deprecated wrappers.

These changes allow the user to predefined which emissions they want to be per particle and which should be integrated. They also enable the mixing of per particle component emissions and galaxy level integrated emissions which previously had to be done in stages with different models.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
