### PR TITLE
Remove the check for the grid to be associated with a line emitting region to allow the use of generic grids

### DIFF
--- a/src/synthesizer/parametric/blackholes.py
+++ b/src/synthesizer/parametric/blackholes.py
@@ -233,16 +233,15 @@ class BlackHole(BlackholesComponent):
             tuple
                 A tuple of all the arguments required by the C extension.
         """
+
         # Which line region is this for?
         if "nlr" in grid.grid_name:
             line_region = "nlr"
         elif "blr" in grid.grid_name:
             line_region = "blr"
         else:
-            raise exceptions.InconsistentArguments(
-                "Grid used for blackholes does not appear to be for"
-                " a line region (nlr or blr)."
-            )
+            # this is a generic disc grid so no line_region
+            line_region = None
 
         # Set up the inputs to the C function.
         grid_props = [

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -320,16 +320,15 @@ class BlackHoles(Particles, BlackholesComponent):
             tuple
                 A tuple of all the arguments required by the C extension.
         """
+
         # Which line region is this for?
         if "nlr" in grid.grid_name:
             line_region = "nlr"
         elif "blr" in grid.grid_name:
             line_region = "blr"
         else:
-            raise exceptions.InconsistentArguments(
-                "Grid used for blackholes does not appear to be for"
-                " a line region (nlr or blr)."
-            )
+            # this is a generic disc grid so no line_region
+            line_region = None
 
         # Handle the case where mask is None
         if mask is None:


### PR DESCRIPTION
Remove the check for the grid to be associated with a line emitting region to allow the use of generic grids. This can be updated later with a check on the specific component type that the grid is made for. 

Closes #759 

## Issue Type
- [x] Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
