### PR TITLE
Fix for periodic boundary

### DIFF
--- a/src/synthesizer/load_data/load_eagle.py
+++ b/src/synthesizer/load_data/load_eagle.py
@@ -1002,4 +1002,6 @@ def assign_galaxy_prop(
         **g_kwargs,
     )
 
+    galaxy.gas.dust_to_metal_ratio = galaxy.dust_to_metal_vijayan19()
+
     return galaxy


### PR DESCRIPTION
## Issue Type
- Bug

The previous version when loading the particle data did not correct for the periodic boundary. So in a few galaxies not all particles were being counted.

Also calculates the dust-to-metal ratio in the load and adds it to the galaxy.

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines