### PR TITLE
Add bolometric luminosity as property

### DIFF
--- a/docs/source/sed/sed_example.ipynb
+++ b/docs/source/sed/sed_example.ipynb
@@ -197,7 +197,7 @@
     "\n",
     "There are a number of helper methods on ``Sed`` for calculating common derived properties. We provide some examples below.\n",
     "\n",
-    "We can calculate the integrated bolometric luminosity of the Sed using the `bolometic_luminosity` property methof:"
+    "We can calculate the integrated bolometric luminosity of the Sed using the `bolometric_luminosity` property method:"
    ]
   },
   {

--- a/docs/source/sed/sed_example.ipynb
+++ b/docs/source/sed/sed_example.ipynb
@@ -197,7 +197,7 @@
     "\n",
     "There are a number of helper methods on ``Sed`` for calculating common derived properties. We provide some examples below.\n",
     "\n",
-    "We can calculate the integrated bolometric luminosity of the Sed:"
+    "We can calculate the integrated bolometric luminosity of the Sed using the `bolometic_luminosity` property methof:"
    ]
   },
   {
@@ -207,7 +207,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sed.measure_bolometric_luminosity()"
+    "sed.bolometric_luminosity"
    ]
   },
   {
@@ -216,7 +216,7 @@
    "id": "1ad27966",
    "metadata": {},
    "source": [
-    "By default any spectra integration will use a trapezoid method. It's also possible to use the simpson rule."
+    "By default any spectra integration will use a trapezoid method. It's also possible to use the simpson rule using the `measure_bolometric_luminosity` method."
    ]
   },
   {

--- a/src/synthesizer/emission_models/agn/unified_agn.py
+++ b/src/synthesizer/emission_models/agn/unified_agn.py
@@ -39,7 +39,7 @@ def scale_by_incident_isotropic(emission, emitters, model):
     # Handle lines and spectra differently
     if isinstance(emission[list(emission.keys())[0]], Sed):
         # Get the isotropic bolometric luminosity
-        emission["disc_incident_isotropic"].measure_bolometric_luminosity()
+        emission["disc_incident_isotropic"].bolometric_luminosity
         isotropic_bolo_lum = emission[
             "disc_incident_isotropic"
         ]._bolometric_luminosity

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -2347,17 +2347,13 @@ class EmissionModel(Extraction, Generation, DustAttenuation, Combination):
                     # Compute the scaling
                     if this_model.per_particle:
                         scaling = (
-                            particle_spectra[
-                                scaler
-                            ].measure_bolometric_luminosity()
-                            / particle_spectra[
-                                label
-                            ].measure_bolometric_luminosity()
+                            particle_spectra[scaler].bolometric_luminosity
+                            / particle_spectra[label].bolometric_luminosity
                         ).value
                     else:
                         scaling = (
-                            spectra[scaler].measure_bolometric_luminosity()
-                            / spectra[label].measure_bolometric_luminosity()
+                            spectra[scaler].bolometric_luminosity
+                            / spectra[label].bolometric_luminosity
                         ).value
 
                     # Scale the spectra (handling 1D and 2D cases)

--- a/src/synthesizer/emission_models/dust/emission.py
+++ b/src/synthesizer/emission_models/dust/emission.py
@@ -121,10 +121,6 @@ class EmissionBase:
         # the dust spectra to the bolometric luminosity of the input spectra
         # and then add the input spectra to the dust spectra
         elif intrinsic_sed is not None and attenuated_sed is not None:
-            # Measure bolometric luminosities
-            intrinsic_sed.measure_bolometric_luminosity()
-            attenuated_sed.measure_bolometric_luminosity()
-
             # Calculate the bolometric dust luminosity as the difference
             # between the intrinsic and attenuated
             bolometric_luminosity = (
@@ -135,7 +131,6 @@ class EmissionBase:
         # If we only have the intrinsic SED, we can just scale the emission
         elif intrinsic_sed is not None:
             # Measure bolometric luminosity
-            intrinsic_sed.measure_bolometric_luminosity()
             bolometric_luminosity = intrinsic_sed.bolometric_luminosity
 
         else:
@@ -187,9 +182,7 @@ class EmissionBase:
         sed = Sed(lam=lam, lnu=self._lnu(nu))
 
         # Normalise the spectrum
-        sed._lnu /= np.expand_dims(
-            sed.measure_bolometric_luminosity().value, axis=-1
-        )
+        sed._lnu /= np.expand_dims(sed._bolometric_luminosity, axis=-1)
 
         # Apply heating due to CMB, if applicable
         sed._lnu *= self.cmb_factor
@@ -762,8 +755,8 @@ class IR_templates:
                 # Calculate the bolometric dust luminosity as the difference
                 # between the intrinsic and attenuated
                 ldust = (
-                    intrinsic_sed.measure_bolometric_luminosity()
-                    - attenuated_sed.measure_bolometric_luminosity()
+                    intrinsic_sed.bolometric_luminosity
+                    - attenuated_sed.bolometric_luminosity
                 )
                 self.ldust = ldust.to("Lsun")
             self.dl07()

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1167,8 +1167,8 @@ class Template:
         self.lam = sed.lam
 
         # Normalise, just in case
-        self.normalisation = sed.measure_bolometric_luminosity()
-        self.lnu /= self.normalisation.value
+        self.normalisation = sed._bolometric_luminosity
+        self.lnu /= self.normalisation
 
         # Set the escape fraction
         self.fesc = fesc

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -453,6 +453,15 @@ class Sed:
         # return the bolometric luminosity with units
         return integral * self.lnu.units * self.nu.units
 
+    @property
+    def _bolometric_luminosity(self):
+        # Return bolometric luminosity in the base synthesizer units as a
+        # float.
+
+        return self.bolometric_luminosity.to(
+            self.lnu.units * self.nu.units
+        ).value
+
     def get_lnu_at_nu(self, nu, kind=False):
         """
         Return lnu with units at a provided frequency using 1d interpolation.

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -34,7 +34,7 @@ from synthesizer.utils import (
     wavelength_to_rgba,
 )
 from synthesizer.utils.integrate import integrate_last_axis
-from synthesizer.warnings import warn
+from synthesizer.warnings import deprecated, warn
 
 
 class Sed:
@@ -489,6 +489,11 @@ class Sed:
         """
         return interp1d(self._lam, self._lnu, kind=kind)(lam) * self.lnu.units
 
+    @deprecated(
+        message=(
+            "Deprecated in favour of bolometric_luminosity" " propery method"
+        )
+    )
     def measure_bolometric_luminosity(
         self, integration_method="trapz", nthreads=1
     ):
@@ -515,6 +520,7 @@ class Sed:
                 If `integration_method` is an incompatible option an error
                 is raised.
         """
+
         start = tic()
 
         # Calculate the bolometric luminosity

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -502,7 +502,7 @@ class Sed:
 
     @deprecated(
         message=(
-            "Deprecated in favour of bolometric_luminosity" " propery method"
+            "Deprecated in favour of bolometric_luminosity propery method"
         )
     )
     def measure_bolometric_luminosity(

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -437,9 +437,18 @@ class Sed:
 
     @property
     def bolometric_luminosity(self):
+        """
+        Return the bolometric luminosity of the SED with units.
+
+        This will integrate the SED using the trapezium method over the
+        final axis (which is always the wavelength axis) for an arbitrary
+        number of dimensions.
+
+        Returns:
+            bolometric_luminosity (unyt_array)
+                The bolometric luminosity.
+        """
         # Calculate the bolometric luminosity using the trapezium rule.
-        # NOTE: to use an alternative integration method
-        # measure_bolometric_luminosity method can be used instead.
         # NOTE: the integration is done "backwards" when integrating over
         # frequency. It's faster to just multiply by -1 than to reverse the
         # array.
@@ -450,17 +459,23 @@ class Sed:
             method="trapz",
         )
 
-        # return the bolometric luminosity with units
+        # Return the bolometric luminosity with units
         return integral * self.lnu.units * self.nu.units
 
     @property
     def _bolometric_luminosity(self):
-        # Return bolometric luminosity in the base synthesizer units as a
-        # float.
+        """
+        Return the bolometric luminosity of the SED without units.
 
-        return self.bolometric_luminosity.to(
-            self.lnu.units * self.nu.units
-        ).value
+        This will integrate the SED using the trapezium method over the
+        final axis (which is always the wavelength axis) for an arbitrary
+        number of dimensions.
+
+        Returns:
+            bolometric_luminosity (float)
+                The bolometric luminosity.
+        """
+        return self.bolometric_luminosity.value
 
     def get_lnu_at_nu(self, nu, kind=False):
         """

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -115,9 +115,6 @@ class Sed:
         else:
             self.lnu = lnu
 
-        # Prepare for bolometric luminosity calculation
-        self.bolometric_luminosity = None
-
         # Redshift of the SED
         self.redshift = 0
 
@@ -438,6 +435,22 @@ class Sed:
                 The shape of self.lnu
         """
         return self.lnu.shape
+
+    @property
+    def bolometric_luminosity(self, integration_method="trapz", nthreads=1):
+        # Calculate the bolometric luminosity
+        # NOTE: the integration is done "backwards" when integrating over
+        # frequency. It's faster to just multiply by -1 than to reverse the
+        # array.
+        integral = -integrate_last_axis(
+            self._nu,
+            self._lnu,
+            nthreads=nthreads,
+            method=integration_method,
+        )
+
+        # return the bolometric luminosity with units
+        return integral * self.lnu.units * self.nu.units
 
     def get_lnu_at_nu(self, nu, kind=False):
         """

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -75,7 +75,6 @@ class Sed:
     fnu = Quantity()
     obsnu = Quantity()
     obslam = Quantity()
-    bolometric_luminosity = Quantity()
 
     def __init__(self, lam, lnu=None, description=None):
         """

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -436,16 +436,18 @@ class Sed:
         return self.lnu.shape
 
     @property
-    def bolometric_luminosity(self, integration_method="trapz", nthreads=1):
-        # Calculate the bolometric luminosity
+    def bolometric_luminosity(self):
+        # Calculate the bolometric luminosity using the trapezium rule.
+        # NOTE: to use an alternative integration method
+        # measure_bolometric_luminosity method can be used instead.
         # NOTE: the integration is done "backwards" when integrating over
         # frequency. It's faster to just multiply by -1 than to reverse the
         # array.
         integral = -integrate_last_axis(
             self._nu,
             self._lnu,
-            nthreads=nthreads,
-            method=integration_method,
+            nthreads=1,
+            method="trapz",
         )
 
         # return the bolometric luminosity with units

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -517,10 +517,6 @@ class Sed:
         """
         start = tic()
 
-        # Don't duplicate the calculation if we already have it
-        if self.bolometric_luminosity is not None:
-            return self.bolometric_luminosity
-
         # Calculate the bolometric luminosity
         # NOTE: the integration is done "backwards" when integrating over
         # frequency. It's faster to just multiply by -1 than to reverse the
@@ -533,10 +529,7 @@ class Sed:
         )
         toc("Calculating bolometric luminosity", start)
 
-        # Assign the integral to the bolometric luminosity
-        self.bolometric_luminosity = integral * self.lnu.units * self.nu.units
-
-        return self.bolometric_luminosity
+        return integral * self.lnu.units * self.nu.units
 
     def measure_window_luminosity(
         self, window, integration_method="trapz", nthreads=1


### PR DESCRIPTION
Adds `bolometric_luminosity` as a property method deprecating `measure_bolometric_luminosity`. This is less efficient since the quantity will always be calculated but, as we've seen, this is safer. 

I'm somewhat ambivalent about whether `measure_bolometric_luminosity` should be deprecated since it allows the bolometric luminosity to be calculated using different methods. However, we're probably never going to use anything other than trapezoid?!

TODO: find all other instances of `measure_bolometric_luminosity` and replace.


## Issue Type
- [x] Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
