### PR TITLE
Modifications to make the pip deployment (hopefully) work

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Publish Python Package
+name: Publish Python 🐍 distribution 📦 to PyPI
 
 on:
   push:
@@ -8,7 +8,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment: pypi-deployment
     # Grant the job permission to request an OIDC token
     permissions:
       contents: read
@@ -16,12 +15,14 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.10"
 
       - name: Install build dependencies
         run: |
@@ -31,8 +32,29 @@ jobs:
       - name: Build source distribution (sdist only)
         run: python -m build --sdist
 
-      # We publish using the "Trusted Publisher" system on PyPi
-      - name: Publish to PyPI via OIDC
-        uses: pypa/gh-action-pypi-publish@v1.6.0
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
         with:
-          user: __token__
+          name: python-package-distributions
+          path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi-deployment
+      url: https://pypi.org/p/cosmos-synthesizer
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,8 +35,9 @@ jobs:
           # is not set up properly and depends on numpy and cython, the former
           # we depend on, the latter we need to install)
           pip install cython
-          WITH_OPENMP=1 pip install .[bluetides,eagle,dense_basis]
+          WITH_OPENMP=1 pip install .[bluetides,eagle]
           pip install "illustris_python @ git+https://github.com/illustristng/illustris_python.git@master"
+          pip install "dense_basis@git+https://github.com/kartheikiyer/dense_basis"
           # Output the compilation report so it can be viewed in an action log
           cat build_synth.log
       - uses: astral-sh/ruff-action@v1 # Lint with Ruff

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -35,7 +35,8 @@ jobs:
           # is not set up properly and depends on numpy and cython, the former
           # we depend on, the latter we need to install)
           pip install cython
-          WITH_OPENMP=1 pip install .[bluetides,eagle,illustris,dense_basis]
+          WITH_OPENMP=1 pip install .[bluetides,eagle,dense_basis]
+          pip install "illustris_python @ git+https://github.com/illustristng/illustris_python.git@master"
           # Output the compilation report so it can be viewed in an action log
           cat build_synth.log
       - uses: astral-sh/ruff-action@v1 # Lint with Ruff

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,7 +34,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install wheel
-          pip install -e .[docs,dense_basis]
+          pip install -e .[docs]
+          pip install "dense_basis@git+https://github.com/kartheikiyer/dense_basis"
           sudo apt install pandoc
       - name: Download test data
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,12 @@ eagle = [
     "schwimmbad",
 ]
 
+# Optional dependency for using dense_basis
+dense_basis = [
+  "dense_basis",
+]
+
+
 # Project urls
 [project.urls]
 "Homepage" = "https://github.com/flaresimulations/synthesizer"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,12 +127,6 @@ eagle = [
     "schwimmbad",
 ]
 
-# Optional dependency for using dense_basis
-dense_basis = [
-  "dense_basis",
-]
-
-
 # Project urls
 [project.urls]
 "Homepage" = "https://github.com/flaresimulations/synthesizer"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,17 +126,6 @@ bluetides = [
 eagle = [
     "schwimmbad",
 ]
-illustris = [
-    "illustris_python @ git+https://github.com/illustristng/illustris_python.git@master",
-]
-
-# Optional dependency for using dense_basis (note that we 
-# currently have to use the main branch since the PyPi version 
-# hasn't been updated with a fix we required)
-dense_basis = [
-  "dense_basis@git+https://github.com/kartheikiyer/dense_basis",
-]
-
 
 # Project urls
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,9 +65,9 @@ classifiers = [  # Optional
   #   4 - Beta
   #   5 - Production/Stable
   "Development Status :: 4 - Beta",  # 3 Alpha/4 Beta/5 Production/Stable
-  "Intended Audience :: Astronomers",
-  "Topic :: Synthetic Observations",
-  "License :: GNU GENERAL PUBLIC LICENSE v3.0",
+  "Intended Audience :: Science/Research",
+  "Topic :: Scientific/Engineering :: Astronomy",
+  "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
 
   # Supported Python versions
   "Programming Language :: Python :: 3.8",

--- a/src/synthesizer/load_data/load_illustris.py
+++ b/src/synthesizer/load_data/load_illustris.py
@@ -35,8 +35,8 @@ try:
 except ImportError:
     raise UnmetDependency(
         "The `illustris_python` module is required to load IllustrisTNG data. "
-        "Install synthesizer with the `illustris` extra dependencies:"
-        " `pip install .[illustris]`."
+        "Install it via `pip install 'illustris_python @ "
+        "git+https://github.com/illustristng/illustris_python.git@master'"
     )
 
 


### PR DESCRIPTION
You can't have optional dependencies that point at git repos on PyPi. 

This means `illustris_python` and `dense_basis` are now signposted to be installed from their repos if needed, instead of being explicit optional dependencies. Not a big problem really but a little less clean.

## Issue Type
<!-- delete options below as required -->
- Bug

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
