### PR TITLE
Moving dense_basis install to an optional dependency

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,7 +35,7 @@ jobs:
           # is not set up properly and depends on numpy and cython, the former
           # we depend on, the latter we need to install)
           pip install cython
-          WITH_OPENMP=1 pip install .[bluetides,eagle,illustris]
+          WITH_OPENMP=1 pip install .[bluetides,eagle,illustris,dense_basis]
           # Output the compilation report so it can be viewed in an action log
           cat build_synth.log
       - uses: astral-sh/ruff-action@v1 # Lint with Ruff

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install wheel
-          pip install -e .[docs]
+          pip install -e .[docs,dense_basis]
           sudo apt install pandoc
       - name: Download test data
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ dependencies = [
   "tqdm",
   "requests",
   "pathos",
-  "dense_basis@git+https://github.com/kartheikiyer/dense_basis",
   "statsmodels",
 ]
 
@@ -134,6 +133,13 @@ eagle = [
 ]
 illustris = [
     "illustris_python @ git+https://github.com/illustristng/illustris_python.git@master",
+]
+
+# Optional dependency for using dense_basis (note that we 
+# currently have to use the main branch since the PyPi version 
+# hasn't been updated with a fix we required)
+dense_basis = [
+  "dense_basis@git+https://github.com/kartheikiyer/dense_basis",
 ]
 
 

--- a/src/synthesizer/parametric/sf_hist.py
+++ b/src/synthesizer/parametric/sf_hist.py
@@ -770,6 +770,7 @@ class DenseBasis(Common):
                 " dense_basis support by running `pip install "
                 ".[dense_basis]`"
             )
+
         # Convert the dense basis tuple arguments to sfh in mass fraction units
         tempsfh, temptime = db.tuple_to_sfh(
             self.db_tuple, self.redshift, interpolator=interpolator, vb=False

--- a/src/synthesizer/parametric/sf_hist.py
+++ b/src/synthesizer/parametric/sf_hist.py
@@ -29,15 +29,6 @@ from synthesizer import exceptions
 from synthesizer.utils.stats import weighted_mean, weighted_median
 from synthesizer.warnings import warn
 
-# This import is in quarantine because it insists on printing
-# "Starting dense_basis" to the console on import! It can stay here until
-# a PR is raised to fix this.
-original_stdout = sys.stdout
-sys.stdout = io.StringIO()
-import dense_basis as db
-
-sys.stdout = original_stdout
-
 # Define a list of the available parametrisations
 parametrisations = (
     "Constant",
@@ -750,7 +741,7 @@ class DenseBasis(Common):
         self, interpolator="gp_george", min_age=5, max_age=10.3
     ):
         """
-        Convert dense basis representation to a binned SFH
+        Convert dense basis representation to a binned SFH.
 
         Args:
             interpolator (string)
@@ -762,6 +753,23 @@ class DenseBasis(Common):
             max_age (float)
                 maximum age of SFH grid
         """
+        # Attempt to import dense_basis, if missing they need to
+        # install the optional dependency
+        try:
+            # This import is in quarantine because it insists on printing
+            # "Starting dense_basis" to the console on import! It can stay here
+            # until a PR is raised to fix this.
+            original_stdout = sys.stdout
+            sys.stdout = io.StringIO()
+            import dense_basis as db
+
+            sys.stdout = original_stdout
+        except ImportError:
+            raise exceptions.UnmetDependency(
+                "dense_basis not found. Please install Synthesizer with "
+                " dense_basis support by running `pip install "
+                ".[dense_basis]`"
+            )
         # Convert the dense basis tuple arguments to sfh in mass fraction units
         tempsfh, temptime = db.tuple_to_sfh(
             self.db_tuple, self.redshift, interpolator=interpolator, vb=False


### PR DESCRIPTION
Moves `dense_basis` to an optional install. This improves install time a bit and I think is justified. Should dense_basis related methods be called without the installation it'll raise an `UnmetDependency` error with installation instructions.


## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
