### PR TITLE
Remove requirement for intrinsic to have non-zero escape fraction

### DIFF
--- a/src/synthesizer/emission_models/stellar/models.py
+++ b/src/synthesizer/emission_models/stellar/models.py
@@ -394,12 +394,6 @@ class IntrinsicEmission(StellarEmissionModel):
             reprocessed (EmissionModel): The reprocessed model to use, if None
                 then one will be created.
         """
-        # Ensure what we've been asked for makes sense
-        if fesc == 0.0:
-            raise ValueError(
-                "Intrinsic emission model requires an escape fraction > 0.0"
-            )
-
         # Make an escaped model if we need one
         if escaped is None:
             escaped = EscapedEmission(


### PR DESCRIPTION
This is a petty requirement. If you are using an emission model and want to test the dependence of your results on fesc, for example, then it will just fall over when it hits zero. Removed.

## Issue Type
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
