### PR TITLE
Introduces abundances dictionary as attribute on `Gas` and `Stars`

### DIFF
--- a/src/synthesizer/components/stellar.py
+++ b/src/synthesizer/components/stellar.py
@@ -29,6 +29,11 @@ class StarsComponent(Component):
         metallicities (Quantity)
             The metallicity of each stellar particle/bin
             (particle/parametric).
+        abundances (dict)
+            A dictionary of the abundances of each element in the stars.
+            The keys are the element symbols and the values are the
+            abundances of each element in the stars (0-1 where 1 is 100%
+            of the stars is composed of that element).
     """
 
     # Define quantities
@@ -40,6 +45,7 @@ class StarsComponent(Component):
         ages,
         metallicities,
         _star_type,
+        abundances,
         **kwargs,
     ):
         """
@@ -51,6 +57,15 @@ class StarsComponent(Component):
             metallicities (array-like, float)
                 The metallicity of each stellar particle/bin
                 (particle/parametric).
+            _star_type (str)
+                The type of stars object (parametric or particle).
+                This is useful for determining the type of stars object
+                without relying on isinstance and possible circular imports.
+            abundances (dict)
+                The abundances of each element in the stars.
+                The keys are the element symbols and the values are the
+                abundances of each element in the stars (0-1 where 1 is 100%
+                of the stars is composed of that element).
         """
         # Initialise the parent class
         Component.__init__(self, "Stars", **kwargs)
@@ -63,6 +78,19 @@ class StarsComponent(Component):
         # determining the type of stars object without relying on isinstance
         # and possible circular imports.
         self._star_type = _star_type
+
+        # Set the abundances dictionary
+        self.abundances = abundances
+
+        # Ensure abundances don't exceed 1
+        tot_abundance = 0
+        for key in self.abundances:
+            tot_abundance += self.abundances[key]
+        if tot_abundance > 1:
+            raise exceptions.InconsistentArguments(
+                f"Abundances cannot exceed 1: "
+                f"{[f'{key}: {val}' for key, val in self.abundances.items()]}"
+            )
 
     @property
     def log10ages(self):

--- a/src/synthesizer/parametric/stars.py
+++ b/src/synthesizer/parametric/stars.py
@@ -97,6 +97,7 @@ class Stars(StarsComponent):
         sfzh=None,
         sf_hist=None,
         metal_dist=None,
+        abundances={},
         **kwargs,
     ):
         """
@@ -142,6 +143,11 @@ class Stars(StarsComponent):
                     - An instance of one of the child classes of ZH. This
                       will be used to calculate an array describing the
                       metallicity distribution.
+            abundances (dict)
+                The abundances of each element in the stars.
+                The keys are the element symbols and the values are the
+                abundances of each element in the stars (0-1 where 1 is 100%
+                of the stars is composed of that element).
         """
         # Instantiate the parent
         StarsComponent.__init__(
@@ -149,6 +155,7 @@ class Stars(StarsComponent):
             10**log10ages * yr,
             metallicities,
             _star_type="parametric",
+            abundances=abundances,
             **kwargs,
         )
 

--- a/src/synthesizer/particle/gas.py
+++ b/src/synthesizer/particle/gas.py
@@ -49,6 +49,11 @@ class Gas(Particles):
         smoothing_lengths (array-like, float)
             The smoothing lengths (describing the sph kernel) of each gas
             particle in simulation length units.
+        abundances (dict)
+            A dictionary of abundances for each element in the gas particles.
+            The keys are the element symbols and the values are the abundances
+            of that element in the gas particles (0-1 where 1 is 100% of the
+            gas is composed of that element).
     """
 
     # Define the allowed attributes
@@ -94,6 +99,7 @@ class Gas(Particles):
         centre=None,
         metallicity_floor=1e-5,
         tau_v=None,
+        abundances={},
         **kwargs,
     ):
         """
@@ -130,10 +136,14 @@ class Gas(Particles):
                 for baryons). This is used to avoid log(0) errors.
             tau_v (float)
                 The dust optical depth in the V band.
+            abundances (dict)
+                A dictionary of abundances for each element in the gas
+                particles. The keys are the element symbols and the values are
+                the abundances of that element in the gas particles (0-1
+                where 1 is 100% of the gas is composed of that element).
             **kwargs
                 Extra optional properties to set on the gas object.
         """
-
         # Instantiate parent
         Particles.__init__(
             self,
@@ -157,6 +167,19 @@ class Gas(Particles):
 
         # Set the smoothing lengths for these gas particles
         self.smoothing_lengths = smoothing_lengths
+
+        # Attach any abundances we've been passed
+        self.abundances = abundances
+
+        # Ensure abundances don't exceed 1
+        tot_abundance = 0
+        for key in self.abundances:
+            tot_abundance += self.abundances[key]
+        if tot_abundance > 1:
+            raise exceptions.InconsistentArguments(
+                f"Abundances cannot exceed 1: "
+                f"{[f'{key}: {val}' for key, val in self.abundances.items()]}"
+            )
 
         # None metallicity warning already captured when loading gas
         if (


### PR DESCRIPTION
Allowing for future functionality around complex abundances in baryons. 

- Both parametric and particle `Stars` can now carry an abundances dictionary.
- `s_oxygen` and `s_hydrogen` are now deprecated and will temporarily update the `abundances` dict. 
- Particle `Gas` can also carry the abundances. Note there is no real parametric `Gas` implementation for now but this is easily ported when there is by following the component implementation. 
- Closes #603 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [ ] I have read the [CONTRIBUTING.md]() -->
- [ ] I have added docstrings to all methods
- [ ] I have added sufficient comments to all lines
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no pep8 errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
