### PR TITLE
Ensuring unit consistency in Emission generators

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -39,7 +39,7 @@ jobs:
         WITH_OPENMP=1 pip install .[bluetides,eagle,illustris]
         # Output the compilation report so it can be viewed in an action log
         cat build_synth.log
-    - uses: chartboost/ruff-action@v1  # Lint with Ruff
+    - uses: chartboost/ruff-action@491342200cdd1cf4d5132a30ddc546b3b5bc531b  # Lint with Ruff
       with:
         version: 0.6.0
         changed-files: 'true'

--- a/docs/source/advanced/units.ipynb
+++ b/docs/source/advanced/units.ipynb
@@ -178,12 +178,15 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from unyt import angstrom, erg, s, Hz\n",
+    "from unyt import Hz, angstrom, erg, s\n",
     "\n",
     "from synthesizer.sed import Sed\n",
     "\n",
     "# Make an sed with arbitrary arguments\n",
-    "sed = Sed(lam=np.linspace(10, 1000, 10) * angstrom, lnu=np.ones(10) * erg / s /Hz)"
+    "sed = Sed(\n",
+    "    lam=np.linspace(10, 1000, 10) * angstrom,\n",
+    "    lnu=np.ones(10) * erg / s /Hz\n",
+    ")"
    ]
   },
   {

--- a/docs/source/advanced/units.ipynb
+++ b/docs/source/advanced/units.ipynb
@@ -167,7 +167,7 @@
     "\n",
     "One simple thing to keep in mind is how to return the value with or without units. This is achieved by the application or omission of a leading underscore to a variable name. \n",
     "\n",
-    "Lets create an `Sed` object, which has a wavelength array stored under `lam`. Note that, since we are not explicitly passing units, the default unit system is assumed."
+    "Lets create an `Sed` object, which has a wavelength array stored under `lam`. "
    ]
   },
   {
@@ -178,11 +178,12 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "from unyt import angstrom, erg, s, Hz\n",
     "\n",
     "from synthesizer.sed import Sed\n",
     "\n",
     "# Make an sed with arbitrary arguments\n",
-    "sed = Sed(lam=np.linspace(10, 1000, 10), lnu=np.ones(10))"
+    "sed = Sed(lam=np.linspace(10, 1000, 10) * angstrom, lnu=np.ones(10) * erg / s /Hz)"
    ]
   },
   {

--- a/docs/source/emission_models/dust_emission.ipynb
+++ b/docs/source/emission_models/dust_emission.ipynb
@@ -80,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for T in [10, 25, 50, 100]:\n",
+    "for T in [10, 25, 50, 100, 1000]:\n",
     "    model = Casey12(T * K, 1.6, 2.0)\n",
     "    sed = model.get_spectra(lam)\n",
     "    plt.plot(np.log10(sed.lam), sed.luminosity, label=f\"{T} K\")\n",
@@ -105,7 +105,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for T in [20, 25, 50, 100]:\n",
+    "for T in [10, 25, 50, 100, 1000]:\n",
     "    model = Casey12(T * K, 1.6, 2.0)\n",
     "    model_cmb = Casey12(T * K, 1.6, 2.0, cmb_heating=True, z=7)\n",
     "    sed = model.get_spectra(lam)\n",

--- a/docs/source/emission_models/dust_emission.ipynb
+++ b/docs/source/emission_models/dust_emission.ipynb
@@ -65,7 +65,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for T in [10, 25, 50, 100]:\n",
+    "for T in [10, 25, 50, 100, 1000]:\n",
     "    model = Greybody(T * K, 1.6)\n",
     "    sed = model.get_spectra(lam)\n",
     "    plt.plot(np.log10(sed.lam), sed.luminosity, label=f\"{T} K\")\n",

--- a/docs/source/emission_models/dust_emission.ipynb
+++ b/docs/source/emission_models/dust_emission.ipynb
@@ -107,7 +107,7 @@
    "source": [
     "for T in [10, 25, 50, 100, 1000]:\n",
     "    model = Casey12(T * K, 1.6, 2.0)\n",
-    "    model_cmb = Casey12(T * K, 1.6, 2.0, cmb_heating=True, z=7)\n",
+    "    model_cmb = Casey12(T * K, 1.6, 2.0, cmb_heating=True, redshift=7)\n",
     "    sed = model.get_spectra(lam)\n",
     "    sed_cmb = model_cmb.get_spectra(lam)\n",
     "    L_ir_ratio = sed_cmb.measure_window_luminosity(\n",

--- a/docs/source/sed/sed_example.ipynb
+++ b/docs/source/sed/sed_example.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from unyt import Angstrom, eV, um\n",
+    "from unyt import Angstrom, eV, um, erg, s, Hz\n",
     "\n",
     "from synthesizer.emission_models.attenuation.igm import Madau96\n",
     "from synthesizer.filters import FilterCollection\n",
@@ -507,7 +507,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sed2 = Sed(sed.lam, np.array([sed.lnu, sed.lnu * 2]))\n",
+    "sed2 = Sed(sed.lam, np.array([sed.lnu, sed.lnu * 2]) * erg /s /Hz)\n",
     "\n",
     "sed2.measure_window_lnu((1400, 1600) * Angstrom)\n",
     "sed2.measure_beta()\n",

--- a/docs/source/sed/sed_example.ipynb
+++ b/docs/source/sed/sed_example.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from unyt import Angstrom, eV, um, erg, s, Hz\n",
+    "from unyt import Angstrom, Hz, erg, eV, s, um\n",
     "\n",
     "from synthesizer.emission_models.attenuation.igm import Madau96\n",
     "from synthesizer.filters import FilterCollection\n",

--- a/src/synthesizer/emission_models/dust/emission.py
+++ b/src/synthesizer/emission_models/dust/emission.py
@@ -148,11 +148,7 @@ class EmissionBase:
         # multidiensional arrays properly)
         if bolometric_luminosity.value.ndim == 0:
             lnu = (
-                bolometric_luminosity.to("erg/s").value
-                * self._get_spectra(lam)._lnu
-                * erg
-                / s
-                / Hz
+                bolometric_luminosity.to("erg/s") * self._get_spectra(lam).lnu
             )
         else:
             lnu = (
@@ -164,6 +160,8 @@ class EmissionBase:
                 / s
                 / Hz
             )
+
+        print(bolometric_luminosity)
 
         # Create new Sed object containing dust emission spectra
         return Sed(lam, lnu=lnu)
@@ -190,11 +188,12 @@ class EmissionBase:
         # Get frequencies
         nu = (c / lam).to(Hz)
 
+        print(self._lnu(nu))
         sed = Sed(lam=lam, lnu=self._lnu(nu))
 
         # Normalise the spectrum
         sed._lnu /= np.expand_dims(
-            sed.measure_bolometric_luminosity().value, axis=-1
+            sed.measure_bolometric_luminosity(), axis=-1
         )
 
         # Apply heating due to CMB, if applicable
@@ -389,7 +388,7 @@ class Greybody(EmissionBase):
                 "Frequency must be given in Hz."
             )
 
-        return (nu / Hz) * self.emissivity * planck(nu, self.temperature)
+        return (nu / Hz) ** self.emissivity * planck(nu, self.temperature)
 
 
 class Casey12(EmissionBase):

--- a/src/synthesizer/emission_models/dust/emission.py
+++ b/src/synthesizer/emission_models/dust/emission.py
@@ -202,7 +202,7 @@ class EmissionBase:
 
         return sed
 
-    def apply_cmb_heating(self, emissivity: float, z: float) -> None:
+    def apply_cmb_heating(self, emissivity: float, redshift: float) -> None:
         """
         Return the factor by which the CMB boosts the infrared luminosity.
 
@@ -211,17 +211,17 @@ class EmissionBase:
         Args:
             emissivity (float)
                 The emissivity index in the FIR (no unit)
-            z (float)
+            redshift (float)
                 The redshift of the galaxy
         """
-        # Temperature of CMB at z=0
+        # Temperature of CMB at redshift=0
         _T_cmb_0 = 2.73 * K
-        _T_cmb_z = _T_cmb_0 * (1 + z)
+        _T_cmb_redshift = _T_cmb_0 * (1 + redshift)
         _exp_factor = 4.0 + emissivity
 
         _temperature = (
             self.temperature**_exp_factor
-            + _T_cmb_z**_exp_factor
+            + _T_cmb_redshift**_exp_factor
             - _T_cmb_0**_exp_factor
         ) ** (1 / _exp_factor)
 
@@ -236,18 +236,26 @@ class EmissionBase:
 class Blackbody(EmissionBase):
     """
     A class to generate a blackbody emission spectrum.
+
+    Attributes:
+        temperature (float)
+            The temperature of the dust.
+        cmb_heating (bool)
+            Option for adding heating by CMB.
+        redshift (float)
+            Redshift.
     """
 
     temperature: unyt_quantity
     cmb_heating: bool
-    z: float
+    redshift: float
 
     @accepts(temperature=temperature_dim)
     def __init__(
         self,
         temperature: unyt_quantity,
         cmb_heating: bool = False,
-        z: float = 0,
+        redshift: float = 0,
     ) -> None:
         """
         A function to generate a simple blackbody spectrum.
@@ -259,7 +267,7 @@ class Blackbody(EmissionBase):
             cmb_heating (bool)
                 Option for adding heating by CMB
 
-            z (float)
+            redshift (float)
                 Redshift of the galaxy
 
         """
@@ -272,7 +280,7 @@ class Blackbody(EmissionBase):
         if cmb_heating:
             # calculate the factor by which the CMB boosts the
             # infrared luminosity
-            self.apply_cmb_heating(emissivity=emissivity, z=z)
+            self.apply_cmb_heating(emissivity=emissivity, redshift=redshift)
         else:
             self.temperature_z = temperature
 
@@ -315,7 +323,7 @@ class Greybody(EmissionBase):
         cmb_heating (bool)
             Option for adding heating by CMB
 
-        z (float)
+        redshift (float)
             Redshift of the galaxy
 
     """
@@ -323,7 +331,7 @@ class Greybody(EmissionBase):
     temperature: unyt_quantity
     emissivity: float
     cmb_heating: bool
-    z: float
+    redshift: float
 
     @accepts(temperature=temperature_dim)
     def __init__(
@@ -331,7 +339,7 @@ class Greybody(EmissionBase):
         temperature: unyt_quantity,
         emissivity: float,
         cmb_heating: bool = False,
-        z: float = 0,
+        redshift: float = 0,
     ) -> None:
         """
         Initialise the dust emission model.
@@ -346,7 +354,7 @@ class Greybody(EmissionBase):
             cmb_heating (bool)
                 Option for adding heating by CMB
 
-            z (float)
+            redshift (float)
                 Redshift of the galaxy
 
         """
@@ -356,7 +364,7 @@ class Greybody(EmissionBase):
         if cmb_heating:
             # calculate the factor by which the CMB boosts the
             # infrared luminosity
-            self.apply_cmb_heating(emissivity=emissivity, z=z)
+            self.apply_cmb_heating(emissivity=emissivity, redshift=redshift)
         else:
             self.temperature_z = temperature
 
@@ -418,7 +426,7 @@ class Casey12(EmissionBase):
         cmb_heating (bool)
                 Option for adding heating by CMB
 
-        z (float)
+        redshift (float)
             Redshift of the galaxy
 
     """
@@ -429,7 +437,7 @@ class Casey12(EmissionBase):
     N_bb: float
     lam_0: unyt_quantity
     cmb_heating: bool
-    z: float
+    redshift: float
 
     @accepts(temperature=temperature_dim)
     def __init__(
@@ -440,7 +448,7 @@ class Casey12(EmissionBase):
         N_bb: float = 1.0,
         lam_0: unyt_quantity = 200.0 * um,
         cmb_heating: bool = False,
-        z: float = 0,
+        redshift: float = 0,
     ) -> None:
         """
         Args:
@@ -465,7 +473,7 @@ class Casey12(EmissionBase):
             cmb_heating (bool)
                 Option for adding heating by CMB
 
-            z (float)
+            redshift (float)
                 Redshift of the galaxy
 
         """
@@ -475,7 +483,7 @@ class Casey12(EmissionBase):
         if cmb_heating:
             # calculate the factor by which the CMB boosts the
             # infrared luminosity
-            self.apply_cmb_heating(emissivity=emissivity, z=z)
+            self.apply_cmb_heating(emissivity=emissivity, redshift=redshift)
         else:
             self.temperature_z = temperature
 

--- a/src/synthesizer/emission_models/dust/emission.py
+++ b/src/synthesizer/emission_models/dust/emission.py
@@ -525,9 +525,14 @@ class Casey12(EmissionBase):
                     The wavelengths at which to calculate lnu.
             """
             return (
-                self.n_pl
-                * ((lam / self.lam_c) ** (self.alpha))
-                * np.exp(-((lam / self.lam_c) ** 2))
+                (
+                    self.n_pl
+                    * ((lam / self.lam_c) ** (self.alpha))
+                    * np.exp(-((lam / self.lam_c) ** 2))
+                ).value
+                * erg
+                / s
+                / Hz
             )
 
         def _blackbody(lam: unyt_array) -> unyt_array:
@@ -539,10 +544,15 @@ class Casey12(EmissionBase):
                     The wavelengths at which to calculate lnu.
             """
             return (
-                self.N_bb
-                * (1 - np.exp(-((self.lam_0 / lam) ** self.emissivity)))
-                * (c / lam) ** 3
-                / (np.exp((h * c) / (lam * kb * self.temperature)) - 1.0)
+                (
+                    self.N_bb
+                    * (1 - np.exp(-((self.lam_0 / lam) ** self.emissivity)))
+                    * (c / lam) ** 3
+                    / (np.exp((h * c) / (lam * kb * self.temperature)) - 1.0)
+                ).value
+                * erg
+                / s
+                / Hz
             )
 
         return _power_law(c / nu) + _blackbody(c / nu)
@@ -769,9 +779,9 @@ class IR_templates:
             )
 
         # Ensure wavelengths have units
-        if has_units(lam):
+        if not has_units(lam):
             raise exceptions.MissingUnits(
-                "Wavelength must be a given without units."
+                "Wavelength must be a given with units."
             )
 
         # Interpret the dust spectra for the given

--- a/src/synthesizer/emission_models/dust/emission.py
+++ b/src/synthesizer/emission_models/dust/emission.py
@@ -509,10 +509,11 @@ class Casey12(EmissionBase):
                 The unnormalised spectral luminosity density.
 
         """
-        # Essential, when using scipy.integrate, since
-        # the integration limits are passed unitless
-        if np.isscalar(nu):
-            nu *= Hz
+        # Ensure we have units
+        if not has_units(nu):
+            raise exceptions.MissingUnits(
+                f"Frequency must be a given with units. (type(nu)={type(nu)})"
+            )
 
         # Define a function to calcualate the power-law component.
         def _power_law(lam: unyt_array) -> float:

--- a/src/synthesizer/emission_models/dust/emission.py
+++ b/src/synthesizer/emission_models/dust/emission.py
@@ -389,7 +389,7 @@ class Greybody(EmissionBase):
                 "Frequency must be given in Hz."
             )
 
-        return nu**self.emissivity * planck(nu, self.temperature)
+        return self.emissivity * planck(nu, self.temperature)
 
 
 class Casey12(EmissionBase):

--- a/src/synthesizer/emission_models/dust/emission.py
+++ b/src/synthesizer/emission_models/dust/emission.py
@@ -389,7 +389,7 @@ class Greybody(EmissionBase):
                 "Frequency must be given in Hz."
             )
 
-        return self.emissivity * planck(nu, self.temperature)
+        return (nu / Hz) * self.emissivity * planck(nu, self.temperature)
 
 
 class Casey12(EmissionBase):

--- a/src/synthesizer/emission_models/dust/emission.py
+++ b/src/synthesizer/emission_models/dust/emission.py
@@ -148,20 +148,16 @@ class EmissionBase:
         # multidiensional arrays properly)
         if bolometric_luminosity.value.ndim == 0:
             lnu = (
-                bolometric_luminosity.to("erg/s") * self._get_spectra(lam).lnu
+                bolometric_luminosity.to("erg/s").value
+                * self._get_spectra(lam).lnu
             )
         else:
             lnu = (
                 np.expand_dims(
                     bolometric_luminosity.to("erg/s").value, axis=-1
                 )
-                * self._get_spectra(lam)._lnu
-                * erg
-                / s
-                / Hz
+                * self._get_spectra(lam).lnu
             )
-
-        print(bolometric_luminosity)
 
         # Create new Sed object containing dust emission spectra
         return Sed(lam, lnu=lnu)
@@ -188,12 +184,11 @@ class EmissionBase:
         # Get frequencies
         nu = (c / lam).to(Hz)
 
-        print(self._lnu(nu))
         sed = Sed(lam=lam, lnu=self._lnu(nu))
 
         # Normalise the spectrum
         sed._lnu /= np.expand_dims(
-            sed.measure_bolometric_luminosity(), axis=-1
+            sed.measure_bolometric_luminosity().value, axis=-1
         )
 
         # Apply heating due to CMB, if applicable

--- a/src/synthesizer/emission_models/dust/emission.py
+++ b/src/synthesizer/emission_models/dust/emission.py
@@ -258,7 +258,7 @@ class Blackbody(EmissionBase):
         redshift: float = 0,
     ) -> None:
         """
-        A function to generate a simple blackbody spectrum.
+        Generate a simple blackbody spectrum.
 
         Args:
             temperature (unyt_array)
@@ -271,14 +271,14 @@ class Blackbody(EmissionBase):
                 Redshift of the galaxy
 
         """
-
         EmissionBase.__init__(self, temperature)
 
-        # emmissivity of true blackbody is 1
+        # Emmissivity of true blackbody is 1
         emissivity = 1.0
 
+        # Are we adding heating by the CMB?
         if cmb_heating:
-            # calculate the factor by which the CMB boosts the
+            # Calculate the factor by which the CMB boosts the
             # infrared luminosity
             self.apply_cmb_heating(emissivity=emissivity, redshift=redshift)
         else:
@@ -319,13 +319,10 @@ class Greybody(EmissionBase):
     Attributes:
         emissivity (float)
             The emissivity of the dust (dimensionless).
-
         cmb_heating (bool)
             Option for adding heating by CMB
-
         redshift (float)
             Redshift of the galaxy
-
     """
 
     temperature: unyt_quantity
@@ -347,22 +344,18 @@ class Greybody(EmissionBase):
         Args:
             temperature (unyt_array)
                 The temperature of the dust.
-
             emissivity (float)
                 The Emissivity (dimensionless).
-
             cmb_heating (bool)
                 Option for adding heating by CMB
-
             redshift (float)
                 Redshift of the galaxy
-
         """
-
         EmissionBase.__init__(self, temperature)
 
+        # Are we adding heating by the CMB?
         if cmb_heating:
-            # calculate the factor by which the CMB boosts the
+            # Calculate the factor by which the CMB boosts the
             # infrared luminosity
             self.apply_cmb_heating(emissivity=emissivity, redshift=redshift)
         else:
@@ -402,33 +395,26 @@ class Greybody(EmissionBase):
 class Casey12(EmissionBase):
     """
     A class to generate a dust emission spectrum using the Casey (2012) model.
+
     https://ui.adsabs.harvard.edu/abs/2012MNRAS.425.3094C/abstract
 
     Attributes:
         emissivity (float)
             The emissivity of the dust (dimensionless).
-
         alpha (float)
             The power-law slope (dimensionless)  [good value = 2.0].
-
         n_bb (float)
             Normalisation of the blackbody component [default 1.0].
-
         lam_0 (float)
             Wavelength where the dust optical depth is unity.
-
         lam_c (float)
             The power law turnover wavelength.
-
         n_pl (float)
             The power law normalisation.
-
         cmb_heating (bool)
                 Option for adding heating by CMB
-
         redshift (float)
             Redshift of the galaxy
-
     """
 
     temperature: unyt_quantity
@@ -451,37 +437,31 @@ class Casey12(EmissionBase):
         redshift: float = 0,
     ) -> None:
         """
+        Initialise the dust emission model.
+
         Args:
             lam (unyt_array)
                 The wavelengths at which to calculate the emission.
-
             temperature (unyt_array)
                 The temperature of the dust.
-
             emissivity (float)
                 The emissivity (dimensionless) [good value = 1.6].
-
             alpha (float)
                 The power-law slope (dimensionless)  [good value = 2.0].
-
             n_bb (float)
                 Normalisation of the blackbody component [default 1.0].
-
             lam_0 (float)
                 Wavelength where the dust optical depth is unity.
-
             cmb_heating (bool)
                 Option for adding heating by CMB
-
             redshift (float)
                 Redshift of the galaxy
-
         """
-
         EmissionBase.__init__(self, temperature)
 
+        # Are we adding heating by the CMB?
         if cmb_heating:
-            # calculate the factor by which the CMB boosts the
+            # Calculate the factor by which the CMB boosts the
             # infrared luminosity
             self.apply_cmb_heating(emissivity=emissivity, redshift=redshift)
         else:
@@ -508,7 +488,6 @@ class Casey12(EmissionBase):
 
         # See Casey+2012, Table 1 for the expression
         # Missing factors of lam_c and c in some places
-
         self.n_pl = (
             self.N_bb
             * (1 - np.exp(-((self.lam_0 / self.lam_c) ** emissivity)))
@@ -530,7 +509,6 @@ class Casey12(EmissionBase):
                 The unnormalised spectral luminosity density.
 
         """
-
         # Essential, when using scipy.integrate, since
         # the integration limits are passed unitless
         if np.isscalar(nu):
@@ -697,7 +675,7 @@ class IR_templates:
         umins: NDArray[np.float32] = self.grid.umin
         alphas: NDArray[np.float32] = self.grid.alpha
 
-        # default Umax=1e7
+        # Default Umax=1e7
         umax: float = 1e7
 
         if self.MH is None:
@@ -705,7 +683,7 @@ class IR_templates:
                 "No hydrogen gas mass provided, assuming a"
                 f"dust-to-gas ratio of {self.dgr}"
             )
-            # calculate MH: Mass in hydrogen gas
+            # Calculate MH: Mass in hydrogen gas
             self.MH = 0.74 * self.mdust / self.dgr
 
         if (self.gamma is None) or (self.umin is None) or (self.alpha == 2.0):
@@ -795,7 +773,7 @@ class IR_templates:
                 "Wavelength must be a given without units."
             )
 
-        # interpret the dust spectra for the given
+        # Interpret the dust spectra for the given
         # wavelength range
         self.grid.interp_spectra(new_lam=lam)
         lnu_old = (
@@ -828,19 +806,21 @@ class IR_templates:
 
 def u_mean_magdis12(mdust: float, ldust: float, p0: float) -> float:
     """
+    Calculate the mean radiation field heating the dust.
+
     P0 value obtained from stacking analysis in Magdis+12
     For alpha=2.0
     https://ui.adsabs.harvard.edu/abs/2012ApJ...760....6M/abstract
     """
-
     return ldust / (p0 * mdust)
 
 
 def u_mean(umin: float, umax: float, gamma: float) -> float:
     """
+    Calculate the mean radiation field heating the dust.
+
     For fixed alpha=2.0, get <U> for Draine and Li model
     """
-
     return (1.0 - gamma) * umin + gamma * np.log(umax / umin) / (
         umin ** (-1) - umax ** (-1)
     )
@@ -848,7 +828,8 @@ def u_mean(umin: float, umax: float, gamma: float) -> float:
 
 def solve_umin(umin: float, umax: float, u_avg: float, gamma: float) -> float:
     """
+    Solve for Umin in the Draine and Li model.
+
     For fixed alpha=2.0, equation to solve to <U> in Draine and Li
     """
-
     return u_mean(umin, umax, gamma) - u_avg

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -125,7 +125,10 @@ class Extraction:
                     mask=this_mask,
                     verbose=verbose,
                     **kwargs,
-                ),
+                )
+                * erg
+                / s
+                / Hz,
             )
 
             # Store the spectra in the right place (integrating if we
@@ -365,6 +368,7 @@ class Generation:
                 intrinsic,
                 attenuated,
             )
+
         elif this_model.lum_intrinsic_model is not None:
             # otherwise we are scaling by a single spectra
             sed = generator.get_spectra(
@@ -749,12 +753,18 @@ class Combination:
                 emission_model.lam,
                 lnu=np.zeros_like(
                     particle_spectra[this_model.combine[0].label]._lnu
-                ),
+                )
+                * erg
+                / s
+                / Hz,
             )
         else:
             out_spec = Sed(
                 emission_model.lam,
-                lnu=np.zeros_like(spectra[this_model.combine[0].label]._lnu),
+                lnu=np.zeros_like(spectra[this_model.combine[0].label]._lnu)
+                * erg
+                / s
+                / Hz,
             )
 
         # Combine the spectra

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -986,7 +986,7 @@ class Grid:
             Sed
                 The spectra grid as an Sed object.
         """
-        return Sed(self.lam, self.spectra[spectra_type])
+        return Sed(self.lam, self.spectra[spectra_type] * erg / s / Hz)
 
     def truncate_grid_lam(self, min_lam, max_lam):
         """

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -1147,14 +1147,16 @@ class Sed:
         new_spectra = spectres(new_lam, self._lam, self._lnu, fill=0)
 
         # Instantiate the new Sed
-        sed = Sed(new_lam, new_spectra)
+        sed = Sed(new_lam, new_spectra * self.lnu.units)
 
         # If self also has fnu we should resample those too and store the
         # shifted wavelengths and frequencies
         if self.fnu is not None:
-            sed.obslam = sed._lam * (1.0 + self.redshift)
-            sed.obsnu = sed._nu / (1.0 + self.redshift)
-            sed.fnu = spectres(sed._obslam, self._obslam, self._fnu)
+            sed.obslam = sed.lam * (1.0 + self.redshift)
+            sed.obsnu = sed.nu / (1.0 + self.redshift)
+            sed.fnu = (
+                spectres(sed._obslam, self._obslam, self._fnu) * self.fnu.units
+            )
             sed.redshift = self.redshift
 
         # Clean up nans, we shouldn't get them but they do appear sometimes...

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -91,6 +91,12 @@ class Sed:
             description (string)
                 An optional descriptive string defining the Sed.
         """
+        # Ensure we have units
+        if not has_units(lam):
+            raise exceptions.MissingUnits("lam must have units.")
+        if lnu is not None and not has_units(lnu):
+            raise exceptions.MissingUnits("lnu must have units.")
+
         start = tic()
 
         # Set the description
@@ -98,12 +104,6 @@ class Sed:
 
         # Set the wavelength
         self.lam = lam
-
-        # Ensure we have units
-        if not has_units(lam):
-            raise exceptions.MissingUnits("lam must have units.")
-        if lnu is not None and not has_units(lnu):
-            raise exceptions.MissingUnits("lnu must have units.")
 
         # Calculate frequency
         self.nu = c / self.lam

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -100,7 +100,7 @@ class Sed:
         self.lam = lam
 
         # Ensure we have units
-        if not has_units(self.lam):
+        if not has_units(lam):
             raise exceptions.MissingUnits("lam must have units.")
         if lnu is not None and not has_units(lnu):
             raise exceptions.MissingUnits("lnu must have units.")
@@ -266,7 +266,7 @@ class Sed:
             )
 
         # They're compatible, add them and make a new Sed
-        new_sed = Sed(self._lam, lnu=self._lnu + second_sed._lnu)
+        new_sed = Sed(self.lam, lnu=self.lnu + second_sed.lnu)
 
         # If fnu exists on both then we need to add those too
         if (self.fnu is not None) and (second_sed.fnu is not None):

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -99,6 +99,12 @@ class Sed:
         # Set the wavelength
         self.lam = lam
 
+        # Ensure we have units
+        if not has_units(self.lam):
+            raise exceptions.MissingUnits("lam must have units.")
+        if lnu is not None and not has_units(lnu):
+            raise exceptions.MissingUnits("lnu must have units.")
+
         # Calculate frequency
         self.nu = c / self.lam
 

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -148,11 +148,15 @@ class Sed:
             sum_over = tuple(range(0, len(self._lnu.shape) - 1))
 
             # Create a new sed object with the first Lnu dimension collapsed
-            new_sed = Sed(self.lam, np.nansum(self._lnu, axis=sum_over))
+            new_sed = Sed(
+                self.lam, np.nansum(self._lnu, axis=sum_over) * self.lnu.units
+            )
 
             # If fnu exists, sum that too
             if self.fnu is not None:
-                new_sed.fnu = np.nansum(self.fnu, axis=sum_over)
+                new_sed.fnu = (
+                    np.nansum(self._fnu, axis=sum_over) * self.fnu.units
+                )
                 new_sed.obsnu = self.obsnu
                 new_sed.obslam = self.obslam
                 new_sed.redshift = self.redshift
@@ -1232,7 +1236,7 @@ class Sed:
         else:
             spectra[mask] *= transmission
 
-        return Sed(self.lam, lnu=spectra)
+        return Sed(self.lam, lnu=spectra * self.lnu.units)
 
     def calculate_ionising_photon_production_rate(
         self, ionisation_energy=13.6 * eV, limit=100, nthreads=1

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -222,7 +222,7 @@ class Sed:
             # Concatenate this lnu array
             new_lnu = np.concatenate((new_lnu, other_lnu))
 
-        return Sed(self._lam, new_lnu)
+        return Sed(self.lam, new_lnu * self.lnu.units)
 
     def __add__(self, second_sed):
         """
@@ -317,7 +317,7 @@ class Sed:
                 A new instance of Sed with scaled lnu.
         """
 
-        return Sed(self._lam, lnu=scaling * self._lnu)
+        return Sed(self.lam, lnu=scaling * self.lnu)
 
     def __rmul__(self, scaling):
         """
@@ -336,7 +336,7 @@ class Sed:
                 A new instance of Sed with scaled lnu.
         """
 
-        return Sed(self._lam, lnu=scaling * self._lnu)
+        return Sed(self._lam, lnu=scaling * self.lnu)
 
     def __str__(self):
         """

--- a/src/synthesizer/utils/integrate.py
+++ b/src/synthesizer/utils/integrate.py
@@ -53,10 +53,14 @@ def integrate_last_axis(xs, ys, nthreads=1, method="trapz"):
         trapz_last_axis if method == "trapz" else simps_last_axis
     )
 
-    # Scale the integrand and xs to avoid numerical issues
-    xscale = xs.max()
-    yscale = ys.max()
-    xs /= xscale
-    ys /= yscale
+    # We need to make a copy of xs and ys to avoid modifying in place
+    _xs = xs.copy()
+    _ys = ys.copy()
 
-    return integration_function(xs, ys, nthreads) * xscale * yscale
+    # Scale the integrand and xs to avoid numerical issues
+    xscale = _xs.max()
+    yscale = _ys.max()
+    _xs /= xscale
+    _ys /= yscale
+
+    return integration_function(_xs, _ys, nthreads) * xscale * yscale

--- a/tests/test_sed.py
+++ b/tests/test_sed.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from unyt import angstrom
 
 from synthesizer.sed import Sed
 
@@ -7,7 +8,7 @@ from synthesizer.sed import Sed
 @pytest.fixture
 def empty_sed():
     """returns an Sed instance"""
-    lam = np.loadtxt("tests/test_sed/lam.txt")
+    lam = np.loadtxt("tests/test_sed/lam.txt") * angstrom
 
     return Sed(lam=lam)
 


### PR DESCRIPTION
While ensuring the dust emission being generated was actually right I stumbled across some inconsistencies. To avoid these inconsistencies units are now used in the generation of spectra. Also:

- Doc strings have been cleaned up.
- `planck` has been "fixed" to produce spectral luminosity density rather than spectral radiance density. In reality this never mattered because the output was always normalised but meant the units were wrong (and would give an incorrect answer if called separately).
- Normalisation is now done consistently using `Sed` methods rather than `scipy`.

I've also updated the ruff workflow version to use the latest hash and fixed an issue introduced in #727 

## Issue Type
<!-- delete options below as required -->
- Bug
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
