### PR TITLE
Improving scaling of integrated spectra calculation

### DIFF
--- a/src/synthesizer/extensions/integrated_spectra.c
+++ b/src/synthesizer/extensions/integrated_spectra.c
@@ -82,12 +82,15 @@ static double *get_spectra_serial(struct grid *grid_props,
 static double *get_spectra_omp(struct grid *grid_props, double *grid_weights,
                                int nthreads) {
 
-  /* Set up array to hold the SED itself. */
-  double *spectra = calloc(grid_props->nlam, sizeof(double));
-  if (spectra == NULL) {
-    PyErr_SetString(PyExc_ValueError, "Failed to allocate memory for spectra.");
+  double *spectra = NULL;
+  int err =
+      posix_memalign((void **)&spectra, 64, grid_props->nlam * sizeof(double));
+  if (err != 0 || spectra == NULL) {
+    PyErr_SetString(PyExc_ValueError,
+                    "Failed to allocate aligned memory for spectra.");
     return NULL;
   }
+  bzero(spectra, grid_props->nlam * sizeof(double));
 
 #pragma omp parallel num_threads(nthreads)
   {

--- a/src/synthesizer/extensions/integrated_spectra.c
+++ b/src/synthesizer/extensions/integrated_spectra.c
@@ -89,36 +89,28 @@ static double *get_spectra_omp(struct grid *grid_props, double *grid_weights,
     return NULL;
   }
 
-  /* Allocate a continuous chunk of data for each thread to use. */
-  double *out_data = calloc(nthreads * grid_props->nlam, sizeof(double));
-  if (out_data == NULL) {
-    PyErr_SetString(PyExc_ValueError,
-                    "Failed to allocate memory for thread spectra.");
-    return NULL;
-  }
-
-  /* Allocate thread spectra. */
-  double **thread_spectra = malloc(nthreads * sizeof(double *));
-  if (thread_spectra == NULL) {
-    PyErr_SetString(PyExc_ValueError,
-                    "Failed to allocate memory for thread spectra.");
-    return NULL;
-  }
-  for (int t = 0; t < nthreads; t++) {
-    thread_spectra[t] = out_data + t * grid_props->nlam;
-  }
-
 #pragma omp parallel num_threads(nthreads)
   {
     /* Get the thread id. */
     int tid = omp_get_thread_num();
 
-    /* Get a local pointer to this threads spectra. */
-    double *local_spectra = thread_spectra[tid];
+    /* We will give each thread a chunk of the spectra to work on. */
 
-#pragma omp for
+    /* How many wavelength elements should each thread get? */
+    int nlam_per_thread = (grid_props->nlam + nthreads - 1) / nthreads;
+
+    /* Calculate the start and end indices for this thread. */
+    int start = tid * nlam_per_thread;
+    int end = start + nlam_per_thread;
+    if (end >= grid_props->nlam) {
+      end = grid_props->nlam;
+    }
+
     /* Loop over wavelengths. */
-    for (int ilam = 0; ilam < grid_props->nlam; ilam++) {
+    for (int ilam = 0; ilam < end - start; ilam++) {
+
+      /* Temporary value to hold the the spectra for this wavelength. */
+      double this_element = 0.0;
 
       /* Loop over grid cells. */
       for (int grid_ind = 0; grid_ind < grid_props->size; grid_ind++) {
@@ -140,29 +132,13 @@ static double *get_spectra_omp(struct grid *grid_props, double *grid_weights,
 
         /* Add the contribution to this wavelength. */
         /* fesc is already included in the weight */
-        local_spectra[ilam] += grid_props->spectra[spectra_ind + ilam] * weight;
+        this_element +=
+            grid_props->spectra[spectra_ind + start + ilam] * weight;
       }
+
+      spectra[start + ilam] = this_element;
     }
   }
-
-  /* Hierarchical reduction */
-  for (int step = 1; step < nthreads; step *= 2) {
-    for (int tid = 0; tid < nthreads; tid += 2 * step) {
-      if (tid + step < nthreads) {
-#pragma omp parallel for num_threads(nthreads)
-        for (int i = 0; i < grid_props->nlam; i++) {
-          thread_spectra[tid][i] += thread_spectra[tid + step][i];
-        }
-      }
-    }
-  }
-
-  /* Copy the final reduced result to spectra */
-  memcpy(spectra, thread_spectra[0], grid_props->nlam * sizeof(double));
-
-  /* Clean up. */
-  free(out_data);
-  free(thread_spectra);
 
   return spectra;
 }


### PR DESCRIPTION
By swapping the parallelisation to an explicit chunking of the wavelength array we get fewer clashes and therefore scale better even when the number of particles is low. 

Here is a plot showing the improved scaling of the reduction step. This uses 1000 particles.
![direct_reduction_integrated_strong_scaling_cic_NStars1000_TotThreahs12](https://github.com/user-attachments/assets/ea3e609b-0be8-4cee-9927-85b18f90762c)

The green and red are the interesting parts here (the bits I've modified), you can see these are indeed now scaling. 

Very clearly there are other issues now. We are now dominated by "untimed overhead" for these low particle count galaxies (low in the grand scheme, the troubling thing is they are very run of the mill). Clearly some future work to do but do keep in mind this is all relative and the entire runtime is very small for these regardless.

For context here is a 100 times more particles:

![direct_reduction_integrated_strong_scaling_cic_NStars100000_TotThreahs12](https://github.com/user-attachments/assets/9bce7e67-2ae9-44b3-bafb-3918c2da8cac)

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
