### PR TITLE
Added a safety check for covering fractions exceeding unity

### DIFF
--- a/src/synthesizer/emission_models/agn/models.py
+++ b/src/synthesizer/emission_models/agn/models.py
@@ -13,6 +13,7 @@ Example usage:
 
 """
 
+from synthesizer import exceptions
 from synthesizer.emission_models.base_model import BlackHoleEmissionModel
 
 
@@ -287,6 +288,12 @@ class DiscTransmittedEmission(BlackHoleEmissionModel):
             **kwargs
 
         """
+        # Ensure the sum of covering fractions is less than 1
+        if covering_fraction_nlr + covering_fraction_blr > 1:
+            raise exceptions.InconsistentArguments(
+                "The sum of the covering fractions must be less than 1."
+            )
+
         # Create the child models
         nlr = NLRTransmittedEmission(
             grid=nlr_grid,
@@ -345,6 +352,12 @@ class DiscEscapedEmission(BlackHoleEmissionModel):
                 fraction of the BLR). Default is 0.1.
             **kwargs
         """
+        # Ensure the sum of covering fractions is less than 1
+        if covering_fraction_nlr + covering_fraction_blr > 1:
+            raise exceptions.InconsistentArguments(
+                "The sum of the covering fractions must be less than 1."
+            )
+
         BlackHoleEmissionModel.__init__(
             self,
             grid=grid,
@@ -494,6 +507,12 @@ class AGNIntrinsicEmission(BlackHoleEmissionModel):
             **kwargs
 
         """
+        # Ensure the sum of covering fractions is less than 1
+        if covering_fraction_nlr + covering_fraction_blr > 1:
+            raise exceptions.InconsistentArguments(
+                "The sum of the covering fractions must be less than 1."
+            )
+
         # Create the child models
         disc = DiscEmission(
             nlr_grid=nlr_grid,

--- a/src/synthesizer/emission_models/agn/unified_agn.py
+++ b/src/synthesizer/emission_models/agn/unified_agn.py
@@ -23,6 +23,7 @@ Example usage::
 import numpy as np
 from unyt import deg
 
+from synthesizer import exceptions
 from synthesizer.emission_models.base_model import BlackHoleEmissionModel
 from synthesizer.sed import Sed
 
@@ -157,6 +158,12 @@ class UnifiedAGN(BlackHoleEmissionModel):
             **kwargs: Any additional keyword arguments to pass to the
                 BlackHoleEmissionModel.
         """
+        # Ensure the sum of covering fractions is less than 1
+        if covering_fraction_nlr + covering_fraction_blr > 1:
+            raise exceptions.InconsistentArguments(
+                "The sum of the covering fractions must be less than 1."
+            )
+
         # Get the incident istropic disc emission model
         self.disc_incident_isotropic = self._make_disc_incident_isotropic(
             nlr_grid,


### PR DESCRIPTION
Added a check to ensure the sum of covering fractions does not exceed 1. 

Closes #732 

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
