### PR TITLE
added nbh property to parametric blackholes

### DIFF
--- a/src/synthesizer/parametric/blackholes.py
+++ b/src/synthesizer/parametric/blackholes.py
@@ -130,6 +130,9 @@ class BlackHole(BlackholesComponent):
             **kwargs,
         )
 
+        # by definition a parametric blackhole is only one blackhole
+        self.nbh = 1
+
         # Ensure the offset has units
         if not has_units(offset):
             raise exceptions.MissingUnits(


### PR DESCRIPTION
Adds `nbh` attribute to parametric blackholes to stop breaks elsewhere.


## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
