### PR TITLE
Fixing some Unified AGN bugs

### DIFF
--- a/src/synthesizer/emission_models/agn/unified_agn.py
+++ b/src/synthesizer/emission_models/agn/unified_agn.py
@@ -236,9 +236,6 @@ class UnifiedAGN(BlackHoleEmissionModel):
             grid=grid,
             label="disc_incident",
             extract="incident",
-            mask_attr="_torus_edgeon_cond",
-            mask_thresh=90 * deg,
-            mask_op="<",
             **kwargs,
         )
 
@@ -279,9 +276,6 @@ class UnifiedAGN(BlackHoleEmissionModel):
         model = BlackHoleEmissionModel(
             label="disc_transmitted",
             combine=(nlr, blr),
-            mask_attr="_torus_edgeon_cond",
-            mask_thresh=90 * deg,
-            mask_op="<",
             **kwargs,
         )
 
@@ -305,6 +299,9 @@ class UnifiedAGN(BlackHoleEmissionModel):
             label="disc_escaped",
             extract="incident",
             fesc=(covering_fraction_nlr + covering_fraction_blr),
+            mask_attr="_torus_edgeon_cond",
+            mask_thresh=90 * deg,
+            mask_op="<",
             **kwargs,
         )
 
@@ -315,9 +312,6 @@ class UnifiedAGN(BlackHoleEmissionModel):
         return BlackHoleEmissionModel(
             label="disc",
             combine=(self.disc_transmitted, self.disc_escaped),
-            mask_attr="_torus_edgeon_cond",
-            mask_thresh=90 * deg,
-            mask_op="<",
             **kwargs,
         )
 
@@ -337,9 +331,6 @@ class UnifiedAGN(BlackHoleEmissionModel):
             extract="nebular",
             fesc=1 - covering_fraction_nlr,
             fixed_parameters={"cosine_inclination": 0.5},
-            mask_attr="_torus_edgeon_cond",
-            mask_thresh=90 * deg,
-            mask_op="<",
             **kwargs,
         )
         blr = BlackHoleEmissionModel(

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -105,6 +105,7 @@ class Extraction:
             # Fix any parameters we need to fix
             prev_properties = {}
             for prop in this_model.fixed_parameters:
+                prev_properties[prop] = getattr(emitter, prop, None)
                 setattr(emitter, prop, this_model.fixed_parameters[prop])
 
             # Get the generator function


### PR DESCRIPTION
Fixes a couple of bugs:

- When a parameter is fixed in an extraction it wasn't reset the parameter on the component. Since `cosine_inclination` is fixed as part of `UnifiedAGN` this led to this parameter being permanently changed.
- Some of the masking choices on `UnifiedAGN` was incorrect. The NLR should always be visible, and thus never masked.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
