### PR TITLE
Added a doppler broadening method on Sed

### DIFF
--- a/docs/source/sed/sed_example.ipynb
+++ b/docs/source/sed/sed_example.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from unyt import Angstrom, eV, um\n",
+    "from unyt import Angstrom, eV, um, km, s\n",
     "\n",
     "from synthesizer.emission_models.attenuation.igm import Madau96\n",
     "from synthesizer.filters import FilterCollection\n",
@@ -412,6 +412,54 @@
     "sed.calculate_ionising_photon_production_rate(\n",
     "    ionisation_energy=13.6 * eV, limit=1000\n",
     ")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "7e40ee5e",
+   "metadata": {},
+   "source": [
+    "## Doppler broadening\n",
+    "\n",
+    "Doppler broadening is broadening of spectral lines due to the Doppler effect caused by a distribution of velocities of atoms or molecules. Different velocities of the emitting (or absorbing) particles result in different Doppler shifts, the cumulative effect of which is the emission (absorption) line broadening."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ce3edaee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# open a grid restricted to just the optical\n",
+    "optical_grid = Grid(grid_name, grid_dir=grid_dir, lam_lims=[3500, 7500])\n",
+    "\n",
+    "# determine the grid point for a young, typical metallicity SSP\n",
+    "log10age = 6.\n",
+    "metallicity = 0.01\n",
+    "grid_point = grid.get_grid_point((log10age, metallicity))\n",
+    "\n",
+    "# get the spectra\n",
+    "nebular_sed = optical_grid.get_spectra(grid_point, spectra_id='nebular')\n",
+    "\n",
+    "# as above\n",
+    "nebular_sed_doppler = optical_grid.get_spectra(grid_point, spectra_id='nebular')\n",
+    "\n",
+    "# add extreme broadening to one spectra\n",
+    "velocity_fwhm = 5000 * km / s\n",
+    "nebular_sed_doppler.add_doppler_broadening(velocity_fwhm=velocity_fwhm)\n",
+    "\n",
+    "# Get bolometric luminosities of both spectra.\n",
+    "# These should be very similar, though not quite identical.\n",
+    "print(nebular_sed.measure_bolometric_luminosity())\n",
+    "print(nebular_sed_doppler.measure_bolometric_luminosity())\n",
+    "\n",
+    "plt.plot(nebular_sed.lam, nebular_sed.lnu)\n",
+    "plt.plot(nebular_sed_doppler.lam, nebular_sed_doppler.lnu)\n",
+    "\n",
+    "plt.show()"
    ]
   },
   {

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -18,9 +18,20 @@ import re
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy.interpolate import interp1d
-from scipy.stats import linregress
+from scipy.stats import linregress, norm
 from spectres import spectres
-from unyt import Hz, angstrom, c, cm, erg, eV, h, pc, s, unyt_array
+from unyt import (
+    Hz,
+    angstrom,
+    c,
+    cm,
+    erg,
+    eV,
+    h,
+    pc,
+    s,
+    unyt_array,
+)
 
 from synthesizer import exceptions
 from synthesizer.conversions import lnu_to_llam
@@ -1317,6 +1328,70 @@ class Sed:
         A wrapper for synthesizer.sed.plot_spectra_as_rainbow()
         """
         return plot_spectra_as_rainbow(self, **kwargs)
+
+    # @accepts(velocity_fwhm=length/time, velocity_sigma=length/time)
+    def add_doppler_broadening(self, velocity_fwhm=None, velocity_sigma=None):
+        """
+        Add Doppler broadening to the spectra. This updates self.lnu to
+        include Gaussian Doppler broadening.
+
+        Args:
+            velocity_fwhm (unyt.array.unyt_quantity)
+                The FWHM of the velocity distribution.
+            velocity_sigma (unyt.array.unyt_quantity)
+                The standard deviation (scale, sigma) of the velocity
+                distribution.
+
+        Updates:
+            self.lnu
+        """
+
+        # Check to see if either of the measures of velocity dispersion have
+        # been provided.
+        if (velocity_sigma is None) and (velocity_fwhm is None):
+            raise exceptions.MissingArgument("")
+
+        # If velocity_sigma has not been provided go ahead and calculate it.
+        if velocity_sigma is None:
+            # Standard relationship between sigma (scale) and FWHM for a
+            # Normal distribution.
+            velocity_sigma = velocity_fwhm / np.sqrt(8 * np.log(2))
+
+        # set up new an array to hold the new spectra
+        new_sed_lnu = np.zeros(len(self.lam))
+
+        # set the first and last values to the original since these are not
+        # calculated
+        new_sed_lnu[0] = self._lnu[0]
+        new_sed_lnu[-1] = self._lnu[-1]
+
+        nu_lower = 0.5 * (self.nu[1:-1] + self.nu[2:])
+        nu_upper = 0.5 * (self.nu[:-2] + self.nu[1:-1])
+
+        # Loop over each resolution element, ignoring the first and last
+        # element. This is because to do this properly we are going to
+        # calculate the probability in each bin using the CDF.
+        for nu0, lnu0 in zip(self.nu[1:-1], self.lnu[1:-1]):
+            # Calculate sigma in freuqncy space.
+            nu_sigma = velocity_sigma * nu0 / c
+
+            # Convert to a dimensionless scale.
+            scale = nu_sigma.to("THz").value
+
+            # Calculate the upper and lower edges of the resolution element.
+            lower_edges = (nu_lower - nu0).to("THz").value
+            upper_edges = (nu_upper - nu0).to("THz").value
+
+            # Now calcualte the fraction of the flux that falls in each
+            # resolution element.
+            fraction = norm.cdf(upper_edges, scale=scale) - norm.cdf(
+                lower_edges, scale=scale
+            )
+
+            new_sed_lnu[1:-1] += lnu0.to("erg/s/Hz").value * fraction
+
+        # replace lnu
+        self.lnu = new_sed_lnu * erg / s / Hz
 
 
 def plot_spectra(


### PR DESCRIPTION
I have added a Doppler (thermal) broadening method on `Sed`. 

- This acts on `Sed.lnu` in place.
- Added an example to the docs.
- The bolometric luminosities are not yet correct due to a wider bug we have discovered.
- No thorough testing yet, need something to compare with. 

## Issue Type
<!-- delete options below as required -->
- [ ] Bug
- [ ] Document
- [x] Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
