### PR TITLE
BUGFIX: `apply_filter` could cause divide by zero errors

### DIFF
--- a/src/synthesizer/filters.py
+++ b/src/synthesizer/filters.py
@@ -1638,7 +1638,7 @@ class Filter:
         # Warn and exit if there are no array elements in this band
         if arr_in_band.size == 0:
             warn(f"{self.filter_code} outside of emission array.")
-            return 0
+            return 0 if arr.nim == 1 else np.zeros(arr.shape[0])
 
         # Multiply the array by the filter transmission curve
         transmission = arr_in_band * t_in_band
@@ -1646,7 +1646,7 @@ class Filter:
         # Ensure we actually have some transmission in this band, no point
         # in calling the C extensions if not
         if np.sum(transmission) == 0:
-            return 0
+            return 0 if arr.nim == 1 else np.zeros(arr.shape[0])
 
         # Sum over the final axis to "collect" transmission in this filer
         sum_per_x = integrate_last_axis(

--- a/src/synthesizer/filters.py
+++ b/src/synthesizer/filters.py
@@ -1638,7 +1638,7 @@ class Filter:
         # Warn and exit if there are no array elements in this band
         if arr_in_band.size == 0:
             warn(f"{self.filter_code} outside of emission array.")
-            return 0 if arr.nim == 1 else np.zeros(arr.shape[0])
+            return 0 if arr.ndim == 1 else np.zeros(arr.shape[0])
 
         # Multiply the array by the filter transmission curve
         transmission = arr_in_band * t_in_band
@@ -1646,7 +1646,7 @@ class Filter:
         # Ensure we actually have some transmission in this band, no point
         # in calling the C extensions if not
         if np.sum(transmission) == 0:
-            return 0 if arr.nim == 1 else np.zeros(arr.shape[0])
+            return 0 if arr.ndim == 1 else np.zeros(arr.shape[0])
 
         # Sum over the final axis to "collect" transmission in this filer
         sum_per_x = integrate_last_axis(

--- a/src/synthesizer/filters.py
+++ b/src/synthesizer/filters.py
@@ -1635,8 +1635,18 @@ class Filter:
         xs_in_band = xs[in_band]
         t_in_band = t[in_band]
 
+        # Warn and exit if there are no array elements in this band
+        if arr_in_band.size == 0:
+            warn(f"{self.filter_code} outside of emission array.")
+            return 0
+
         # Multiply the array by the filter transmission curve
         transmission = arr_in_band * t_in_band
+
+        # Ensure we actually have some transmission in this band, no point
+        # in calling the C extensions if not
+        if np.sum(transmission) == 0:
+            return 0
 
         # Sum over the final axis to "collect" transmission in this filer
         sum_per_x = integrate_last_axis(


### PR DESCRIPTION
`Filter.apply_filter` never checked to ensure the non-zero masked array had elements (it now does, warns the user and returns 0), or checked if the array contribution in the band was 0 (if so there's no need to do the more expensive integration, this will now also return 0). 

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
