### PR TITLE
BUGFIX: Fixed mask behind the scenes mask generation for parametric BlackHole line generation

### DIFF
--- a/src/synthesizer/parametric/blackholes.py
+++ b/src/synthesizer/parametric/blackholes.py
@@ -372,9 +372,10 @@ class BlackHole(BlackholesComponent):
                 " a line region (nlr or blr)."
             )
 
-        # Handle the case where mask is None
+        # Handle the case where mask is None, we need to make a mask of size
+        # 1 since a parametric blackhole is always singular
         if mask is None:
-            mask = np.ones(self.nbh, dtype=bool)
+            mask = np.ones(1, dtype=bool)
 
         # Set up the inputs to the C function.
         grid_props = [


### PR DESCRIPTION
If a mask is None when passed to `_prepare_line_args` on a `BlackHole` the code would look for the `self.nbh` attribute on the `BlackHole` which doesn't exist because parametric black holes are always singular. This is now fixed.

Closes #735 

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
