### PR TITLE
Small fixes to the documentation

### DIFF
--- a/docs/source/getting_started/overview.rst
+++ b/docs/source/getting_started/overview.rst
@@ -61,7 +61,7 @@ The generation of spectra in synthesizer is handled through *Emission Models*.
 An emission model is a set of standardised procedures for generating spectra from a ``Galaxy`` or a component.
 These often take one of four forms: extraction, combinations, generation, and attenuation.
 Further details are provided in the 
-`Emission Models <../emission_models/emission_model.ipynb>`_ section.
+`Emission Models <../emission_models/emission_models.rst>`_ section.
 
 Observables
 ***********

--- a/src/synthesizer/base_galaxy.py
+++ b/src/synthesizer/base_galaxy.py
@@ -1129,12 +1129,6 @@ class BaseGalaxy:
                 The type of image to be made, either "hist" -> a histogram, or
                 "smoothed" -> particles smoothed over a kernel for a particle
                 galaxy. Otherwise, only smoothed is applicable.
-            stellar_photometry (string)
-                The stellar spectra key from which to extract photometry
-                to use for the image.
-            blackhole_photometry (string)
-                The black hole spectra key from which to extract photometry
-                to use for the image.
             kernel (array-like, float)
                 The values from one of the kernels from the kernel_functions
                 module. Only used for smoothed images.


### PR DESCRIPTION
- Removed descriptions for the old arguments `stellar_photometry` and `blackhole_photometry` in `get_images_flux` as this confused me when searching the docs here: https://flaresimulations.github.io/synthesizer/_autosummary/synthesizer.base_galaxy.html#synthesizer.base_galaxy.BaseGalaxy.get_images_flux
- Fixed broken link to the Emission Models section here: https://flaresimulations.github.io/synthesizer/getting_started/overview.html

## Issue Type
- Document

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
