### PR TITLE
Updating grid axes to work for old and new grids

### DIFF
--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -233,47 +233,122 @@ class Grid:
         plural_name = pluralize(name)
         singular_name = depluralize(name)
 
-        # If we have the axis name, return the axis with units
+        # Another old convention was allowing for logged axes to be stored in
+        # the grid file (this is no longer allowed)
+        log_name = f"log10{name}"
+        log_plural_name = f"log10{plural_name}"
+        log_singular_name = f"log10{singular_name}"
+        print(name, plural_name, singular_name)
+
+        # If we have the axis name, return the axis with units (handling all
+        # the silly pluralisation and logging conventions)
         if name in self.axes:
             return unyt_array(self._axes_values[name], self._axes_units[name])
-
-        # If we have the plural axis name, return the axis with units
         elif plural_name in self.axes:
             return unyt_array(
                 self._axes_values[plural_name], self._axes_units[plural_name]
             )
-
-        # If we have the singular axis name, return the axis with units
         elif singular_name in self.axes:
+            warn(
+                "The use of singular axis names is deprecated. Update "
+                "your grid file."
+            )
             return unyt_array(
                 self._axes_values[singular_name],
                 self._axes_units[singular_name],
             )
+        elif log_name in self.axes:
+            warn(
+                "The use of logged axis names is deprecated. Update "
+                "your grid file."
+            )
+            return unyt_array(
+                10 ** self._axes_values[log_name], self._axes_units[log_name]
+            )
+        elif log_plural_name in self.axes:
+            warn(
+                "The use of logged axis names is deprecated. Update "
+                "your grid file."
+            )
+            return unyt_array(
+                10 ** self._axes_values[log_plural_name],
+                self._axes_units[log_plural_name],
+            )
+        elif log_singular_name in self.axes:
+            warn(
+                "The use of logged axis names is deprecated. Update "
+                "your grid file."
+            )
+            return unyt_array(
+                10 ** self._axes_values[log_singular_name],
+                self._axes_units[log_singular_name],
+            )
 
-        # It might be a Quantity style unitless request?
+        # It might be a Quantity style unitless request? (handling all
+        # the silly pluralisation and logging conventions)
         elif name[1:] in self.axes:
             return self._axes_values[name[1:]]
-
-        # It might be a Quantity style unitless request for a pluralised axis?
         elif plural_name[1:] in self.axes:
             return self._axes_values[plural_name[1:]]
-
-        # It might be a Quantity style unitless request for
-        # a singularised axis?
         elif singular_name[1:] in self.axes:
+            warn(
+                "The use of singular axis names is deprecated. Update "
+                "your grid file."
+            )
             return self._axes_values[singular_name[1:]]
+        elif log_name[1:] in self.axes:
+            warn(
+                "The use of logged axis names is deprecated. Update "
+                "your grid file."
+            )
+            return 10 ** self._axes_values[log_name[1:]]
+        elif log_plural_name[1:] in self.axes:
+            warn(
+                "The use of logged axis names is deprecated. Update "
+                "your grid file."
+            )
+            return 10 ** self._axes_values[log_plural_name[1:]]
+        elif log_singular_name[1:] in self.axes:
+            warn(
+                "The use of logged axis names is deprecated. Update "
+                "your grid file."
+            )
+            return 10 ** self._axes_values[log_singular_name[1:]]
 
-        # Are we doing a log10 request?
+        # Are we doing a log10 request? (handling all the silly pluralisation)
         elif name[:5] == "log10" and name[5:] in self.axes:
             return np.log10(self._axes_values[name[5:]])
-
-        # Are we doing a log10 request for a pluralised axis?
         elif plural_name[:5] == "log10" and plural_name[5:] in self.axes:
             return np.log10(self._axes_values[plural_name[5:]])
-
-        # Are we doing a log10 request for a singularised axis?
         elif singular_name[:5] == "log10" and singular_name[5:] in self.axes:
+            warn(
+                "The use of singular axis names is deprecated. Update "
+                "your grid file."
+            )
             return np.log10(self._axes_values[singular_name[5:]])
+        elif log_name[:5] == "log10" and log_name[5:] in self.axes:
+            warn(
+                "The use of logged axis names is deprecated. Update "
+                "your grid file."
+            )
+            return self._axes_values[log_name[5:]]
+        elif (
+            log_plural_name[:5] == "log10" and log_plural_name[5:] in self.axes
+        ):
+            warn(
+                "The use of logged axis names is deprecated. Update "
+                "your grid file."
+            )
+            return self._axes_values[log_plural_name[5:]]
+        elif (
+            log_singular_name[:5] == "log10"
+            and log_singular_name[5:] in self.axes
+        ):
+            warn(
+                "The use of logged axis names is deprecated. Update "
+                "your grid file."
+            )
+            return self._axes_values[log_singular_name[5:]]
 
         # If we get here, we don't have the attribute
         raise AttributeError(
@@ -288,6 +363,7 @@ class Grid:
 
             # Get list of axes
             self.axes = list(hf.attrs["axes"])
+            print(self.axes)
 
             # Set the values of each axis as an attribute
             # e.g. self.log10age == hdf["axes"]["log10age"]

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -235,10 +235,22 @@ class Grid:
 
         # Another old convention was allowing for logged axes to be stored in
         # the grid file (this is no longer allowed)
-        log_name = f"log10{name}"
-        log_plural_name = f"log10{plural_name}"
-        log_singular_name = f"log10{singular_name}"
-        print(name, plural_name, singular_name)
+        if name[0] != "_":
+            log_name = f"log10{name}"
+            log_plural_name = f"log10{plural_name}"
+            log_singular_name = f"log10{singular_name}"
+        else:
+            log_name = f"_log10{name[1:]}"
+            log_plural_name = f"_log10{plural_name[1:]}"
+            log_singular_name = f"_log10{singular_name[1:]}"
+        print(
+            name,
+            plural_name,
+            singular_name,
+            log_name,
+            log_plural_name,
+            log_singular_name,
+        )
 
         # If we have the axis name, return the axis with units (handling all
         # the silly pluralisation and logging conventions)

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -243,14 +243,6 @@ class Grid:
             log_name = f"_log10{name[1:]}"
             log_plural_name = f"_log10{plural_name[1:]}"
             log_singular_name = f"_log10{singular_name[1:]}"
-        print(
-            name,
-            plural_name,
-            singular_name,
-            log_name,
-            log_plural_name,
-            log_singular_name,
-        )
 
         # If we have the axis name, return the axis with units (handling all
         # the silly pluralisation and logging conventions)
@@ -374,25 +366,31 @@ class Grid:
             self.parameters = {k: v for k, v in hf.attrs.items()}
 
             # Get list of axes
-            self.axes = list(hf.attrs["axes"])
-            print(self.axes)
+            axes = list(hf.attrs["axes"])
 
             # Set the values of each axis as an attribute
             # e.g. self.log10age == hdf["axes"]["log10age"]
-            for axis in self.axes:
+            for axis in axes:
                 # What are the units of this axis?
                 axis_units = hf["axes"][axis].attrs.get(
                     "Units", "dimensionless"
                 )
                 log_axis = hf["axes"][axis].attrs.get("log_on_read", False)
 
+                if "log10" in axis:
+                    log_axis = True
+
+                # Get the values
+                values = hf["axes"][axis][:]
+                if "log10" in axis:
+                    values = 10**values
+                    axis = axis.replace("log10", "")
+
                 # Set all the axis attributes
-                self._axes_values[axis] = hf["axes"][axis][:]
+                self.axes.append(axis)
+                self._axes_values[axis] = values
                 self._axes_units[axis] = axis_units
-                if log_axis:
-                    self._logged_axes.append(True)
-                else:
-                    self._logged_axes.append(False)
+                self._logged_axes.append(log_axis)
 
             # Number of axes
             self.naxes = len(self.axes)

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -40,6 +40,7 @@ from synthesizer import exceptions
 from synthesizer.line import Line, LineCollection, flatten_linelist
 from synthesizer.sed import Sed
 from synthesizer.units import Quantity, accepts
+from synthesizer.utils import depluralize, pluralize
 from synthesizer.utils.ascii_table import TableFormatter
 from synthesizer.warnings import warn
 
@@ -164,6 +165,10 @@ class Grid:
         self.parameters = {}
 
         # Get the axes of the grid from the HDF5 file
+        self.axes = []  # axes names
+        self._logged_axes = []  # need to know which have been logged
+        self._axes_values = {}
+        self._axes_units = {}
         self._get_axes()
 
         # Get the ionising luminosity (if available)
@@ -210,20 +215,70 @@ class Grid:
             f"{self.grid_dir}/{self.grid_name}.{self.grid_ext}"
         )
 
-    @property
-    def log10metallicities(self):
-        """Return the log10 metallicity axis."""
-        return np.log10(self.metallicity)
-
-    @property
-    def log10ages(self):
+    def __getattr__(self, name):
         """
-        Return the log10 age axis.
+        Return an attribute handling arbitrary axis names.
 
-        This is an alias to provide a pluralised version of the log10age
-        attribute.
+        This method allows for the dynamic extraction of axes with units,
+        either logged or not or using singular or plural axis names (to handle
+        legacy naming conventions).
         """
-        return self.log10age
+        # First up, do we just have the attribute and it isn't an axis?
+        if name in self.__dict__:
+            return self.__dict__[name]
+
+        # Now, do some silly pluralisation checks to handle old naming
+        # conventions. We do this now so everything works, we can grumble
+        # about it later
+        plural_name = pluralize(name)
+        singular_name = depluralize(name)
+
+        # If we have the axis name, return the axis with units
+        if name in self.axes:
+            return unyt_array(self._axes_values[name], self._axes_units[name])
+
+        # If we have the plural axis name, return the axis with units
+        elif plural_name in self.axes:
+            return unyt_array(
+                self._axes_values[plural_name], self._axes_units[plural_name]
+            )
+
+        # If we have the singular axis name, return the axis with units
+        elif singular_name in self.axes:
+            return unyt_array(
+                self._axes_values[singular_name],
+                self._axes_units[singular_name],
+            )
+
+        # It might be a Quantity style unitless request?
+        elif name[1:] in self.axes:
+            return self._axes_values[name[1:]]
+
+        # It might be a Quantity style unitless request for a pluralised axis?
+        elif plural_name[1:] in self.axes:
+            return self._axes_values[plural_name[1:]]
+
+        # It might be a Quantity style unitless request for
+        # a singularised axis?
+        elif singular_name[1:] in self.axes:
+            return self._axes_values[singular_name[1:]]
+
+        # Are we doing a log10 request?
+        elif name[:5] == "log10" and name[5:] in self.axes:
+            return np.log10(self._axes_values[name[5:]])
+
+        # Are we doing a log10 request for a pluralised axis?
+        elif plural_name[:5] == "log10" and plural_name[5:] in self.axes:
+            return np.log10(self._axes_values[plural_name[5:]])
+
+        # Are we doing a log10 request for a singularised axis?
+        elif singular_name[:5] == "log10" and singular_name[5:] in self.axes:
+            return np.log10(self._axes_values[singular_name[5:]])
+
+        # If we get here, we don't have the attribute
+        raise AttributeError(
+            f"'{self.__class__.__name__}' object has no attribute '{name}'"
+        )
 
     def _get_axes(self):
         """Get the grid axes from the HDF5 file."""
@@ -237,7 +292,19 @@ class Grid:
             # Set the values of each axis as an attribute
             # e.g. self.log10age == hdf["axes"]["log10age"]
             for axis in self.axes:
-                setattr(self, axis, hf["axes"][axis][:])
+                # What are the units of this axis?
+                axis_units = hf["axes"][axis].attrs.get(
+                    "Units", "dimensionless"
+                )
+                log_axis = hf["axes"][axis].attrs.get("log_on_read", False)
+
+                # Set all the axis attributes
+                self._axes_values[axis] = hf["axes"][axis][:]
+                self._axes_units[axis] = axis_units
+                if log_axis:
+                    self._logged_axes.append(True)
+                else:
+                    self._logged_axes.append(False)
 
             # Number of axes
             self.naxes = len(self.axes)

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -252,13 +252,18 @@ class Stars(StarsComponent):
 
         # Check if metallicities are uniformly binned in log10metallicity or
         # linear metallicity or not at all (e.g. BPASS)
-        if len(set(self.metallicities[:-1] - self.metallicities[1:])) == 1:
+        if (
+            len(np.unique(self.metallicities[:-1] - self.metallicities[1:]))
+            == 1
+        ):
             # Regular linearly
             self.metallicity_grid_type = "Z"
 
         elif (
             len(
-                set(self.log10metallicities[:-1] - self.log10metallicities[1:])
+                np.unique(
+                    self.log10metallicities[:-1] - self.log10metallicities[1:]
+                )
             )
             == 1
         ):

--- a/src/synthesizer/utils/util_funcs.py
+++ b/src/synthesizer/utils/util_funcs.py
@@ -330,3 +330,59 @@ def combine_arrays(arr1, arr2):
     # If both are not None then combine them
     else:
         return np.concatenate([arr1, arr2])
+
+
+def pluralize(word: str) -> str:
+    """Pluralize a singular word.
+
+    Args:
+        word (str): The word to pluralize.
+
+    Returns:
+        str: The pluralized word.
+    """
+    if (
+        word.endswith("s")
+        or word.endswith("x")
+        or word.endswith("z")
+        or word.endswith("sh")
+        or word.endswith("ch")
+    ):
+        return word + "es"
+    elif word.endswith("y") and word[-2] not in "aeiou":
+        return word[:-1] + "ies"
+    elif word.endswith("f"):
+        return word[:-1] + "ves"
+    elif word.endswith("fe"):
+        return word[:-2] + "ves"
+    elif word.endswith("o") and word[-2] not in "aeiou":
+        return word + "es"
+    else:
+        return word + "s"
+
+
+def depluralize(word: str) -> str:
+    """
+    Convert a plural word to its singular form based on simple rules.
+
+    Args:
+        word (str): The word to depluralize.
+
+    Returns:
+        str: The depluralized word.
+    """
+
+    if word.endswith("ies") and len(word) > 3:  # babies -> baby
+        return word[:-3] + "y"
+    elif word.endswith("ves"):  # leaves -> leaf, knives -> knife
+        return word[:-3] + "f"
+    elif word.endswith("oes"):  # heroes -> hero, potatoes -> potato
+        return word[:-2]
+    elif word.endswith(
+        ("ches", "shes", "xes", "sses")
+    ):  # boxes -> box, churches -> church
+        return word[:-2]
+    elif word.endswith("s") and len(word) > 2:  # general case: cats -> cat
+        return word[:-1]
+
+    return word  # Return unchanged if no rule applies

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from synthesizer.grid import Grid
 
 
@@ -6,3 +8,20 @@ def test_grid_returned(test_grid):
     Test that a Grid object is returned.
     """
     assert isinstance(test_grid, Grid)
+
+
+def test_grid_axes(test_grid):
+    """
+    Test that the axes are returned correctly.
+    """
+    # Test the automatic extraction defined by the __getattr__ overload
+    assert getattr(test_grid.ages, "units", None) is not None
+    assert getattr(test_grid.metallicities, "units", None) is not None
+    assert isinstance(test_grid._ages, np.ndarray)
+    assert np.allclose(test_grid._ages, 10**test_grid.log10ages)
+
+    # Test the silly singular and plural nonsense works (hopefully we can
+    # remove this in the future)
+    assert np.allclose(test_grid._ages, test_grid._age)
+    assert np.allclose(test_grid._metallicities, test_grid._metallicity)
+    assert np.allclose(test_grid.log10ages, test_grid.log10age)


### PR DESCRIPTION
`Grid` axes now handle extraction by via singular, plural, united, unitless and logged naming conventions. This lays the groundwork for using the new grid files while maintaining old behaviour with warnings.

Closes #530 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
