### PR TITLE
BUGFIX: Better handling of operation errors, NaNs, templates and optical depth fix

### DIFF
--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -2244,7 +2244,7 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                         **kwargs,
                     )
 
-                    spectra.update(rel_particle_spectra)
+                    spectra.update(rel_spectra)
                     particle_spectra.update(rel_particle_spectra)
 
             # Skip models for a different emitters

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -2389,7 +2389,10 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                         del particle_spectra[model.label]
 
         for key, spec in spectra.items():
-            print(spec.shape, particle_spectra[key].shape)
+            if key not in particle_spectra:
+                print(key, spec.shape)
+            else:
+                print(key, spec.shape, particle_spectra[key].shape)
 
         return spectra, particle_spectra
 

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -2280,23 +2280,31 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                     raise e
 
             elif this_model._is_dust_attenuating:
-                spectra, particle_spectra = self._dust_attenuate_spectra(
-                    this_model,
-                    spectra,
-                    particle_spectra,
-                    emitter,
-                    this_mask,
-                )
+                try:
+                    spectra, particle_spectra = self._dust_attenuate_spectra(
+                        this_model,
+                        spectra,
+                        particle_spectra,
+                        emitter,
+                        this_mask,
+                    )
+                except Exception as e:
+                    print(f"Error in {this_model.label}!")
+                    raise e
 
             elif this_model._is_dust_emitting or this_model._is_generating:
-                spectra, particle_spectra = self._generate_spectra(
-                    this_model,
-                    emission_model,
-                    spectra,
-                    particle_spectra,
-                    self.lam,
-                    emitter,
-                )
+                try:
+                    spectra, particle_spectra = self._generate_spectra(
+                        this_model,
+                        emission_model,
+                        spectra,
+                        particle_spectra,
+                        self.lam,
+                        emitter,
+                    )
+                except Exception as e:
+                    print(f"Error in {this_model.label}!")
+                    raise e
 
             # Are we scaling the spectra?
             for scaler in this_model.scale_by:
@@ -2569,33 +2577,45 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
 
             # Are we doing a combination?
             if this_model._is_combining:
-                lines, particle_lines = self._combine_lines(
-                    line_ids,
-                    emission_model,
-                    lines,
-                    particle_lines,
-                    this_model,
-                )
+                try:
+                    lines, particle_lines = self._combine_lines(
+                        line_ids,
+                        emission_model,
+                        lines,
+                        particle_lines,
+                        this_model,
+                    )
+                except Exception as e:
+                    print(f"Error in {this_model.label}!")
+                    raise e
 
             elif this_model._is_dust_attenuating:
-                lines, particle_lines = self._dust_attenuate_lines(
-                    line_ids,
-                    this_model,
-                    lines,
-                    particle_lines,
-                    emitter,
-                    this_mask,
-                )
+                try:
+                    lines, particle_lines = self._dust_attenuate_lines(
+                        line_ids,
+                        this_model,
+                        lines,
+                        particle_lines,
+                        emitter,
+                        this_mask,
+                    )
+                except Exception as e:
+                    print(f"Error in {this_model.label}!")
+                    raise e
 
             elif this_model._is_dust_emitting or this_model._is_generating:
-                lines, particle_lines = self._generate_lines(
-                    line_ids,
-                    this_model,
-                    emission_model,
-                    lines,
-                    particle_lines,
-                    emitter,
-                )
+                try:
+                    lines, particle_lines = self._generate_lines(
+                        line_ids,
+                        this_model,
+                        emission_model,
+                        lines,
+                        particle_lines,
+                        emitter,
+                    )
+                except Exception as e:
+                    print(f"Error in {this_model.label}!")
+                    raise e
 
             # Are we scaling the spectra?
             for scaler in this_model.scale_by:

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -2276,7 +2276,7 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                         this_model,
                     )
                 except Exception as e:
-                    print(f"Error in {this_model.label}")
+                    print(f"Error in {this_model.label}!")
                     raise e
 
             elif this_model._is_dust_attenuating:

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -1791,7 +1791,7 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                         alpha=0.3,
                     ),
                     fontsize=fontsize,
-                    alpha=1.0,
+                    alpha=alpha,
                     zorder=2,
                 )
 

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -2268,12 +2268,16 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
 
             # Are we doing a combination?
             if this_model._is_combining:
-                spectra, particle_spectra = self._combine_spectra(
-                    emission_model,
-                    spectra,
-                    particle_spectra,
-                    this_model,
-                )
+                try:
+                    spectra, particle_spectra = self._combine_spectra(
+                        emission_model,
+                        spectra,
+                        particle_spectra,
+                        this_model,
+                    )
+                except Exception as e:
+                    print(f"Error in {this_model.label}")
+                    raise e
 
             elif this_model._is_dust_attenuating:
                 spectra, particle_spectra = self._dust_attenuate_spectra(

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -2388,6 +2388,9 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                     if model.per_particle and model.label in particle_spectra:
                         del particle_spectra[model.label]
 
+        for key, spec in spectra.items():
+            print(spec.shape, particle_spectra[key].shape)
+
         return spectra, particle_spectra
 
     def _get_lines(

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -2388,12 +2388,6 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                     if model.per_particle and model.label in particle_spectra:
                         del particle_spectra[model.label]
 
-        for key, spec in spectra.items():
-            if key not in particle_spectra:
-                print(key, spec.shape)
-            else:
-                print(key, spec.shape, particle_spectra[key].shape)
-
         return spectra, particle_spectra
 
     def _get_lines(

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -341,7 +341,9 @@ class Generation:
             spectra[this_model.label] = Sed(
                 lam, np.zeros((emitter.nparticles, lam.size))
             )
-            return spectra
+            if per_particle:
+                particle_spectra[this_model.label] = spectra[this_model.label]
+            return spectra, particle_spectra
 
         # Handle the dust emission case
         if this_model._is_dust_emitting:
@@ -456,7 +458,13 @@ class Generation:
                     luminosity=np.zeros(emitter.nparticles),
                     continuum=np.zeros(emitter.nparticles),
                 )
-            return lines
+
+            # We need to make sure we do this for each particle too if needs
+            # be
+            if per_particle:
+                particle_lines[this_model.label] = lines[this_model.label]
+
+            return lines, particle_lines
 
         # Now we have the spectra we can get the emission at each line
         # and include it

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -777,6 +777,15 @@ class Combination:
                 lnu=np.zeros_like(spectra[this_model.combine[0].label]._lnu),
             )
 
+        print(
+            "Combining:",
+            this_model.label,
+            out_spec.shape,
+            this_model.emitter,
+            this_model.combine,
+            this_model.per_particle,
+        )
+
         # Combine the spectra
         for combine_model in this_model.combine:
             if this_model.per_particle:

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -594,7 +594,6 @@ class DustAttenuation:
         tau_v = 1
         for tv in this_model.tau_v:
             tau_v *= getattr(emitter, tv) if isinstance(tv, str) else tv
-            tau_v *= getattr(emitter, tv) if isinstance(tv, str) else tv
 
         # Get the spectra to apply dust to
         if this_model.per_particle:

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -782,7 +782,11 @@ class Combination:
             this_model.label,
             out_spec.shape,
             this_model.emitter,
-            this_model.combine,
+            [
+                this_model.combine[i].label
+                for i in range(len(this_model.combine))
+            ],
+            spectra[this_model.combine[0].label],
             this_model.per_particle,
         )
 

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -602,6 +602,9 @@ class DustAttenuation:
         else:
             apply_dust_to = spectra[this_model.apply_dust_to.label]
 
+        if this_model.emitter == "blackhole":
+            print("Blackhole tau used:", tau_v)
+
         # Otherwise, we are applying a dust curve (there's no
         # alternative)
         sed = apply_dust_to.apply_attenuation(

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -133,12 +133,6 @@ class Extraction:
             if this_model.per_particle:
                 particle_spectra[label] = sed
                 spectra[label] = sed.sum()
-                print(
-                    "Extracting:",
-                    label,
-                    spectra[label].shape,
-                    particle_spectra[label].shape,
-                )
             else:
                 spectra[label] = sed
 
@@ -396,12 +390,6 @@ class Generation:
         if per_particle:
             particle_spectra[this_model.label] = sed
             spectra[this_model.label] = sed.sum()
-            print(
-                "Generating:",
-                this_model.label,
-                spectra[this_model.label].shape,
-                particle_spectra[this_model.label].shape,
-            )
         else:
             spectra[this_model.label] = sed
 
@@ -626,13 +614,6 @@ class DustAttenuation:
         if this_model.per_particle:
             particle_spectra[this_model.label] = sed
             spectra[this_model.label] = sed.sum()
-            print(
-                "Dust attenuating:",
-                this_model.label,
-                spectra[this_model.label].shape,
-                particle_spectra[this_model.label].shape,
-                apply_dust_to.shape,
-            )
         else:
             spectra[this_model.label] = sed
 
@@ -777,24 +758,6 @@ class Combination:
                 emission_model.lam,
                 lnu=np.zeros_like(spectra[this_model.combine[0].label]._lnu),
             )
-            print(
-                "Not a per particle model",
-                out_spec.shape,
-                spectra[this_model.combine[0].label]._lnu,
-            )
-
-        print(
-            "Combining:",
-            this_model.label,
-            out_spec.shape,
-            this_model.emitter,
-            [
-                this_model.combine[i].label
-                for i in range(len(this_model.combine))
-            ],
-            spectra[this_model.combine[0].label].shape,
-            this_model.per_particle,
-        )
 
         # Combine the spectra
         for combine_model in this_model.combine:
@@ -807,12 +770,6 @@ class Combination:
         if this_model.per_particle:
             particle_spectra[this_model.label] = out_spec
             spectra[this_model.label] = out_spec.sum()
-            print(
-                "Combining:",
-                this_model.label,
-                spectra[this_model.label].shape,
-                particle_spectra[this_model.label].shape,
-            )
         else:
             spectra[this_model.label] = out_spec
 

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -777,6 +777,11 @@ class Combination:
                 emission_model.lam,
                 lnu=np.zeros_like(spectra[this_model.combine[0].label]._lnu),
             )
+            print(
+                "Not a per particle model",
+                out_spec.shape,
+                spectra[this_model.combine[0].label]._lnu,
+            )
 
         print(
             "Combining:",

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -762,9 +762,14 @@ class Combination:
         # Combine the spectra
         for combine_model in this_model.combine:
             if this_model.per_particle:
-                out_spec._lnu += particle_spectra[combine_model.label]._lnu
+                nan_mask = np.isnan(particle_spectra[combine_model.label]._lnu)
+                out_spec._lnu[~nan_mask] += particle_spectra[
+                    combine_model.label
+                ]._lnu[~nan_mask]
             else:
-                out_spec._lnu += spectra[combine_model.label]._lnu
+                out_spec._lnu[~nan_mask] += spectra[combine_model.label]._lnu[
+                    ~nan_mask
+                ]
 
         # Store the spectra in the right place (integrating if we need to)
         if this_model.per_particle:

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -767,6 +767,7 @@ class Combination:
                     combine_model.label
                 ]._lnu[~nan_mask]
             else:
+                nan_mask = np.isnan(spectra[combine_model.label]._lnu)
                 out_spec._lnu[~nan_mask] += spectra[combine_model.label]._lnu[
                     ~nan_mask
                 ]

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -346,9 +346,9 @@ class Generation:
         if getattr(emitter, "nparticles", 1) == 0:
             spectra[this_model.label] = Sed(lam, np.zeros(lam.size))
             if per_particle:
-                particle_spectra[this_model.label] = spectra[this_model.label][
-                    None, :
-                ]
+                particle_spectra[this_model.label] = Sed(
+                    lam, np.zeros((emitter.nparticles, lam.size))
+                )
             return spectra, particle_spectra
 
         # Handle the dust emission case

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -396,6 +396,12 @@ class Generation:
         if per_particle:
             particle_spectra[this_model.label] = sed
             spectra[this_model.label] = sed.sum()
+            print(
+                "Generating:",
+                this_model.label,
+                spectra[this_model.label].shape,
+                particle_spectra[this_model.label].shape,
+            )
         else:
             spectra[this_model.label] = sed
 
@@ -620,6 +626,12 @@ class DustAttenuation:
         if this_model.per_particle:
             particle_spectra[this_model.label] = sed
             spectra[this_model.label] = sed.sum()
+            print(
+                "Dust attenuating:",
+                this_model.label,
+                spectra[this_model.label].shape,
+                particle_spectra[this_model.label].shape,
+            )
         else:
             spectra[this_model.label] = sed
 
@@ -753,14 +765,14 @@ class Combination:
         """
         # Create an empty spectra to add to
         if this_model.per_particle:
-            particle_spectra[this_model.label] = Sed(
+            out_spec = Sed(
                 emission_model.lam,
                 lnu=np.zeros_like(
                     particle_spectra[this_model.combine[0].label]._lnu
                 ),
             )
         else:
-            spectra[this_model.label] = Sed(
+            out_spec = Sed(
                 emission_model.lam,
                 lnu=np.zeros_like(spectra[this_model.combine[0].label]._lnu),
             )
@@ -768,20 +780,22 @@ class Combination:
         # Combine the spectra
         for combine_model in this_model.combine:
             if this_model.per_particle:
-                particle_spectra[this_model.label]._lnu += particle_spectra[
-                    combine_model.label
-                ]._lnu
+                out_spec._lnu += particle_spectra[combine_model.label]._lnu
             else:
-                spectra[this_model.label]._lnu += spectra[
-                    combine_model.label
-                ]._lnu
+                out_spec._lnu += spectra[combine_model.label]._lnu
 
-        # If we made a per particle spectra we need to sum it and get the
-        # integrated spectra
+        # Store the spectra in the right place (integrating if we need to)
         if this_model.per_particle:
-            spectra[this_model.label] = particle_spectra[
-                this_model.label
-            ].sum()
+            particle_spectra[this_model.label] = out_spec
+            spectra[this_model.label] = out_spec.sum()
+            print(
+                "Combining:",
+                this_model.label,
+                spectra[this_model.label].shape,
+                particle_spectra[this_model.label].shape,
+            )
+        else:
+            spectra[this_model.label] = out_spec
 
         return spectra, particle_spectra
 

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -133,6 +133,12 @@ class Extraction:
             if this_model.per_particle:
                 particle_spectra[label] = sed
                 spectra[label] = sed.sum()
+                print(
+                    "Extracting:",
+                    label,
+                    spectra[label].shape,
+                    particle_spectra[label].shape,
+                )
             else:
                 spectra[label] = sed
 
@@ -338,11 +344,11 @@ class Generation:
         # If we have an empty emitter we can just return zeros (only applicable
         # when nparticles exists in the emitter)
         if getattr(emitter, "nparticles", 1) == 0:
-            spectra[this_model.label] = Sed(
-                lam, np.zeros((emitter.nparticles, lam.size))
-            )
+            spectra[this_model.label] = Sed(lam, np.zeros(lam.size))
             if per_particle:
-                particle_spectra[this_model.label] = spectra[this_model.label]
+                particle_spectra[this_model.label] = spectra[this_model.label][
+                    None, :
+                ]
             return spectra, particle_spectra
 
         # Handle the dust emission case

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -786,7 +786,7 @@ class Combination:
                 this_model.combine[i].label
                 for i in range(len(this_model.combine))
             ],
-            spectra[this_model.combine[0].label],
+            spectra[this_model.combine[0].label].shape,
             this_model.per_particle,
         )
 

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -631,6 +631,7 @@ class DustAttenuation:
                 this_model.label,
                 spectra[this_model.label].shape,
                 particle_spectra[this_model.label].shape,
+                apply_dust_to.shape,
             )
         else:
             spectra[this_model.label] = sed

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -601,9 +601,6 @@ class DustAttenuation:
         else:
             apply_dust_to = spectra[this_model.apply_dust_to.label]
 
-        if this_model.emitter == "blackhole":
-            print("Blackhole tau used:", tau_v)
-
         # Otherwise, we are applying a dust curve (there's no
         # alternative)
         sed = apply_dust_to.apply_attenuation(

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1154,6 +1154,8 @@ class Template:
         # It's convenient to have an sed object for the next steps
         sed = Sed(lam, lnu)
 
+        print("Before interpolation:", lnu)
+
         # Before we do anything, do we have a grid we need to unify with?
         if unify_with_grid is not None:
             # Interpolate the template Sed onto the grid wavelength array

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1202,4 +1202,6 @@ class Template:
                 scaling[:, None] * self.lnu * (1 - self.fesc),
             )
 
+        print(sed)
+
         return sed

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1163,6 +1163,8 @@ class Template:
         self.lnu = sed.lnu
         self.lam = sed.lam
 
+        print("Pre-normalisation: ", self.lnu)
+
         # Normalise, just in case
         self.normalisation = sed.measure_bolometric_luminosity()
         self.lnu /= self.normalisation.value
@@ -1188,21 +1190,22 @@ class Template:
             )
 
         print(bolometric_luminosity)
+        print(self.normalisation)
+
+        # Compute the scaling based on normalisation
+        scaling = (bolometric_luminosity / self.normalisation).value
+        print(scaling)
 
         # Handle the dimensions of the bolometric luminosity
         if bolometric_luminosity.shape[0] == 1:
             sed = Sed(
                 self.lam,
-                bolometric_luminosity.to(self.lnu.units * Hz).value
-                * self.lnu
-                * (1 - self.fesc),
+                scaling * self.lnu * (1 - self.fesc),
             )
         else:
             sed = Sed(
                 self.lam,
-                bolometric_luminosity.to(self.lnu.units * Hz).value[:, None]
-                * self.lnu
-                * (1 - self.fesc),
+                scaling[:, None] * self.lnu * (1 - self.fesc),
             )
 
         print(sed)

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1187,6 +1187,8 @@ class Template:
                 "bolometric luminosity must be provided with units"
             )
 
+        print(bolometric_luminosity)
+
         # Handle the dimensions of the bolometric luminosity
         if bolometric_luminosity.shape[0] == 1:
             sed = Sed(

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1205,4 +1205,6 @@ class Template:
                 * (1 - self.fesc),
             )
 
+        print(sed)
+
         return sed

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1188,8 +1188,7 @@ class Template:
             )
 
         # Compute the scaling based on normalisation
-        scaling = (bolometric_luminosity / self.normalisation).value
-        print(scaling)
+        scaling = bolometric_luminosity.value
 
         # Handle the dimensions of the bolometric luminosity
         if bolometric_luminosity.shape[0] == 1:

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1154,8 +1154,6 @@ class Template:
         # It's convenient to have an sed object for the next steps
         sed = Sed(lam, lnu)
 
-        print("Before interpolation:", lnu)
-
         # Before we do anything, do we have a grid we need to unify with?
         if unify_with_grid is not None:
             # Interpolate the template Sed onto the grid wavelength array
@@ -1164,8 +1162,6 @@ class Template:
         # Attach the template now we've done the interpolation (if needed)
         self.lnu = sed.lnu
         self.lam = sed.lam
-
-        print("Pre-normalisation: ", self.lnu)
 
         # Normalise, just in case
         self.normalisation = sed.measure_bolometric_luminosity()
@@ -1191,9 +1187,6 @@ class Template:
                 "bolometric luminosity must be provided with units"
             )
 
-        print(bolometric_luminosity)
-        print(self.normalisation)
-
         # Compute the scaling based on normalisation
         scaling = (bolometric_luminosity / self.normalisation).value
         print(scaling)
@@ -1211,6 +1204,5 @@ class Template:
             )
 
         print(sed)
-        print(self.lnu)
 
         return sed

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1189,7 +1189,6 @@ class Template:
 
         # Compute the scaling based on normalisation
         scaling = bolometric_luminosity.value
-        print(scaling)
 
         # Handle the dimensions of the bolometric luminosity
         if bolometric_luminosity.shape[0] == 1:
@@ -1202,7 +1201,5 @@ class Template:
                 self.lam,
                 scaling[:, None] * self.lnu * (1 - self.fesc),
             )
-
-        print(sed)
 
         return sed

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1189,6 +1189,7 @@ class Template:
 
         # Compute the scaling based on normalisation
         scaling = bolometric_luminosity.value
+        print(scaling)
 
         # Handle the dimensions of the bolometric luminosity
         if bolometric_luminosity.shape[0] == 1:

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1206,5 +1206,6 @@ class Template:
             )
 
         print(sed)
+        print(self.lnu)
 
         return sed

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1202,6 +1202,4 @@ class Template:
                 scaling[:, None] * self.lnu * (1 - self.fesc),
             )
 
-        print(sed)
-
         return sed

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -162,11 +162,11 @@ class Sed:
             sum_over = tuple(range(0, len(self._lnu.shape) - 1))
 
             # Create a new sed object with the first Lnu dimension collapsed
-            new_sed = Sed(self.lam, np.sum(self._lnu, axis=sum_over))
+            new_sed = Sed(self.lam, np.nansum(self._lnu, axis=sum_over))
 
             # If fnu exists, sum that too
             if self.fnu is not None:
-                new_sed.fnu = np.sum(self.fnu, axis=sum_over)
+                new_sed.fnu = np.nansum(self.fnu, axis=sum_over)
                 new_sed.obsnu = self.obsnu
                 new_sed.obslam = self.obslam
                 new_sed.redshift = self.redshift

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -1151,7 +1151,7 @@ class Sed:
             new_lam = rebin_1d(self.lam, resample_factor, func=np.mean)
 
         # Evaluate the function at the desired wavelengths
-        new_spectra = spectres(new_lam, self._lam, self._lnu)
+        new_spectra = spectres(new_lam, self._lam, self._lnu, fill=0)
 
         # Instantiate the new Sed
         sed = Sed(new_lam, new_spectra)
@@ -1163,6 +1163,14 @@ class Sed:
             sed.obsnu = sed._nu / (1.0 + self.redshift)
             sed.fnu = spectres(sed._obslam, self._obslam, self._fnu)
             sed.redshift = self.redshift
+
+        # Clean up nans, we shouldn't get them but they do appear sometimes...
+        sed._lnu = np.nan_to_num(sed._lnu)
+        sed._fnu = np.nan_to_num(sed._fnu)
+        sed._lam = np.nan_to_num(sed._lam)
+        sed._nu = np.nan_to_num(sed._nu)
+        sed._obslam = np.nan_to_num(sed._obslam)
+        sed._obsnu = np.nan_to_num(sed._obsnu)
 
         toc("Resampling Sed", start)
 


### PR DESCRIPTION
This PR fixes a myriad of small bugs (and one huge bug). It also wraps calls to operations in try-except blocks to reraise the error with some more information about the emission that caused the error (although this could be done better and will be done better, we just need to get the bug fixes in ASAP).

- Optical depths were being double multiplied due to a bad copy paste. This is a dire bug but now fixed.
- `nansum` along with some nan masks are now used to avoid nans destroying sums with numerical values + some nan components (this could probably be expanded on).
- `Sed` resampling now also checks for nans and zeros them.
- Template scaling has been refactored slightly.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
