### PR TITLE
Some Quality of Life improvements to the `Template` 

### DIFF
--- a/src/synthesizer/exceptions.py
+++ b/src/synthesizer/exceptions.py
@@ -135,6 +135,24 @@ class InconsistentAddition(Exception):
             return "Unable to add"
 
 
+class InconsistentMultiplication(Exception):
+    """
+    Generic exception class for when multiplying two objects is impossible.
+    """
+
+    def __init__(self, *args):
+        if args:
+            self.message = args[0]
+        else:
+            self.message = None
+
+    def __str__(self):
+        if self.message:
+            return "{0} ".format(self.message)
+        else:
+            return "Unable to multiply"
+
+
 class InconsistentCoordinates(Exception):
     """
     Generic exception class for when coordinates are inconsistent.

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1366,20 +1366,5 @@ class Template:
                 "bolometric luminosity must be provided with units"
             )
 
-        # Compute the scaling based on normalisation
-        scaling = bolometric_luminosity.value
-
-        # Handle the dimensions of the bolometric luminosity, or handle it as ]
-        # a scalar
-        if len(scaling.shape) == 0 or bolometric_luminosity.shape[0] == 1:
-            sed = Sed(
-                self.lam,
-                scaling * self.lnu * (1 - self.fesc),
-            )
-        else:
-            sed = Sed(
-                self.lam,
-                scaling[:, None] * self.lnu * (1 - self.fesc),
-            )
-
-        return sed
+        # Scale the spectra and return
+        return self._sed * bolometric_luminosity

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1368,13 +1368,6 @@ class Template:
 
         # Compute the scaling based on normalisation
         scaling = bolometric_luminosity.value
-        print(
-            scaling,
-            np.isscalar(bolometric_luminosity),
-            np.isscalar(scaling),
-            type(scaling),
-            scaling.shape,
-        )
 
         # Handle the dimensions of the bolometric luminosity, or handle it as ]
         # a scalar

--- a/src/synthesizer/grid.py
+++ b/src/synthesizer/grid.py
@@ -1336,12 +1336,14 @@ class Template:
             sed = sed.get_resampled_sed(new_lam=unify_with_grid.lam)
 
         # Attach the template now we've done the interpolation (if needed)
+        self._sed = sed
         self.lnu = sed.lnu
         self.lam = sed.lam
 
         # Normalise, just in case
         self.normalisation = sed._bolometric_luminosity
-        self.lnu /= self.normalisation
+        self._sed._lnu /= self.normalisation
+        self._lnu /= self.normalisation
 
         # Set the escape fraction
         self.fesc = fesc
@@ -1366,9 +1368,17 @@ class Template:
 
         # Compute the scaling based on normalisation
         scaling = bolometric_luminosity.value
+        print(
+            scaling,
+            np.isscalar(bolometric_luminosity),
+            np.isscalar(scaling),
+            type(scaling),
+            scaling.shape,
+        )
 
-        # Handle the dimensions of the bolometric luminosity
-        if bolometric_luminosity.shape[0] == 1:
+        # Handle the dimensions of the bolometric luminosity, or handle it as ]
+        # a scalar
+        if len(scaling.shape) == 0 or bolometric_luminosity.shape[0] == 1:
             sed = Sed(
                 self.lam,
                 scaling * self.lnu * (1 - self.fesc),

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -338,8 +338,8 @@ class Sed:
             return self
 
         # Handle an single element array scaling factor
-        elif len(scaling) == 1:
-            scaling = np.asscalar(scaling)
+        elif scaling.size == 1:
+            scaling = scaling.item()
             if not inplace:
                 return Sed(self.lam, lnu=scaling * self._lnu * self.lnu.units)
             else:

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -312,7 +312,7 @@ class Sed:
         if np.isscalar(scaling) and not inplace:
             return Sed(self.lam, lnu=scaling * self.lnu)
         elif np.isscalar(scaling) and inplace:  # pragma: no cover
-            self._lnu *= scaling
+            self.lnu *= scaling
             return self
 
         # Handle an single element array scaling factor
@@ -321,7 +321,7 @@ class Sed:
             if not inplace:
                 return Sed(self.lam, lnu=scaling * self.lnu)
             else:
-                self._lnu *= scaling
+                self.lnu *= scaling
                 return self
 
         # Handle a multi-element array scaling factor as long as it matches
@@ -337,7 +337,7 @@ class Sed:
             if not inplace:
                 return Sed(self.lam, lnu=new_scaling * self.lnu)
             else:
-                self._lnu *= new_scaling
+                self.lnu *= new_scaling
                 return self
 
         # If the scaling array is the same shape as the lnu array then we can
@@ -353,7 +353,7 @@ class Sed:
             and scaling.shape == self.shape
             and inplace
         ):
-            self._lnu *= scaling
+            self.lnu *= scaling
             return self
 
         # Otherwise, we've been handed a bad scaling factor


### PR DESCRIPTION
Adds an attribute to the template to hold the unscaled "original" `Sed`. Also cleans up some logic by refining the overloaded multiplication of an `Sed` object. This means every type of scaler is handled up to the size of the `lnu` array and if an incompatible type is used, a helpful error is produced.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
