### PR TITLE
Update abundances with plural metallicities axis

### DIFF
--- a/src/synthesizer/abundances/abundance_patterns.py
+++ b/src/synthesizer/abundances/abundance_patterns.py
@@ -2,7 +2,7 @@
 
 Abundance patterns describe the relative abundances of elements in a particular
 component of a galaxy (e.g. stars, gas, dust). This code is used to define
-abundance patterns as a function of metallicity, alpha enhancement, etc.
+abundance patterns as a function of metallicities, alpha enhancement, etc.
 
 The main current use of this code is in the creation cloudy input models when
 processing SPS incident grids to model nebular emission.
@@ -30,8 +30,8 @@ class Abundances:
     scaling and depletion on to dust.
 
     Attributes:
-        metallicity (float)
-            Mass fraction in metals, default is reference metallicity.
+        metallicities (float)
+            Mass fraction in metals, default is reference metallicities.
             Optional initialisation argument. If not provided is calculated
             from the provided abundance pattern.
         alpha (float)
@@ -68,7 +68,7 @@ class Abundances:
         dust (dict, float)
             The logarithmic abundance of each element in the dust phase.
         metal_mass_fraction (float)
-            Mass fraction in metals. Since this should be metallicity it is
+            Mass fraction in metals. Since this should be metallicities it is
             redundant but serves as a useful test.
         dust_mass_fraction (float)
             Mass fraction in metals.
@@ -78,7 +78,7 @@ class Abundances:
 
     def __init__(
         self,
-        metallicity=None,
+        metallicities=None,
         alpha=0.0,
         abundances=None,
         reference=reference_abundance_patterns.GalacticConcordance,
@@ -90,14 +90,14 @@ class Abundances:
         Initialise an abundance pattern
 
         Args:
-            metallicity (float)
-                Mass fraction in metals, default is reference metallicity.
+            metallicities (float)
+                Mass fraction in metals, default is reference metallicities.
             alpha (float)
                 Enhancement of the alpha elements relative to the reference
                 abundance pattern.
             abundances (dict, float/str)
                 A dictionary containing the abundances for specific elements or
-                functions to calculate them for the specified metallicity.
+                functions to calculate them for the specified metallicities.
             reference (class or str)
                 Reference abundance pattern object or str defining the class.
             depletion (dict, float)
@@ -126,7 +126,7 @@ class Abundances:
         }
 
         # save all arguments to object
-        self.metallicity = metallicity  # mass fraction in metals
+        self.metallicities = metallicities  # mass fraction in metals
         self.alpha = alpha
         self.reference = reference
         # depletion on to dust
@@ -151,19 +151,19 @@ class Abundances:
         if isinstance(self.reference, type):
             self.reference = self.reference()
 
-        # If a metallicity is not provided use the metallicity assumed by the
+        # If metallicities is not provided use the metallicities assumed by the
         # Reference abundance pattern.
-        if self.metallicity is None:
-            self.metallicity = self.reference.metallicity
+        if self.metallicities is None:
+            self.metallicities = self.reference.metallicities
 
         # Set helium mass fraction following Bressan et al. (2012)
         # 10.1111/j.1365-2966.2012.21948.x
         # https://ui.adsabs.harvard.edu/abs/2012MNRAS.427..127B/abstract
-        self.helium_mass_fraction = 0.2485 + 1.7756 * self.metallicity
+        self.helium_mass_fraction = 0.2485 + 1.7756 * self.metallicities
 
         # Define mass fraction in hydrogen
         self.hydrogen_mass_fraction = (
-            1.0 - self.helium_mass_fraction - self.metallicity
+            1.0 - self.helium_mass_fraction - self.metallicities
         )
 
         # logathrimic total abundance of element relative to H
@@ -178,10 +178,10 @@ class Abundances:
         )
 
         # Scale elemental abundances from reference abundances based on given
-        # metallicity
+        # metallicities
         for e in self.metals:
             total[e] = self.reference.abundance[e] + np.log10(
-                self.metallicity / self.reference.metallicity
+                self.metallicities / self.reference.metallicities
             )
 
         # Scale alpha-element abundances from reference abundances
@@ -209,12 +209,12 @@ class Abundances:
 
                     # get the specific function request by value
                     scaling_function = getattr(scaling_study, element_name)
-                    total[element] = scaling_function(metallicity)
+                    total[element] = scaling_function(metallicities)
 
                     # Setting alpha or abundances will result in the
-                    # metallicity no longer being correct. To account for
+                    # metallicities no longer being correct. To account for
                     # this we need to rescale the abundances to recover
-                    # the correct metallicity. However, we don't want to
+                    # the correct metallicities. However, we don't want to
                     # rescale the things we've changed. For this reason,
                     # here we record the elements which have changed. See
                     # below for the rescaling.
@@ -268,7 +268,7 @@ class Abundances:
 
                         # if value is a str use this to call the specific
                         # function to calculate the abundance from the
-                        # metallicity.
+                        # metallicities.
                         elif isinstance(value, str):
                             # get the class holding functions for this element
                             scaling_study = getattr(
@@ -284,12 +284,12 @@ class Abundances:
                                 scaling_study, element_name
                             )
 
-                            total[element] = scaling_function(metallicity)
+                            total[element] = scaling_function(metallicities)
 
                         # Setting alpha or abundances will result in the
                         # metallicity no longer being correct. To account for
                         # this we need to rescale the abundances to recover
-                        # the correct metallicity. However, we don't want to
+                        # the correct metallicities. However, we don't want to
                         # rescale the things we've changed. For this reason,
                         # here we record the elements which have changed. See
                         # below for the rescaling.
@@ -314,9 +314,9 @@ class Abundances:
         # and so (by rearranging) the scaling factor is:
         scaling = (
             mass_in_unscaled_metals
-            - self.metallicity * mass_in_unscaled_metals
-            - self.metallicity * mass_in_non_metals
-        ) / (mass_in_scaled_metals * (self.metallicity - 1))
+            - self.metallicities * mass_in_unscaled_metals
+            - self.metallicities * mass_in_non_metals
+        ) / (mass_in_scaled_metals * (self.metallicities - 1))
 
         # now apply this scaling
         for i in scaled_metals:
@@ -337,7 +337,7 @@ class Abundances:
             self.gas = self.total
             self.depletion = {element: 1.0 for element in self.all_elements}
             self.dust = {element: -np.inf for element in self.all_elements}
-            self.metal_mass_fraction = self.metallicity
+            self.metal_mass_fraction = self.metallicities
             self.dust_mass_fraction = 0.0
             self.dust_to_metal_ratio = 0.0
 
@@ -509,8 +509,8 @@ class Abundances:
         summary += "ABUNDANCE PATTERN SUMMARY\n"
         summary += f"X: {self.hydrogen_mass_fraction:.3f}\n"
         summary += f"Y: {self.helium_mass_fraction:.3f}\n"
-        summary += f"Z: {self.metallicity:.3f}\n"
-        ratio = self.metallicity / self.reference.metallicity
+        summary += f"Z: {self.metallicities:.3f}\n"
+        ratio = self.metallicities / self.reference.metallicities
         summary += f"Z/Z_ref: {ratio:.2g}\n"
         summary += f"alpha: {self.alpha:.3f}\n"
         summary += f"dust mass fraction: {self.dust_mass_fraction}\n"

--- a/src/synthesizer/abundances/abundance_scalings.py
+++ b/src/synthesizer/abundances/abundance_scalings.py
@@ -30,15 +30,15 @@ class Dopita2006:
         self.available_elements = ["N", "C"]
 
         # the reference metallicity for the model
-        self.reference_metallicity = 0.016
+        self.reference_metallicities = 0.016
 
-    def nitrogen(self, metallicity):
+    def nitrogen(self, metallicities):
         """
         Scaling function for Nitrogen.
 
         Args:
-            metallicity (float)
-                The metallicity (mass fraction in metals)
+            metallicities (float)
+                The metallicities (mass fraction in metals)
 
         Returns:
             abundance (float)
@@ -46,22 +46,23 @@ class Dopita2006:
 
         """
 
-        # the metallicity scaled to the Dopita (2006) value
-        scaled_metallicity = metallicity / self.reference_metallicity
+        # the metallicities scaled to the Dopita (2006) value
+        scaled_metallicities = metallicities / self.reference_metallicities
 
         abundance = np.log10(
-            1.1e-5 * scaled_metallicity + 4.9e-5 * (scaled_metallicity) ** 2
+            1.1e-5 * scaled_metallicities
+            + 4.9e-5 * (scaled_metallicities) ** 2
         )
 
         return abundance
 
-    def carbon(self, metallicity):
+    def carbon(self, metallicities):
         """
         Scaling functions for Carbon.
 
         Args:
-            metallicity (float)
-                The metallicity (mass fraction in metals)
+            metallicities (float)
+                The metallicities (mass fraction in metals)
 
         Returns:
             abundance (float)
@@ -69,11 +70,11 @@ class Dopita2006:
 
         """
 
-        # the metallicity scaled to the Dopita (2006) value
-        scaled_metallicity = metallicity / self.reference_metallicity
+        # the metallicities scaled to the Dopita (2006) value
+        scaled_metallicities = metallicities / self.reference_metallicities
 
         abundance = np.log10(
-            6e-5 * scaled_metallicity + 2e-4 * (scaled_metallicity) ** 2
+            6e-5 * scaled_metallicities + 2e-4 * (scaled_metallicities) ** 2
         )
 
         return abundance
@@ -102,7 +103,7 @@ class GalacticConcordance:
         self.bibcode = "2017MNRAS.466.4403N"
 
         # the reference metallicity (mass fraction in metals), i.e. Z
-        self.reference_metallicity = 0.015
+        self.reference_metallicities = 0.015
 
         # logarthmic abundances, i.e. log10(N_element/N_H)
         self.reference_abundance = {
@@ -207,7 +208,7 @@ class GalacticConcordance:
             scaling_parameter,
             lower_break=-0.25,
             upper_break=0.5,
-            reference_metallicity=0.015,
+            reference_metallicities=0.015,
             reference_abundances={},
         ):
             """
@@ -225,7 +226,7 @@ class GalacticConcordance:
                 upper_break (float)
                     The upper-break (O/H) above which the abundance simply
                     scales with metallicity. By default 0.5.
-                reference_metallicity (float)
+                reference_metallicities (float)
                     The reference metallicity.
                 reference_abundances (dict, float)
                     Dictionary of reference abundances.
@@ -240,24 +241,24 @@ class GalacticConcordance:
             self.scaling_parameter = scaling_parameter
 
             # should try and inherit these
-            self.reference_metallicity = reference_metallicity
+            self.reference_metallicities = reference_metallicities
             self.reference_abundances = reference_abundances
 
-        def __call__(self, metallicity):
+        def __call__(self, metallicities):
             """
-            Calculate the abundance for a given metallicity.
+            Calculate the abundance for a given metallicities.
 
             Arguments:
-                metallicity (float)
-                    The metallicity.
+                metallicities (float)
+                    The metallicities.
 
             Returns:
                 abundance (float)
                     The abundance of the specific element.
             """
 
-            # calculate log10(oxygen to hydrogen) for a given metallicity
-            log10xi = np.log10(metallicity / self.reference_metallicity)
+            # calculate log10(oxygen to hydrogen) for a given metallicities
+            log10xi = np.log10(metallicities / self.reference_metallicities)
 
             if log10xi < self.lower_break:
                 delta_x = self.scaling_parameter
@@ -274,13 +275,13 @@ class GalacticConcordance:
 
             return abundance
 
-    def oxygen_to_hydrogen(self, metallicity):
+    def oxygen_to_hydrogen(self, metallicities):
         """
         Calculate the oxygen to hydrogen ratio (O/H) for the provided
         metallicity.
 
         Arguments:
-            metallicity (float)
+            metallicities (float)
                 The metallicity.
 
         Returns:
@@ -290,7 +291,7 @@ class GalacticConcordance:
 
         # calculate oxygen to hydroge for a given metallicity
         return self.reference_oxygen_abundance + np.log10(
-            metallicity / self.reference_metallicity
+            metallicities / self.reference_metallicities
         )
 
     def nitrogen_to_oxygen(self, oxygen_to_hydrogen):
@@ -313,13 +314,13 @@ class GalacticConcordance:
 
         return nitrogen_to_oxygen
 
-    def nitrogen(self, metallicity):
+    def nitrogen(self, metallicities):
         """
-        Calculate the Nitrogen abundance (N/H) for a given metallicity.
+        Calculate the Nitrogen abundance (N/H) for a given metallicities.
 
         Args:
-            metallicity (float)
-                The metallicity.
+            metallicities (float)
+                The metallicities.
 
         Returns:
             abundance (float)
@@ -328,7 +329,7 @@ class GalacticConcordance:
         """
 
         # calculate oxygen to hydrogen for a given metallicity
-        oxygen_to_hydrogen = self.oxygen_to_hydrogen(metallicity)
+        oxygen_to_hydrogen = self.oxygen_to_hydrogen(metallicities)
 
         abundance = (
             self.nitrogen_to_oxygen(oxygen_to_hydrogen) + oxygen_to_hydrogen
@@ -356,13 +357,13 @@ class GalacticConcordance:
 
         return carbon_to_oxygen
 
-    def carbon(self, metallicity):
+    def carbon(self, metallicities):
         """
         Calculate the Carbon abundance (C/H) for a given metallicity.
 
         Args:
-            metallicity (float)
-                The metallicity.
+            metallicities (float)
+                The metallicities.
 
         Returns:
             abundance (float)
@@ -371,7 +372,7 @@ class GalacticConcordance:
         """
 
         # calculate oxygen to hydrogen for a given metallicity
-        oxygen_to_hydrogen = self.oxygen_to_hydrogen(metallicity)
+        oxygen_to_hydrogen = self.oxygen_to_hydrogen(metallicities)
 
         abundance = (
             self.carbon_to_oxygen(oxygen_to_hydrogen) + oxygen_to_hydrogen

--- a/src/synthesizer/abundances/reference_abundance_patterns.py
+++ b/src/synthesizer/abundances/reference_abundance_patterns.py
@@ -25,7 +25,7 @@ class Asplund2009:
         self.bibcode = "2009ARA&A..47..481A"
 
         # total metallicity
-        self.metallicity = 0.0134
+        self.metallicities = 0.0134
 
         # logarthmic abundances, i.e. log10(N_element/N_H)
         self.abundance = {
@@ -77,8 +77,8 @@ class GalacticConcordance:
         self.arxiv = None
         self.bibcode = "2017MNRAS.466.4403N"
 
-        # total metallicity
-        self.metallicity = 0.015
+        # total metallicities
+        self.metallicities = 0.015
 
         # logarthmic abundances, i.e. log10(N_element/N_H)
         self.abundance = {
@@ -129,8 +129,8 @@ class Gutkin2016:
         self.arxiv = "arXiv:1607.06086"
         self.bibcode = "2016MNRAS.462.1757G"
 
-        # total metallicity
-        self.metallicity = 0.01524
+        # total metallicities
+        self.metallicities = 0.01524
 
         # logarthmic abundances, i.e. log10(N_element/N_H)
         self.abundance = {


### PR DESCRIPTION
Here I have updated Abundances by replacing `metallicity` with `metallicities`. This allows `create_cloudy_input_grid` in `synthesizer-grids` to work.

## Issue Type
- Bug
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
