### PR TITLE
Fixing the scaling in Unified AGN

### DIFF
--- a/src/synthesizer/emission_models/agn/unified_agn.py
+++ b/src/synthesizer/emission_models/agn/unified_agn.py
@@ -36,14 +36,9 @@ def scale_by_incident_isotropic(emission, emitters, model):
         emitters (dict): The emitters used to generate the emission.
         model (UnifiedAGN): The Unified AGN model.
     """
+
     # Handle lines and spectra differently
     if isinstance(emission[list(emission.keys())[0]], Sed):
-        # Get the isotropic bolometric luminosity
-        emission["disc_incident_isotropic"].bolometric_luminosity
-        isotropic_bolo_lum = emission[
-            "disc_incident_isotropic"
-        ]._bolometric_luminosity
-
         # Scale the spectra
         for key, spectra in emission.items():
             # Get the model
@@ -57,7 +52,7 @@ def scale_by_incident_isotropic(emission, emitters, model):
             emitter = emitters[this_model.emitter]
 
             # Get the scaling
-            scaling = emitter._bolometric_luminosity / isotropic_bolo_lum
+            scaling = emitter._bolometric_luminosity
 
             # Scale the spectra
             if spectra.ndim == 1 and scaling.ndim == 0:
@@ -73,6 +68,16 @@ def scale_by_incident_isotropic(emission, emitters, model):
                 spectra._lnu = spectra._lnu * np.expand_dims(scaling, axis=-1)
 
     else:
+        disc_bolometric_luminosity = (
+            emitters["blackhole"]
+            .spectra["disc_incident_isotropic"]
+            ._bolometric_luminosity
+        )
+        blackhole_bolometric_luminosity = emitters[
+            "blackhole"
+        ]._bolometric_luminosity
+        scaling = blackhole_bolometric_luminosity / disc_bolometric_luminosity
+
         # Loop over the different emissions
         for key, line_collection in emission.items():
             # Get the model
@@ -85,16 +90,11 @@ def scale_by_incident_isotropic(emission, emitters, model):
             # Get the emitter
             emitter = emitters[this_model.emitter]
 
-            print(line_collection)
+            # Get the scaling
+            scaling = emitter._bolometric_luminosity
 
             # Loop over the lines
             for line in line_collection:
-                # Get the continuum of the isotropic disc emission
-                isotropic_continuum = line._continuum
-
-                # Get the scaling
-                scaling = emitter._bolometric_luminosity / isotropic_continuum
-
                 # Scale the line
                 line._luminosity *= scaling
                 line._continuum *= scaling


### PR DESCRIPTION
This PR fixes an issue that only became apparent when testing the line emission functionality of the Unified AGN. This emerged because the scaling applied in the emission model was wrong. 

The best way of fixing this was deemed to be normalising the spectra, and line emission quantities, in the grid file by the isotropic bolometric luminosity. With this in place the scaling to be applied to the spectra is simply the bolometric luminosity of each BH. 

- This testing also suggests an independent bug (or physics) in the BLR modelling, likely at the cloudy modelling stage. I'm working to identify this but it is independent of this PR.
- This will require an update of the AGN test grid. However, that can probably wait until the BLR bug is caught since no one should be using the AGN modelling yet and any other PRs using the AGN modelling should still pass (though be very wrong).

## Issue Type
- [x] Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
