### PR TITLE
Refining instantaneous SFH and metallicity distributions (+ SFH and Z Dist helpers)

### DIFF
--- a/docs/source/components/stars.ipynb
+++ b/docs/source/components/stars.ipynb
@@ -61,7 +61,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This can be visualised in synthesizer using a `Grid` object (see [here](../grids/grids.rst)), to assign these to SFZH bins."
+    "But more informatively this can be visualised in Synthesizer by calling the ``get_sfzh`` method, which will assign the star particles to a SFZH grid. This can be an arbitrary grid, but here we will use the ``Grid`` object's axes."
    ]
   },
   {
@@ -77,7 +77,25 @@
     "\n",
     "grid = Grid(grid_name, grid_dir=grid_dir)\n",
     "\n",
-    "stars.plot_sfzh(grid)"
+    "sfzh = stars.get_sfzh(grid.log10age, grid.metallicity)\n",
+    "sfzh.plot_sfzh()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also calculate (with ``get_*`` methods) or plot (with ``plot_*`` methods) the star formation history (SFH) and metallicity distribution (ZD) in isolation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stars.plot_sfh(grid.log10age)\n",
+    "stars.plot_metal_dist(grid.metallicity)"
    ]
   },
   {
@@ -256,7 +274,7 @@
     "inst_stars = Stars(\n",
     "    log10ages,\n",
     "    metallicities,\n",
-    "    sf_hist=100 * Myr,\n",
+    "    sf_hist=105 * Myr,\n",
     "    metal_dist=10**-3,\n",
     "    initial_mass=10**9 * Msun,\n",
     ")"

--- a/docs/source/components/stars.ipynb
+++ b/docs/source/components/stars.ipynb
@@ -437,7 +437,9 @@
     "combined = arr_stars + const_stars + exp_stars + logn_stars\n",
     "print(combined)\n",
     "\n",
-    "fig, ax = combined.plot_sfzh()"
+    "fig, ax = combined.plot_sfzh()\n",
+    "combined.plot_sfh(show=True)\n",
+    "combined.plot_metal_dist(show=True)"
    ]
   },
   {

--- a/examples/particle/plot_create_sampled_sed.py
+++ b/examples/particle/plot_create_sampled_sed.py
@@ -9,7 +9,7 @@ with constant star formation.
 
 import matplotlib.pyplot as plt
 import numpy as np
-from unyt import Myr
+from unyt import Msun, Myr
 
 from synthesizer.emission_models import IncidentEmission
 from synthesizer.grid import Grid
@@ -38,7 +38,11 @@ metal_dist = ZDist.DeltaConstant(**Z_p)
 sfh_p = {"duration": 100 * Myr}
 sfh = SFH.Constant(**sfh_p)  # constant star formation
 sfzh = ParametricStars(
-    log10ages, metallicities, sf_hist=sfh, metal_dist=metal_dist
+    log10ages,
+    metallicities,
+    sf_hist=sfh,
+    metal_dist=metal_dist,
+    initial_mass=10**9 * Msun,
 )
 print(sfzh)
 # sfzh.plot()
@@ -58,16 +62,6 @@ galaxy.generate_intrinsic_spectra(grid, fesc=0.0)
 calculate only integrated SEDs """
 galaxy.stars.get_spectra(model)
 
-# --- generate dust screen
-# galaxy.get_screen(0.5) # tau_v
-
-# --- generate CF00 variable dust screen
-# galaxy.get_CF00(grid, 0.5, 0.5) # grid, tau_v_BC, tau_v_ISM
-
-# --- generate for los model
-# TODO: to be implemented
-# tau_vs = np.ones(N) * 0.5
-# galaxy.get_los(tau_vs)  # grid, tau_v_BC, tau_v_ISM
 
 for sed_type, sed in galaxy.stars.spectra.items():
     plt.plot(np.log10(sed.lam), np.log10(sed.lnu), label=sed_type)

--- a/examples/particle/plot_single_star_test.py
+++ b/examples/particle/plot_single_star_test.py
@@ -48,10 +48,14 @@ part_stars = ParticleStars(
 )
 
 # Calculate the particle SFZH grid (equivalent to grid weights)
-part_sfzh = part_stars.get_sfzh(grid, grid_assignment_method="cic")
+part_sfzh = part_stars.get_sfzh(
+    log10ages=grid.log10age,
+    metallicities=grid.metallicity,
+    grid_assignment_method="cic",
+)
 
 # Plot the SFZH
-part_stars.plot_sfzh(grid, grid_assignment_method="cic")
+part_stars.plot_sfzh()
 
 # Create the figure and axes for the comparison
 fig, ax = plt.subplots()

--- a/examples/particle/plot_single_star_test.py
+++ b/examples/particle/plot_single_star_test.py
@@ -52,7 +52,7 @@ part_sfzh = part_stars.get_sfzh(
     log10ages=grid.log10age,
     metallicities=grid.metallicity,
     grid_assignment_method="cic",
-)
+).sfzh
 
 # Plot the SFZH
 part_stars.plot_sfzh()

--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -39,6 +39,7 @@ class StarsComponent(Component):
         self,
         ages,
         metallicities,
+        _star_type,
         **kwargs,
     ):
         """
@@ -57,6 +58,11 @@ class StarsComponent(Component):
         # The common stellar attributes between particle and parametric stars
         self.ages = ages
         self.metallicities = metallicities
+
+        # The type of stars object (parametric or particle). This is useful for
+        # determining the type of stars object without relying on isinstance
+        # and possible circular imports.
+        self._star_type = _star_type
 
     @property
     def log10ages(self):

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -942,7 +942,7 @@ class Stars(StarsComponent):
 
         # Set labels
         ax.set_xlabel(r"$\log_{10}(\mathrm{age}/\mathrm{yr})$")
-        ax.set_ylabel(r"$\log_{10}Z$")
+        ax.set_ylabel(r"$Z$")
 
         # Set the limits so all axes line up
         ax.set_ylim(self.metallicities[0], self.metallicities[-1])

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -954,6 +954,116 @@ class Stars(StarsComponent):
 
         return fig, ax
 
+    def get_sfh(self):
+        """
+        Get the star formation history of the stellar population.
+
+        Returns:
+            unyt_array:
+                The star formation history of the stellar population.
+        """
+        return self.sf_hist
+
+    def plot_sfh(
+        self,
+        xlimits=(),
+        ylimits=(),
+        show=True,
+    ):
+        """
+        Plot the star formation history of the stellar population.
+
+        Args:
+            xlimits (tuple)
+                The limits of the x-axis.
+            ylimits (tuple)
+                The limits of the y-axis.
+            show (bool)
+                Should we invoke plt.show()?
+
+        Returns:
+            fig
+                The Figure object contain the plot axes.
+            ax
+                The Axes object containing the plotted data.
+        """
+        fig, ax = plt.subplots()
+        ax.semilogy()
+        ax.step(self.log10ages, self.sf_hist, where="mid", color="blue")
+        ax.fill_between(
+            self.log10ages,
+            self.sf_hist,
+            step="mid",
+            color="blue",
+            alpha=0.5,
+        )
+
+        ax.set_xlabel(r"$\log_{10}(\mathrm{age}/\mathrm{yr})$")
+        ax.set_ylabel(r"SFH / M$_\odot$")
+
+        if show:
+            plt.show()
+
+        return fig, ax
+
+    def get_metal_dist(self):
+        """
+        Get the metallicity distribution of the stellar population.
+
+        Returns:
+            unyt_array:
+                The metallicity distribution of the stellar population.
+        """
+        return self.metal_dist
+
+    def plot_metal_dist(
+        self,
+        xlimits=(),
+        ylimits=(),
+        show=True,
+    ):
+        """
+        Plot the metallicity distribution of the stellar population.
+
+        Args:
+            xlimits (tuple)
+                The limits of the x-axis.
+            ylimits (tuple)
+                The limits of the y-axis.
+            show (bool)
+                Should we invoke plt.show()?
+
+        Returns:
+            fig
+                The Figure object contain the plot axes.
+            ax
+                The Axes object containing the plotted data.
+        """
+        fig, ax = plt.subplots()
+        ax.semilogy()
+        ax.step(self.metallicities, self.metal_dist, where="mid", color="red")
+        ax.fill_between(
+            self.metallicities,
+            self.metal_dist,
+            step="mid",
+            color="red",
+            alpha=0.5,
+        )
+
+        ax.set_xlabel(r"$Z$")
+        ax.set_ylabel(r"Z_D / M$_\odot$")
+
+        # Apply limits if provided
+        if len(ylimits) > 0:
+            ax.set_ylim(ylimits)
+        if len(xlimits) > 0:
+            ax.set_xlim(xlimits)
+
+        if show:
+            plt.show()
+
+        return fig, ax
+
     def _prepare_sed_args(self, *args, **kwargs):
         """Prepare arguments for SED generation."""
         raise exceptions.NotImplementedError(

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -2354,10 +2354,10 @@ class Stars(Particles, StarsComponent):
         # Plot the SFH as a step function
         fig, ax = plt.subplots()
         ax.semilogy()
-        ax.step(metallicities, metal_dist, where="mid", color="blue")
+        ax.step(metallicities, metal_dist, where="mid", color="red")
 
         ax.fill_between(
-            metallicities, metal_dist, step="mid", alpha=0.5, color="blue"
+            metallicities, metal_dist, step="mid", alpha=0.5, color="red"
         )
         ax.set_xlabel(r"$Z$")
         ax.set_ylabel(r"Z_D / M$_\odot$")

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -21,8 +21,6 @@ Example usages:
 
 import os
 
-import cmasher as cmr
-import matplotlib.pyplot as plt
 import numpy as np
 from unyt import Hz, Mpc, Msun, Myr, angstrom, c, erg, km, s, yr
 
@@ -35,7 +33,6 @@ from synthesizer.parametric import Stars as Para_Stars
 from synthesizer.particle.particles import Particles
 from synthesizer.units import Quantity, accepts
 from synthesizer.utils.ascii_table import TableFormatter
-from synthesizer.utils.plt import single_histxy
 from synthesizer.utils.util_funcs import combine_arrays
 from synthesizer.warnings import deprecated, warn
 
@@ -196,7 +193,13 @@ class Stars(Particles, StarsComponent):
             tau_v=tau_v,
             name="Stars",
         )
-        StarsComponent.__init__(self, ages, metallicities, **kwargs)
+        StarsComponent.__init__(
+            self,
+            ages,
+            metallicities,
+            _star_type="particle",
+            **kwargs,
+        )
 
         # Ensure we don't have negative ages
         if len(ages) > 0:
@@ -1921,7 +1924,8 @@ class Stars(Particles, StarsComponent):
 
     def _prepare_sfzh_args(
         self,
-        grid,
+        log10ages,
+        metallicities,
         grid_assignment_method,
         nthreads,
     ):
@@ -1929,8 +1933,10 @@ class Stars(Particles, StarsComponent):
         Prepare the arguments for SFZH computation with the C functions.
 
         Args:
-            grid (Grid)
-                The SPS grid object to extract spectra from.
+            log10ages (array-like, float)
+                The log10 ages of the desired SFZH.
+            metallicities (array-like, float)
+                The metallicities of the desired SFZH.
             grid_assignment_method (string)
                 The type of method used to assign particles to a SPS grid
                 point. Allowed methods are cic (cloud in cell) or nearest
@@ -1943,8 +1949,8 @@ class Stars(Particles, StarsComponent):
         """
         # Set up the inputs to the C function.
         grid_props = [
-            np.ascontiguousarray(grid.log10age, dtype=np.float64),
-            np.ascontiguousarray(grid.metallicity, dtype=np.float64),
+            np.ascontiguousarray(log10ages, dtype=np.float64),
+            np.ascontiguousarray(metallicities, dtype=np.float64),
         ]
         part_props = [
             np.ascontiguousarray(self.log10ages, dtype=np.float64),
@@ -1983,48 +1989,63 @@ class Stars(Particles, StarsComponent):
 
     def get_sfzh(
         self,
-        grid,
+        log10ages,
+        metallicities,
         grid_assignment_method="cic",
         nthreads=0,
     ):
         """
-        Generate the binned SFZH history of this collection of particles.
+        Generate the binned SFZH history of these stars.
+
+        The binned SFZH is calculated by binning the particles onto the
+        desired grid defined by the input log10ages and metallicities.
 
         The binned SFZH produced by this method is equivalent to the weights
         used to extract spectra from the grid.
 
         Args:
-            grid (Grid)
-                The spectral grid object.
+            log10ages (array-like, float)
+                The log10 ages of the desired SFZH.
+            metallicities (array-like, float)
+                The metallicities of the desired SFZH.
             grid_assignment_method (string)
                 The type of method used to assign particles to a SPS grid
                 point. Allowed methods are cic (cloud in cell) or nearest
-                grid point (ngp) or there uppercase equivalents (CIC, NGP).
-                Defaults to cic.
+                grid point (ngp) or their uppercase equivalents (CIC, NGP).
+                Defaults to cic. (particle only)
             nthreads (int)
                 The number of threads to use in the computation. If set to -1
-                all available threads will be used.
+                all available threads will be used. (particle only)
 
         Returns:
             numpy.ndarray:
                 Numpy array of containing the SFZH.
         """
-
+        # Import parametric stars here to avoid circular imports
         from synthesizer.extensions.sfzh import compute_sfzh
+        from synthesizer.parametric import Stars as ParametricStars
 
         # Prepare the arguments for the C function.
         args = self._prepare_sfzh_args(
-            grid,
+            log10ages,
+            metallicities,
             grid_assignment_method=grid_assignment_method.lower(),
             nthreads=nthreads,
         )
 
-        # Get the SFZH
-        self.sfzh = compute_sfzh(*args)
+        # Get the SFZH and create the ParametricStars object
+        self.sfzh = ParametricStars(
+            log10ages,
+            metallicities,
+            sfzh=compute_sfzh(*args),
+        )
 
         return self.sfzh
 
-    def plot_sfzh(self, grid, grid_assignment_method="cic", show=True):
+    def plot_sfzh(
+        self,
+        show=True,
+    ):
         """
         Plot the binned SZFH.
 
@@ -2038,65 +2059,99 @@ class Stars(Particles, StarsComponent):
             ax
                 The Axes object containing the plotted data.
         """
-
         # Ensure we have the SFZH
         if self.sfzh is None:
-            self.get_sfzh(grid, grid_assignment_method)
+            raise exceptions.MissingAttribute(
+                "The SFZH has not been calculated. Run get_sfzh() first."
+            )
+        return self.sfzh.plot_sfzh(show=show)
 
-        # Get the grid axes
-        log10ages = grid.log10age
-        log10metallicities = np.log10(grid.metallicity)
+    def _prepare_sfh_args(
+        self,
+        log10ages,
+        metallicities,
+        grid_assignment_method,
+        nthreads,
+    ):
+        """
+        Prepare the arguments for SFH computation with the C functions.
 
-        # Create the figure and extra axes for histograms
-        fig, ax, haxx, haxy = single_histxy()
+        Args:
+            grid (Grid)
+                The SPS grid object to extract spectra from.
+            grid_assignment_method (string)
+                The type of method used to assign particles to a SPS grid
+                point. Allowed methods are cic (cloud in cell) or nearest
+                grid point (ngp) or there uppercase equivalents (CIC, NGP).
+                Defaults to cic.
 
-        # Visulise the SFZH grid
-        ax.pcolormesh(
-            log10ages,
-            log10metallicities,
-            self.sfzh.T,
-            cmap=cmr.sunburst,
+        Returns:
+            tuple
+                A tuple of all the arguments required by the C extension.
+        """
+        # Set up the inputs to the C function.
+        grid_props = [
+            np.ascontiguousarray(log10ages, dtype=np.float64),
+            np.ascontiguousarray(metallicities, dtype=np.float64),
+        ]
+        part_props = [
+            np.ascontiguousarray(self.log10ages, dtype=np.float64),
+            np.ascontiguousarray(self.metallicities, dtype=np.float64),
+        ]
+        part_mass = np.ascontiguousarray(
+            self._initial_masses, dtype=np.float64
         )
 
-        # Add binned Z to right of the plot
-        metal_dist = np.sum(self.sfzh, axis=0)
-        haxy.fill_betweenx(
-            log10metallicities,
-            metal_dist / np.max(metal_dist),
-            step="mid",
-            color="k",
-            alpha=0.3,
+        # Make sure we set the number of particles to the size of the mask
+        npart = np.int32(len(part_mass))
+
+        # Get the grid dimensions after slicing what we need
+        grid_dims = np.zeros(len(grid_props), dtype=np.int32)
+        for ind, g in enumerate(grid_props):
+            grid_dims[ind] = len(g)
+
+        # Convert inputs to tuples
+        grid_props = tuple(grid_props)
+        part_props = tuple(part_props)
+
+        # If nthreads = -1 we will use all available
+        if nthreads == -1:
+            nthreads = os.cpu_count()
+
+        return (
+            grid_props,
+            part_props,
+            part_mass,
+            grid_dims,
+            len(grid_props),
+            npart,
+            grid_assignment_method,
+            nthreads,
         )
 
-        # Add binned SF_HIST to top of the plot
-        sf_hist = np.sum(self.sfzh, axis=1)
-        haxx.fill_between(
-            log10ages,
-            sf_hist / np.max(sf_hist),
-            step="mid",
-            color="k",
-            alpha=0.3,
-        )
+    def get_sfh(self, log10ages):
+        """
+        Generate the SFH of these stars.
 
-        # Set plot limits
-        haxy.set_xlim([0.0, 1.2])
-        haxy.set_ylim(log10metallicities[0], log10metallicities[-1])
-        haxx.set_ylim([0.0, 1.2])
-        haxx.set_xlim(log10ages[0], log10ages[-1])
+        The SFH is calculated by summing the mass of the particles in each age
+        bin defined by the input log10ages.
 
-        # Set labels
-        ax.set_xlabel(r"$\log_{10}(\mathrm{age}/\mathrm{yr})$")
-        ax.set_ylabel(r"$\log_{10}Z$")
+        Args:
+            log10ages (array-like, float)
+                The log10 ages of the desired SFH.
 
-        # Set the limits so all axes line up
-        ax.set_ylim(log10metallicities[0], log10metallicities[-1])
-        ax.set_xlim(log10ages[0], log10ages[-1])
+        Returns:
+            numpy.ndarray:
+                Numpy array of containing the SFH.
+        """
+        # Ensure we have the SFZH
+        if self.sfzh is None:
+            raise exceptions.MissingAttribute(
+                "The SFZH has not been calculated. Run get_sfzh() first."
+            )
 
-        # Shall we show it?
-        if show:
-            plt.show()
-
-        return fig, ax
+        # Get the SFH
+        return self.sfzh.get_sfh(log10ages)
 
     @deprecated(
         message="is now just a wrapper "


### PR DESCRIPTION
#702 highlights a fundamental issue with how the instantaneous values were used to create SFZHs. This has now been modified to use the CIC machinery and will now give the expected result when computing statistics because the weights are correctly assigned, therefore closes #702. 

While doing this I also generalised things a bit better. Instead of a `Grid` you can now make SFZH for any arbitrary set of axes. I also introduced helpers for each individual axis (SFH and metallicity distributions) to make this a little easier.

## Issue Type
<!-- delete options below as required -->
- Bug
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
