### PR TITLE
Handle sed objects with ndim > 2

### DIFF
--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -610,7 +610,7 @@ class Sed:
         # Apply the correct method
         if integration_method == "average":
             # Apply to the correct axis of the spectra
-            if self.ndim == 2:
+            if self.ndim >= 2:
                 lnu = (
                     np.array(
                         [
@@ -796,7 +796,7 @@ class Sed:
             s = (self.lam > window[0]) & (self.lam < window[1])
 
             # Handle different spectra dimensions
-            if self.ndim == 2:
+            if self.ndim >= 2:
                 beta = np.array(
                     [
                         linregress(
@@ -1058,7 +1058,7 @@ class Sed:
         mean_red = np.mean(red)
 
         # Handle different spectra shapes
-        if self.ndim == 2:
+        if self.ndim >= 2:
             # Multiple spectra case
 
             # Perform polyfit for the continuum fit for all spectra


### PR DESCRIPTION
Grids have ndim > 2 (e.g. age, metallicity, wavelength). Some of the `sed` class methods strictly test for 2 dimensions, which leads them to break. This updates those checks, to handle sed objects with higher numbers of dimensions.

## Issue Type
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
