### PR TITLE
Fully implementing Line fluxes

### DIFF
--- a/docs/source/lines/galaxy_lines.ipynb
+++ b/docs/source/lines/galaxy_lines.ipynb
@@ -71,7 +71,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the case of a particle based galaxy you can either get the integrated line emission or per-particle line emission (by using a per particle model) the  with ``get_lines`` method."
+    "In the case of a particle based galaxy you can either get the integrated line emission or per-particle line emission (by using a per particle model) with ``get_lines`` method."
    ]
   },
   {
@@ -233,6 +233,52 @@
     ")\n",
     "\n",
     "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Observer frame lines\n",
+    "\n",
+    "Just like an `Sed` lines can be shifted into the observer frame by calling the `get_flux` method with a cosmology and redshift. This can either be done on a whole `LineCollection` or an individual `Line`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.cosmology import Planck18 as cosmo\n",
+    "\n",
+    "# Use a LineCollection level method\n",
+    "stars.lines[\"emergent\"].get_flux(cosmo, z=8)\n",
+    "for line in stars.lines[\"emergent\"]:\n",
+    "    print(f\"{line.id}: {line.flux} @ {line.obslam}\")\n",
+    "\n",
+    "# Extract a line an caluclate its flux (not the flux is both stored\n",
+    "# and returned)\n",
+    "print(stars.lines[\"nebular\"][\"H 1 4861.32A\"].get_flux(cosmo, z=5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Additionally, just like an `Sed` object, you can also calculate the rest frame flux at 10 parsecs using the `get_flux0` method (again both on a `Line` and a `LineCollection`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use a LineCollection level method\n",
+    "stars.lines[\"emergent\"].get_flux0()\n",
+    "for line in stars.lines[\"emergent\"]:\n",
+    "    print(f\"{line.id}: {line.flux} @ {line.obslam}\")"
    ]
   }
  ],

--- a/src/synthesizer/line.py
+++ b/src/synthesizer/line.py
@@ -616,7 +616,7 @@ class Line:
     continuum = Quantity()
     luminosity = Quantity()
     flux = Quantity()
-    observed_wavelength = Quantity()
+    obslam = Quantity()
 
     @accepts(
         wavelength=angstrom,
@@ -854,7 +854,7 @@ class Line:
 
         # Set the observed wavelength (in this case this is the rest frame
         # wavelength)
-        self.observed_wavelength = self.wavelength
+        self.obslam = self.wavelength
 
         return self.flux
 
@@ -896,11 +896,11 @@ class Line:
         self.flux = self.luminosity / (4 * np.pi * luminosity_distance**2)
 
         # Set the observed wavelength
-        self.observed_wavelength = self.wavelength * (1 + z)
+        self.obslam = self.wavelength * (1 + z)
 
         # If we are applying an IGM model apply it
         if igm is not None:
-            self.flux *= igm().get_transmission(z, self.observed_wavelength)
+            self.flux *= igm().get_transmission(z, self._obslam)
 
         return self.flux
 

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -887,10 +887,12 @@ class Sed:
 
     def get_fnu0(self):
         """
-        Calculate a dummy observed frame spectral energy distribution.
-        Useful when you want rest-frame quantities.
+        Calculate the rest frame spectral flux density.
 
         Uses a standard distance of 10 pcs.
+
+        This will also populate the observed wavelength and frequency arrays
+        in the which in this case are the same as the emitted arrays.
 
         Returns:
             fnu (ndarray)
@@ -908,6 +910,9 @@ class Sed:
     def get_fnu(self, cosmo, z, igm=None):
         """
         Calculate the observed frame spectral energy distribution.
+
+        This will also populate the observed wavelength and frequency arrays
+        with the observer frame values.
 
         NOTE: if a redshift of 0 is passed the flux return will be calculated
         assuming a distance of 10 pc omitting IGM since at this distance
@@ -947,14 +952,14 @@ class Sed:
         self.fnu = self.lnu * (1.0 + z) / (4 * np.pi * luminosity_distance**2)
 
         # If we are applying an IGM model apply it
-        if igm:
+        if igm is not None:
             self._fnu *= igm().get_transmission(z, self._obslam)
 
         return self.fnu
 
     def get_photo_lnu(self, filters, verbose=True, nthreads=1):
         """
-        Calculate broadband luminosities using a FilterCollection object
+        Calculate broadband luminosities using a FilterCollection object.
 
         Args:
             filters (filters.FilterCollection)
@@ -969,7 +974,6 @@ class Sed:
             photo_lnu (dict)
                 A dictionary of rest frame broadband luminosities.
         """
-
         # Intialise result dictionary
         photo_lnu = {}
 
@@ -987,7 +991,7 @@ class Sed:
 
     def get_photo_fnu(self, filters, verbose=True, nthreads=1):
         """
-        Calculate broadband fluxes using a FilterCollection object
+        Calculate broadband fluxes using a FilterCollection object.
 
         Args:
             filters (object)
@@ -1002,7 +1006,6 @@ class Sed:
             (dict)
                 A dictionary of fluxes in each filter in filters.
         """
-
         # Ensure fluxes actually exist
         if (self.obslam is None) | (self.fnu is None):
             return ValueError(


### PR DESCRIPTION
While `Line` objects could carry fluxes previously this wasn't implemented to the same level it is on `Sed` objects. Now it is:
 
- There is a rest frame flux method which it falls back to when the redshift is 0. 
- The observed wavelength is also calculated and stored. 
- The flux can be calculated both from a `Line` and a `LineCollection`. 
- An IGM attenuation can optionally be applied.

Closes #758 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [ ] I have read the [CONTRIBUTING.md]() -->
- [ ] I have added docstrings to all methods
- [ ] I have added sufficient comments to all lines
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no pep8 errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
