### PR TITLE
Introduce a fallback data mirror on dropbox to get around server failures (until we find a better host)

### DIFF
--- a/src/synthesizer/download_data.py
+++ b/src/synthesizer/download_data.py
@@ -43,6 +43,13 @@ def _download(url, save_dir, filename=None):
     # Download the file
     response = requests.get(url, stream=True)
 
+    # Ensure the request was successful
+    if response.status_code != 200:
+        raise exceptions.DownloadError(
+            f"Failed to download {url}. \n"
+            "Status code: {response.status_code}"
+        )
+
     # Sizes in bytes.
     total_size = int(response.headers.get("content-length", 0))
     block_size = 1024

--- a/src/synthesizer/download_data.py
+++ b/src/synthesizer/download_data.py
@@ -23,22 +23,33 @@ from tqdm import tqdm
 from synthesizer import exceptions
 
 
-def _download(url, save_dir, filename=None):
+def _download_from_xcs_host(filename, save_dir, save_filename=None):
     """
-    Download the file at the given URL to the given path.
+    Download the file from the XCS server.
 
     Args:
-        url (str)
-            The url to download from.
+        filename (str)
+            The name of the file to download.
         save_dir (str)
             The directory in which to save the file.
+        save_filename (str)
+            The name to save the file as. If None, the file will be saved with
+            the same name as the download.
     """
-    if filename is None:
-        # Get the file name
-        filename = url.split("/")[-1]
+    # Define the base URL
+    xcs_url = (
+        "https://xcs-host.phys.sussex.ac.uk/html/sym_links/synthesizer_data/"
+    )
+
+    # Define the full URL
+    url = xcs_url + filename
+
+    # If we have no save file name then its the same as the download
+    if save_filename is None:
+        save_filename = filename
 
     # Define the save path
-    save_path = f"{save_dir}/{filename}"
+    save_path = f"{save_dir}/{save_filename}"
 
     # Download the file
     response = requests.get(url, stream=True)
@@ -46,8 +57,7 @@ def _download(url, save_dir, filename=None):
     # Ensure the request was successful
     if response.status_code != 200:
         raise exceptions.DownloadError(
-            f"Failed to download {url}. \n"
-            "Status code: {response.status_code}"
+            f"Failed to download {url}. Status code: {response.status_code}"
         )
 
     # Sizes in bytes.
@@ -62,6 +72,96 @@ def _download(url, save_dir, filename=None):
                 f.write(chunk)
 
 
+def _download_from_dropbox(
+    filename,
+    db_id,
+    save_dir,
+    save_filename=None,
+):
+    """
+    Download the file from the Dropbox server.
+
+    Args:
+        filename (str)
+            The name of the file to download.
+        db_id (str)
+            The Dropbox ID of the file.
+        save_dir (str)
+            The directory in which to save the file.
+        save_filename (str)
+            The name to save the file as. If None, the file will be saved with
+            the same name as the download.
+    """
+    # Define the base URL
+    dropbox_url = "https://www.dropbox.com/s/"
+
+    # Define the full URL
+    url = f"{dropbox_url}/{db_id}/{filename}?dl=1"
+
+    # If we have no save file name then its the same as the download
+    if save_filename is None:
+        save_filename = filename
+
+    # Define the save path
+    save_path = f"{save_dir}/{save_filename}"
+
+    # Download the file
+    response = requests.get(url, stream=True)
+
+    # Ensure the request was successful
+    if response.status_code != 200:
+        raise exceptions.DownloadError(
+            f"Failed to download {url}. Status code: {response.status_code}"
+        )
+
+    # Sizes in bytes.
+    total_size = int(response.headers.get("content-length", 0))
+    block_size = 1024
+
+    # Stream the file to disk with a nice progress bar.
+    with tqdm(total=total_size, unit="B", unit_scale=True) as progress_bar:
+        with open(save_path, "wb") as f:
+            for chunk in response.iter_content(block_size):
+                progress_bar.update(len(chunk))
+                f.write(chunk)
+
+
+def _download(
+    filename,
+    save_dir,
+    save_filename=None,
+    db_id=None,
+):
+    """
+    Download the file at the given URL to the given path.
+
+    Args:
+        filename (str)
+            The name of the file to download.
+        save_dir (str)
+            The directory in which to save the file.
+        save_filename (str)
+            The name to save the file as. If None, the file will be saved with
+            the same name as the download.
+        db_id (str)
+            The Dropbox ID of the file. (Only needed to use the dropbox
+            fall back when the primary host fails.)
+    """
+    # If we don't have a dropbox alternative just use the primary, if it fails
+    # it fails
+    if db_id is None:
+        _download_from_xcs_host(filename, save_dir, save_filename)
+        return
+
+    # Try the primary host
+    try:
+        _download_from_xcs_host(filename, save_dir, save_filename)
+    except exceptions.DownloadError:
+        print("Failed to download from primary host. Trying dropbox...")
+        # If the primary host fails, try the dropbox alternative
+        _download_from_dropbox(filename, db_id, save_dir, save_filename)
+
+
 def download_test_grids(destination):
     """
     Download the test grids for synthesizer.
@@ -70,15 +170,19 @@ def download_test_grids(destination):
         destination (str)
             The path to the destination directory.
     """
-    base_url = (
-        "https://xcs-host.phys.sussex.ac.uk/html/sym_links/synthesizer_data/"
-    )
-
     # Define the files to get
     files = [
         "bpass-2.2.1-bin_chabrier03-0.1,300.0_cloudy-c23.01-sps.hdf5",
         "agnsed-limited_cloudy-c23.01-blr.hdf5",
         "agnsed-limited_cloudy-c23.01-nlr.hdf5",
+    ]
+
+    # Define the dropbox ids for each file (only used if we fall back on
+    # dropbox)
+    db_ids = [
+        "z6vbxpndmak7w83xt24x3",
+        "zjim8bpiquggs2yatxvsz",
+        "cigwp1b6oplmmnu4e68ns",
     ]
 
     # Define the file names the downloads will be saved as
@@ -89,8 +193,8 @@ def download_test_grids(destination):
     ]
 
     # Download each file
-    for f, outf in zip(files, out_files):
-        _download(base_url + f, destination, outf)
+    for f, outf, db_id in zip(files, out_files, db_ids):
+        _download(f, destination, outf, db_id)
 
 
 def download_stellar_test_grids(destination):
@@ -101,13 +205,13 @@ def download_stellar_test_grids(destination):
         destination (str)
             The path to the destination directory.
     """
-    url = (
-        "https://xcs-host.phys.sussex.ac.uk/html/sym_links/synthesizer_data/"
-        "bpass-2.2.1-bin_chabrier03-0.1,300.0_cloudy-c23.01-sps.hdf5"
+    # Download the stellar grid
+    _download(
+        "bpass-2.2.1-bin_chabrier03-0.1,300.0_cloudy-c23.01-sps.hdf5",
+        destination,
+        "test_grid.hdf5",
+        "z6vbxpndmak7w83xt24x3",
     )
-
-    # Download each file
-    _download(url, destination, "test_grid.hdf5")
 
 
 def download_agn_test_grids(destination):
@@ -118,14 +222,17 @@ def download_agn_test_grids(destination):
         destination (str)
             The path to the destination directory.
     """
-    base_url = (
-        "https://xcs-host.phys.sussex.ac.uk/html/sym_links/synthesizer_data/"
-    )
-
     # Define the files to get
     files = [
         "agnsed-limited_cloudy-c23.01-blr.hdf5",
         "agnsed-limited_cloudy-c23.01-nlr.hdf5",
+    ]
+
+    # Define the dropbox ids for each file (only used if we fall back on
+    # dropbox)
+    db_ids = [
+        "zjim8bpiquggs2yatxvsz",
+        "cigwp1b6oplmmnu4e68ns",
     ]
 
     # Define the file names the downloads will be saved as
@@ -135,8 +242,8 @@ def download_agn_test_grids(destination):
     ]
 
     # Download each file
-    for f, outf in zip(files, out_files):
-        _download(base_url + f, destination, outf)
+    for f, outf, db_id in zip(files, out_files, db_ids):
+        _download(f, destination, outf, db_id)
 
 
 def download_dust_grid(destination):
@@ -147,12 +254,8 @@ def download_dust_grid(destination):
         destination (str)
             The path to the destination directory.
     """
-    base_url = (
-        "https://xcs-host.phys.sussex.ac.uk/html/sym_links/synthesizer_data/"
-    )
-
-    # Download each file
-    _download(base_url + "MW3.1.hdf5", destination)
+    # Download the dust grid
+    _download("MW3.1.hdf5", destination, "MW3.1.hdf5", "7fzg4rvw9toeh2fgt6m78")
 
 
 def download_camels_data(snap, lh, destination):

--- a/src/synthesizer/download_data.py
+++ b/src/synthesizer/download_data.py
@@ -93,10 +93,14 @@ def _download_from_dropbox(
             the same name as the download.
     """
     # Define the base URL
-    dropbox_url = "https://www.dropbox.com/s/"
+    dropbox_url = "https://www.dropbox.com/scl/fi/"
 
     # Define the full URL
-    url = f"{dropbox_url}/{db_id}/{filename}?dl=1"
+    url = (
+        f"{dropbox_url}/{db_id[0]}/{filename}"
+        f"?rlkey={db_id[1]}&st={db_id[2]}&dl=1"
+    )
+    # url = "https://www.dropbox.com/scl/fi/z6vbxpndmak7w83xt24x3/bpass-2.2.1-bin_chabrier03-0.1-300.0_cloudy-c23.01-sps.hdf5?rlkey=078fk0ttwpxg49yy60z0zzelh&st=orpc20cw&dl=1"
 
     # If we have no save file name then its the same as the download
     if save_filename is None:
@@ -180,9 +184,9 @@ def download_test_grids(destination):
     # Define the dropbox ids for each file (only used if we fall back on
     # dropbox)
     db_ids = [
-        "z6vbxpndmak7w83xt24x3",
-        "zjim8bpiquggs2yatxvsz",
-        "cigwp1b6oplmmnu4e68ns",
+        ("z6vbxpndmak7w83xt24x3", "078fk0ttwpxg49yy60z0zzelh", "3g8i5bnq"),
+        ("zjim8bpiquggs2yatxvsz", "ce2ozz64kp4ii4hehejizakoq", "z6ziagfc"),
+        ("cigwp1b6oplmmnu4e68ns", "xhfz356nc2cjlivce9rx3k4y9", "sv76rwoi"),
     ]
 
     # Define the file names the downloads will be saved as
@@ -210,7 +214,7 @@ def download_stellar_test_grids(destination):
         "bpass-2.2.1-bin_chabrier03-0.1,300.0_cloudy-c23.01-sps.hdf5",
         destination,
         "test_grid.hdf5",
-        "z6vbxpndmak7w83xt24x3",
+        ("z6vbxpndmak7w83xt24x3", "078fk0ttwpxg49yy60z0zzelh", "3g8i5bnq"),
     )
 
 
@@ -231,8 +235,8 @@ def download_agn_test_grids(destination):
     # Define the dropbox ids for each file (only used if we fall back on
     # dropbox)
     db_ids = [
-        "zjim8bpiquggs2yatxvsz",
-        "cigwp1b6oplmmnu4e68ns",
+        ("zjim8bpiquggs2yatxvsz", "ce2ozz64kp4ii4hehejizakoq", "z6ziagfc"),
+        ("cigwp1b6oplmmnu4e68ns", "xhfz356nc2cjlivce9rx3k4y9", "sv76rwoi"),
     ]
 
     # Define the file names the downloads will be saved as
@@ -255,7 +259,12 @@ def download_dust_grid(destination):
             The path to the destination directory.
     """
     # Download the dust grid
-    _download("MW3.1.hdf5", destination, "MW3.1.hdf5", "7fzg4rvw9toeh2fgt6m78")
+    _download(
+        "MW3.1.hdf5",
+        destination,
+        "MW3.1.hdf5",
+        ("7fzg4rvw9toeh2fgt6m78", "7n4f135b36lq429ts8jsi4zx1", "2tb1rfw7"),
+    )
 
 
 def download_camels_data(snap, lh, destination):

--- a/src/synthesizer/exceptions.py
+++ b/src/synthesizer/exceptions.py
@@ -333,3 +333,22 @@ class UnmetDependency(Exception):
         if self.message:
             return "{0} ".format(self.message)
         return "There are unmet package dependencies."
+
+
+class DownloadError(Exception):
+    """
+    Generic exception class for anything to do with not having specific
+    packages not mentioned in the requirements. This is usually when there
+    are added dependency due to including extraneous capabilities.
+    """
+
+    def __init__(self, *args):
+        if args:
+            self.message = args[0]
+        else:
+            self.message = None
+
+    def __str__(self):
+        if self.message:
+            return "{0} ".format(self.message)
+        return "There was an error downloading the data."


### PR DESCRIPTION
Our test data host is currently down again. This PR introduces a fallback option using Dropbox. This isn't an ideal solution since Dropbox has a bandwidth limit and we could feasibly reach this reasonably often. However, as a quick fix and later a fallback option this will at least keep the wheel turning.

This also introduces a `DownloadError` for more obvious failures.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
