### PR TITLE
Fix atomic timing docs typo

### DIFF
--- a/docs/source/advanced/config_options.rst
+++ b/docs/source/advanced/config_options.rst
@@ -6,7 +6,7 @@ Synthesizer uses C extensions for much of the heavy lifting done in the backgrou
 - ``WITH_OPENMP`` controls whether the C extensions will be compiled with OpenMP threading enabled. This can be set to an arbitrary value to compiler with OpenMP or can be the file path to the OpenMP installation directory (specifically the directory containing the ``include`` and ``lib`` directories). This later option is useful for systems where OpenMP is not automatically detected like OSX when ``libomp`` has been installed with homebrew.
 - ``ENABLE_DEBUGGING_CHECKS`` turns on debugging checks within the C extensions. These (expensive) checks are extra consistency checks to ensure the code is behaving as expected. Turning these on will slow down the code significantly.
 - ``RUTHLESS`` turns on almost all compiler warnings and converts them into errors to ensure the C code in synthesizer is clean. Note, that this does not include the ``--pedantic`` flag because Python and Numpy themselves do not adhere to these rules and thus do not compile using ``gcc`` and this flag.
-- ``ATOMIC_TIMINGS`` turns on low level timings for expensive computations. This is required to use time related profiling scripts. 
+- ``ATOMIC_TIMING`` turns on low level timings for expensive computations. This is required to use time related profiling scripts. 
 - ``CFLAGS`` allows the user to override the flags passed to the C compiler. Simply pass your desired flags to this variable.
 - ``LDFLAGS`` allows the user to override the directories used during linking.
 - ``EXTRA_INCLUDES`` allows the user to provide any extra include directories that fail to be automatically picked up.
@@ -17,13 +17,13 @@ To define them globally simply export them into your environment, e.g.
 .. code-block:: bash
 
     export WITH_OPENMP=/path/to/openmp
-    export ATOMIC_TIMINGS=1
+    export ATOMIC_TIMING=1
 
 To define them only while running ``pip install`` simply included them before the call to ``pip``, e.g.
 
 .. code-block:: bash
 
-    WITH_OPENMP=1 ATOMIC_TIMINGS=1 pip install cosmos-synthesizer
+    WITH_OPENMP=1 ATOMIC_TIMING=1 pip install cosmos-synthesizer
 
 These options can be used both when installing from source and from PyPI, e.g.
 


### PR DESCRIPTION
DWISOTT

## Issue Type
- Document

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
