### PR TITLE
Pipeline instrument arguments

### DIFF
--- a/src/synthesizer/pipeline/pipeline.py
+++ b/src/synthesizer/pipeline/pipeline.py
@@ -36,6 +36,7 @@ from unyt import unyt_array
 
 from synthesizer import check_openmp, exceptions
 from synthesizer.instruments.filters import FilterCollection
+from synthesizer.instruments import Instrument, InstrumentCollection
 from synthesizer.pipeline.pipeline_io import PipelineIO
 from synthesizer.pipeline.pipeline_utils import (
     combine_list_of_dicts,
@@ -147,8 +148,9 @@ class Pipeline:
         Args:
             emission_model (EmissionModel): The emission model to use for the
                 pipeline.
-            instruments (list): A list of Instrument objects to use for the
-                pipeline.
+            instruments (Instrument, InstrumentCollection): Either a singular
+                Instrument object, or an InstrumentCollection containing 
+                multiple Instrument objects.
             nthreads (int): The number of threads to use for shared memory
                 parallelism. Default is 1.
             comm (MPI.Comm): The MPI communicator to use for MPI parallelism.
@@ -162,7 +164,15 @@ class Pipeline:
 
         # Attach all the attributes we need to know what to do
         self.emission_model = emission_model
-        self.instruments = instruments
+
+        # Check if it's a single instrument
+        if isinstance(instruments, Instrument):
+            # mock up an InstrumentCollection
+            collection = InstrumentCollection()
+            collection.add_instruments(self, instruments)
+            self.instruments = collection
+        else:
+            self.instruments = instruments
 
         # Set verbosity
         self.verbose = verbose


### PR DESCRIPTION
Updates inputs to Pipeline to allow accepting a singular instrument. Fixes docstring to make it clear that only an `Instrument` or `InstrumentCollection` are accepted as `instruments`.

## Issue Type
- Bug
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
