### PR TITLE
Adjusting plot size to avoid overlapping models in galaxy spectra docs

### DIFF
--- a/docs/source/spectra/galaxy.ipynb
+++ b/docs/source/spectra/galaxy.ipynb
@@ -126,7 +126,7 @@
     "gal_total[\"disc_transmitted_blr\"].set_save(False)\n",
     "gal_total[\"young_attenuated_nebular\"].set_save(False)\n",
     "\n",
-    "gal_total.plot_emission_tree(figsize=(10, 6), fontsize=8)"
+    "gal_total.plot_emission_tree(figsize=(14, 6), fontsize=8)"
    ]
   },
   {
@@ -145,7 +145,7 @@
     "gal_total.save_spectra(\n",
     "    \"total\", \"dust_emission\", \"total_attenuated\", \"total_intrinsic\"\n",
     ")\n",
-    "gal_total.plot_emission_tree(figsize=(10, 6), fontsize=8)"
+    "gal_total.plot_emission_tree(figsize=(14, 6), fontsize=8)"
    ]
   },
   {


### PR DESCRIPTION
The galaxy spectra docs were a bit ugly due to the size of the emission tree plot.

This is a simple fix to that.

## Issue Type
<!-- delete options below as required -->
- Document

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
