### PR TITLE
Fixing `limit_to` argument in imaging methods

### DIFF
--- a/docs/source/imaging/particle_imaging.ipynb
+++ b/docs/source/imaging/particle_imaging.ipynb
@@ -162,6 +162,7 @@
     "    fov=width,\n",
     "    emission_model=model,\n",
     "    img_type=\"hist\",\n",
+    "    limit_to=\"nebular\",  # we can limit to a single image type\n",
     ")\n",
     "\n",
     "# Get the image\n",

--- a/src/synthesizer/base_galaxy.py
+++ b/src/synthesizer/base_galaxy.py
@@ -1080,6 +1080,10 @@ class BaseGalaxy:
                     f"Unknown emitter in emission model. ({model.emitter})"
                 )
 
+        # If we are limiting to a specific image then return that
+        if limit_to is not None:
+            return images[limit_to]
+
         # Return the image at the root of the emission model
         return images[emission_model.label]
 
@@ -1182,6 +1186,10 @@ class BaseGalaxy:
                 raise KeyError(
                     f"Unknown emitter in emission model. ({model.emitter})"
                 )
+
+        # If we are limiting to a specific image then return that
+        if limit_to is not None:
+            return images[limit_to]
 
         # Return the image at the root of the emission model
         return images[emission_model.label]

--- a/src/synthesizer/components/component.py
+++ b/src/synthesizer/components/component.py
@@ -493,6 +493,10 @@ class Component(ABC):
         # Store the images
         self.images_lnu.update(images)
 
+        # If we are limiting to a specific image then return that
+        if limit_to is not None:
+            return images[limit_to]
+
         # Return the image at the root of the emission model
         return images[emission_model.label]
 
@@ -586,6 +590,10 @@ class Component(ABC):
 
         # Store the images
         self.images_fnu.update(images)
+
+        # If we are limiting to a specific image then return that
+        if limit_to is not None:
+            return images[limit_to]
 
         # Return the image at the root of the emission model
         return images[emission_model.label]


### PR DESCRIPTION
Imaging methods were set up to return the root model image. If `limit_to` were passed then only that image would be generated and any error would be caused when indexing for the root when `limit_to` and the root model differ. This is now fixed.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
