### PR TITLE
using correct redshift from eagle header, plus bug in particle dust calculation

### DIFF
--- a/src/synthesizer/particle/galaxy.py
+++ b/src/synthesizer/particle/galaxy.py
@@ -816,7 +816,11 @@ class Galaxy(BaseGalaxy):
         # intialisation). If the user handed dust masses and then called this
         # function, they will be overwritten and it will be confusing but
         # that's so unlikely and they'll work out when they see this comment.
-        self.gas.dust_masses = self.gas.masses * self.gas.dust_to_metal_ratio
+        self.gas.dust_masses = (
+            self.gas.masses
+            * self.gas.metallicities
+            * self.gas.dust_to_metal_ratio
+        )
 
         return dtm
 


### PR DESCRIPTION
## Issue Type
- Bug

The eagle load_data will now use the redshift from the header rather than from the tag.

There was a bug in particle/galaxy.py in calculating the dust masses from the dust-to-metal ratio. There was a missing metallicity factor. 

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
