### PR TITLE
Add index for CAMELS Swift-EAGLE

### DIFF
--- a/src/synthesizer/load_data/load_camels.py
+++ b/src/synthesizer/load_data/load_camels.py
@@ -632,7 +632,7 @@ def load_CAMELS_SwiftEAGLE_subfind(
     # Get subhalos with minimum number of star particles
     mask = np.where(lentype[:, 4] > min_star_part)[0]
 
-    # convert formation times to ages
+    # Convert formation times to ages
     cosmo = FlatLambdaCDM(H0=h * 100, Om0=Om0)
     universe_age = cosmo.age(redshift)
 
@@ -675,7 +675,7 @@ def load_CAMELS_SwiftEAGLE_subfind(
         g_coods,
         g_hsml,
     ):
-        gal = Galaxy()
+        gal = Galaxy(name=idx)
         gal.redshift = redshift
         gal.centre = pos[idx] * kpc
         gal.index = idx


### PR DESCRIPTION
Small change, adds index to galaxy name for CAMELS Swift-EAGLE, which does some pre-filtering by mass for performance reasons, to allow easy look up down stream.

## Issue Type
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
