### PR TITLE
Allow the loading of a Flares master file without abundances

### DIFF
--- a/src/synthesizer/load_data/load_flares.py
+++ b/src/synthesizer/load_data/load_flares.py
@@ -23,11 +23,6 @@ def load_FLARES(master_file, region, tag, read_abundances=False):
         galaxies (object):
             `ParticleGalaxy` object containing stars
     """
-    
-    if read_abundances:
-        print("Reading abundances...")
-    else:
-        print("Not reading abundances.")
 
     zed = float(tag[5:].replace("p", "."))
     scale_factor = 1.0 / (1.0 + zed)
@@ -71,17 +66,30 @@ def load_FLARES(master_file, region, tag, read_abundances=False):
     for i, (b, e) in enumerate(zip(begin, end)):
         # Create the individual galaxy objects
         galaxies[i] = Galaxy(redshift=zed)
+        
+        if read_abundances == True:
 
-        galaxies[i].load_stars(
-            imasses[b:e] * Msun,
-            ages[b:e] * yr,
-            metallicities[b:e],
-            s_oxygen=s_oxygen[b:e],
-            s_hydrogen=s_hydrogen[b:e],
-            coordinates=coods[b:e, :] * Mpc,
-            current_masses=masses[b:e] * Msun,
-            smoothing_lengths=s_hsml[b:e] * Mpc,
-        )
+            galaxies[i].load_stars(
+                imasses[b:e] * Msun,
+                ages[b:e] * yr,
+                metallicities[b:e],
+                s_oxygen=s_oxygen[b:e],
+                s_hydrogen=s_hydrogen[b:e],
+                coordinates=coods[b:e, :] * Mpc,
+                current_masses=masses[b:e] * Msun,
+                smoothing_lengths=s_hsml[b:e] * Mpc,
+            )
+        
+        if read_abundances == False:
+            
+            galaxies[i].load_stars(
+                imasses[b:e] * Msun,
+                ages[b:e] * yr,
+                metallicities[b:e],
+                coordinates=coods[b:e, :] * Mpc,
+                current_masses=masses[b:e] * Msun,
+                smoothing_lengths=s_hsml[b:e] * Mpc,
+            )
 
     # Get the gas particle begin / end indices
     begin, end = get_len(glens)

--- a/src/synthesizer/load_data/load_flares.py
+++ b/src/synthesizer/load_data/load_flares.py
@@ -78,8 +78,7 @@ def load_FLARES(master_file, region, tag, read_abundances=False):
                 current_masses=masses[b:e] * Msun,
                 smoothing_lengths=s_hsml[b:e] * Mpc,
             )
-
-        if not read_abundances:
+        else:
             galaxies[i].load_stars(
                 imasses[b:e] * Msun,
                 ages[b:e] * yr,

--- a/src/synthesizer/load_data/load_flares.py
+++ b/src/synthesizer/load_data/load_flares.py
@@ -40,8 +40,8 @@ def load_FLARES(master_file, region, tag, read_abundances=False):
         s_hsml = hf[f"{region}/{tag}/Particle/S_sml"][:]  # Mpc (physical)
 
         metallicities = hf[f"{region}/{tag}/Particle/S_Z_smooth"][:]
-        
-        if read_abundances == True:
+
+        if read_abundances:
             s_oxygen = hf[f"{region}/{tag}/Particle/S_Abundance_Oxygen"][:]
             s_hydrogen = hf[f"{region}/{tag}/Particle/S_Abundance_Hydrogen"][:]
 
@@ -66,9 +66,8 @@ def load_FLARES(master_file, region, tag, read_abundances=False):
     for i, (b, e) in enumerate(zip(begin, end)):
         # Create the individual galaxy objects
         galaxies[i] = Galaxy(redshift=zed)
-        
-        if read_abundances == True:
 
+        if read_abundances:
             galaxies[i].load_stars(
                 imasses[b:e] * Msun,
                 ages[b:e] * yr,
@@ -79,9 +78,8 @@ def load_FLARES(master_file, region, tag, read_abundances=False):
                 current_masses=masses[b:e] * Msun,
                 smoothing_lengths=s_hsml[b:e] * Mpc,
             )
-        
-        if read_abundances == False:
-            
+
+        if not read_abundances:
             galaxies[i].load_stars(
                 imasses[b:e] * Msun,
                 ages[b:e] * yr,

--- a/src/synthesizer/load_data/load_flares.py
+++ b/src/synthesizer/load_data/load_flares.py
@@ -7,7 +7,7 @@ from synthesizer.load_data.utils import get_len
 from ..particle.galaxy import Galaxy
 
 
-def load_FLARES(master_file, region, tag):
+def load_FLARES(master_file, region, tag, read_abundances=False):
     """
     Load FLARES galaxies from a FLARES master file
 
@@ -23,6 +23,11 @@ def load_FLARES(master_file, region, tag):
         galaxies (object):
             `ParticleGalaxy` object containing stars
     """
+    
+    if read_abundances:
+        print("Reading abundances...")
+    else:
+        print("Not reading abundances.")
 
     zed = float(tag[5:].replace("p", "."))
     scale_factor = 1.0 / (1.0 + zed)
@@ -40,8 +45,10 @@ def load_FLARES(master_file, region, tag):
         s_hsml = hf[f"{region}/{tag}/Particle/S_sml"][:]  # Mpc (physical)
 
         metallicities = hf[f"{region}/{tag}/Particle/S_Z_smooth"][:]
-        s_oxygen = hf[f"{region}/{tag}/Particle/S_Abundance_Oxygen"][:]
-        s_hydrogen = hf[f"{region}/{tag}/Particle/S_Abundance_Hydrogen"][:]
+        
+        if read_abundances == True:
+            s_oxygen = hf[f"{region}/{tag}/Particle/S_Abundance_Oxygen"][:]
+            s_hydrogen = hf[f"{region}/{tag}/Particle/S_Abundance_Hydrogen"][:]
 
         g_sfr = hf[f"{region}/{tag}/Particle/G_SFR"][:]  # Msol / yr
         g_masses = hf[f"{region}/{tag}/Particle/G_Mass"][:]  # 1e10 Msol


### PR DESCRIPTION
Here I have added `read_abundances=False` as an argument for `load_flares()` since the Master file I had access to did not have the properties `Particle/S_Abundance_Oxygen` and `Particle/S_Abundance_Hydrogen`. 

## Issue Type
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
