### PR TITLE
Automatically calculate the extent when plotting a map

### DIFF
--- a/src/synthesizer/imaging/image.py
+++ b/src/synthesizer/imaging/image.py
@@ -645,7 +645,6 @@ class Image:
     def plot_map(
         self,
         show=False,
-        extent=None,
         cmap="Greys_r",
         cbar_label=None,
         norm=None,
@@ -661,8 +660,6 @@ class Image:
         Args:
             show (bool)
                 Whether to show the plot or not (Default False).
-            extent (array_like)
-                The extent of the x and y axes.
             cmap (str)
                 The name of the matplotlib colormap for image plotting. Can be
                 any valid string that can be passed to the cmap argument of
@@ -697,6 +694,14 @@ class Image:
         # Create the axis
         if ax is None:
             ax = fig.add_subplot(111)
+
+        # Get the extent of the image
+        extent = [
+            -self._fov[0] / 2,
+            self._fov[0] / 2,
+            -self._fov[1] / 2,
+            self._fov[1] / 2,
+        ]
 
         # Plot the image and remove the surrounding axis
         im = ax.imshow(

--- a/src/synthesizer/imaging/image.py
+++ b/src/synthesizer/imaging/image.py
@@ -645,6 +645,7 @@ class Image:
     def plot_map(
         self,
         show=False,
+        extent=None,
         cmap="Greys_r",
         cbar_label=None,
         norm=None,
@@ -660,6 +661,8 @@ class Image:
         Args:
             show (bool)
                 Whether to show the plot or not (Default False).
+            extent (array_like)
+                The extent of the x and y axes.
             cmap (str)
                 The name of the matplotlib colormap for image plotting. Can be
                 any valid string that can be passed to the cmap argument of
@@ -695,13 +698,14 @@ class Image:
         if ax is None:
             ax = fig.add_subplot(111)
 
-        # Get the extent of the image
-        extent = [
-            -self._fov[0] / 2,
-            self._fov[0] / 2,
-            -self._fov[1] / 2,
-            self._fov[1] / 2,
-        ]
+        # If no extent has been passed, calculate it
+        if extent is None:
+            extent = [
+                -self._fov[0] / 2,
+                self._fov[0] / 2,
+                -self._fov[1] / 2,
+                self._fov[1] / 2,
+            ]
 
         # Plot the image and remove the surrounding axis
         im = ax.imshow(


### PR DESCRIPTION
As stated in #801, you don't need to pass an extent when plotting a map since we already have the means to define the extent. This is now handled but the extent can be overridden if desired.

Closes #801 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
