### PR TITLE
Catching more errors in downloads and redirecting to dropbox

### DIFF
--- a/src/synthesizer/download_data.py
+++ b/src/synthesizer/download_data.py
@@ -151,10 +151,6 @@ def _download(
     # Try the primary host
     try:
         _download_from_xcs_host(filename, save_dir)
-    except exceptions.DownloadError:
-        print("Failed to download from primary host. Trying dropbox...")
-        # If the primary host fails, try the dropbox alternative
-        _download_from_dropbox(filename, save_dir)
     except KeyboardInterrupt as e:
         # Re-raise the keyboard interrupt
         raise KeyboardInterrupt(e)

--- a/src/synthesizer/download_data.py
+++ b/src/synthesizer/download_data.py
@@ -155,6 +155,13 @@ def _download(
         print("Failed to download from primary host. Trying dropbox...")
         # If the primary host fails, try the dropbox alternative
         _download_from_dropbox(filename, save_dir)
+    except KeyboardInterrupt as e:
+        # Re-raise the keyboard interrupt
+        raise KeyboardInterrupt(e)
+    except Exception as e:
+        print("Failed to download from primary host:", e)
+        print("Trying dropbox...")
+        _download_from_dropbox(filename, save_dir)
 
 
 def download_test_grids(destination):


### PR DESCRIPTION
While our server is proving more temperamental there's some unaccounted for errors which won't trigger falling back to dropbox. With this PR every exception except a `KeyboardInterrupt` will trigger falling back.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
