### PR TITLE
Removing redundant coordinate shift in imaging

### DIFF
--- a/src/synthesizer/imaging/image.py
+++ b/src/synthesizer/imaging/image.py
@@ -267,10 +267,6 @@ class Image:
         # strip them off
         coordinates = coordinates.to(self.resolution.units).value
 
-        # In case coordinates haven't been centered we need to centre them
-        if not (coordinates.min() < 0 and coordinates.max() > 0):
-            coordinates -= np.average(coordinates, axis=0, weights=signal)
-
         self.arr = np.histogram2d(
             coordinates[:, 0],
             coordinates[:, 1],
@@ -380,10 +376,6 @@ class Image:
         # strip them off
         coordinates = coordinates.to(self.resolution.units).value
         smoothing_lengths = smoothing_lengths.to(self.resolution.units).value
-
-        # In case coordinates haven't been centered we need to centre them
-        if not (coordinates.min() < 0 and coordinates.max() > 0):
-            coordinates -= np.average(coordinates, axis=0, weights=signal)
 
         # Prepare the inputs, we need to make sure we are passing C contiguous
         # arrays.


### PR DESCRIPTION
The imaging code has a dangerous coordinates check which can error when the weights are all zero. This check is actually redundant since 99% of the time centred coordinates are passed in and there are other checks that would handle the 1% rather than the "automatic fix" that was used. 

This PR removes this dangerous check.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
