### PR TITLE
BUGFIX: Fixing `Grid.get_spectra` edge case 

### DIFF
--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -591,9 +591,9 @@ class DustAttenuation:
         """
         # Unpack the tau_v value unpacking any attributes we need
         # to extract from the emitter
-        tau_v = 1
+        tau_v = 0
         for tv in this_model.tau_v:
-            tau_v *= getattr(emitter, tv) if isinstance(tv, str) else tv
+            tau_v += getattr(emitter, tv) if isinstance(tv, str) else tv
 
         # Get the spectra to apply dust to
         if this_model.per_particle:
@@ -650,10 +650,9 @@ class DustAttenuation:
         """
         # Unpack the tau_v value unpacking any attributes we need
         # to extract from the emitter
-        tau_v = 1
+        tau_v = 0
         for tv in this_model.tau_v:
-            tau_v *= getattr(emitter, tv) if isinstance(tv, str) else tv
-            tau_v *= getattr(emitter, tv) if isinstance(tv, str) else tv
+            tau_v += getattr(emitter, tv) if isinstance(tv, str) else tv
 
         # Get the lines to apply dust to
         if this_model.per_particle:

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -718,7 +718,10 @@ class Grid:
 
         # Throw an exception if grid point is outside grid bounds
         try:
-            return Sed(self.lam, lnu=self.spectra[spectra_id][grid_point])
+            return Sed(
+                self.lam,
+                lnu=self.spectra[spectra_id][grid_point] * erg / s / Hz,
+            )
         except IndexError:
             # Modify the error message for clarity
             raise IndexError(

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -681,9 +681,7 @@ class Stars(StarsComponent):
 
         # Check we have units
         if not has_units(lum):
-            raise exceptions.IncorrectUnits(
-                "lum must be given with unyt units"
-            )
+            raise exceptions.MissingUnits("lum must be given with unyt units")
 
         # Calculate the current luminosity in scale_filter
         sed = self.spectra[spectra_type]

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -760,7 +760,7 @@ class Stars(StarsComponent):
         conversion = flux / current_flux
 
         # Apply conversion to the masses
-        self.initial_mass *= conversion
+        self._initial_mass *= conversion
 
         # Apply the conversion to all spectra
         for key in self.spectra:

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -696,7 +696,7 @@ class Stars(StarsComponent):
         conversion = lum / current_lum
 
         # Apply conversion to the masses
-        self.initial_mass *= conversion
+        self._initial_mass *= conversion
 
         # Apply the conversion to all spectra
         for key in self.spectra:

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -503,13 +503,16 @@ class Sed:
         # NOTE: the integration is done "backwards" when integrating over
         # frequency. It's faster to just multiply by -1 than to reverse the
         # array.
-        self.bolometric_luminosity = -integrate_last_axis(
+        integral = -integrate_last_axis(
             self._nu,
             self._lnu,
             nthreads=nthreads,
             method=integration_method,
         )
         toc("Calculating bolometric luminosity", start)
+
+        # Assign the integral to the bolometric luminosity
+        self.bolometric_luminosity = integral * self.lnu.units * self.nu.units
 
         return self.bolometric_luminosity
 

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -20,7 +20,7 @@ import numpy as np
 from scipy.interpolate import interp1d
 from scipy.stats import linregress
 from spectres import spectres
-from unyt import Hz, angstrom, c, cm, erg, eV, h, pc, s, unyt_array
+from unyt import Hz, angstrom, c, cm, erg, eV, h, pc, s
 
 from synthesizer import exceptions
 from synthesizer.conversions import lnu_to_llam
@@ -97,17 +97,7 @@ class Sed:
         self.description = description
 
         # Set the wavelength
-        if isinstance(lam, (unyt_array, np.ndarray)):
-            self.lam = lam
-        elif isinstance(lam, list):
-            self.lam = np.asarray(lam)  # \AA
-        else:
-            raise ValueError(
-                (
-                    "`lam` must be a unyt_array, list, list of "
-                    "lists, or N-d numpy array"
-                )
-            )
+        self.lam = lam
 
         # Calculate frequency
         self.nu = c / self.lam
@@ -117,17 +107,7 @@ class Sed:
         if lnu is None:
             self.lnu = np.zeros(self.lam.shape)
         else:
-            if isinstance(lnu, (unyt_array, np.ndarray)):
-                self.lnu = lnu
-            elif isinstance(lnu, list):
-                self.lnu = np.asarray(lnu)
-            else:
-                raise ValueError(
-                    (
-                        "`lnu` must be a unyt_array, list, list "
-                        "of lists, or N-d numpy array"
-                    )
-                )
+            self.lnu = lnu
 
         # Prepare for bolometric luminosity calculation
         self.bolometric_luminosity = None

--- a/src/synthesizer/utils/integrate.py
+++ b/src/synthesizer/utils/integrate.py
@@ -53,4 +53,10 @@ def integrate_last_axis(xs, ys, nthreads=1, method="trapz"):
         trapz_last_axis if method == "trapz" else simps_last_axis
     )
 
-    return integration_function(xs, ys, nthreads)
+    # Scale the integrand and xs to avoid numerical issues
+    xscale = xs.max()
+    yscale = ys.max()
+    xs /= xscale
+    ys /= yscale
+
+    return integration_function(xs, ys, nthreads) * xscale * yscale


### PR DESCRIPTION
@stephenmwilkins found a bug where the result of `measure_bolometric_luminosity` differed from the numpy result but only when the `Sed` was sourced from `Grid.get_spectra` which did not previously associate units to the grid point it made the `Sed` from. It is unclear exactly what causes this but passing units (which would be best practice anyway) fixes this issue immediately.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
