### PR TITLE
Removing `lam_mask` effects in argument preparation

### DIFF
--- a/profiling/int_spectra_strong_scaling.py
+++ b/profiling/int_spectra_strong_scaling.py
@@ -239,6 +239,7 @@ def int_spectra_strong_scaling(
             label=key,
             linestyle=linestyles[key],
             linewidth=3 if key == "Total" else 1,
+            zorder=1 if key == "Total" else 3,
         )
 
     ax_main.set_ylabel("Time (s)")
@@ -257,6 +258,7 @@ def int_spectra_strong_scaling(
             label=key,
             linestyle=linestyles[key],
             linewidth=3 if key == "Total" else 1,
+            zorder=1 if key == "Total" else 3,
         )
 
     # PLot a 1-1 line

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -54,6 +54,7 @@ from synthesizer.emission_models.operations import (
     Generation,
     Transformation,
 )
+from synthesizer.extensions.timers import tic, toc
 from synthesizer.line import LineCollection
 from synthesizer.units import Quantity, accepts
 from synthesizer.warnings import deprecation, warn
@@ -2317,7 +2318,9 @@ class EmissionModel(Extraction, Generation, Transformation, Combination):
         # modifications made here so we'll make a copy of it (this is a
         # shallow copy so very cheap and doesn't copy any pointed to objects
         # only their reference)
+        copy_start = tic()
         emission_model = copy.copy(self)
+        toc("Copying emission model", copy_start)
 
         # Before we do anything, check that we have the emitters we need
         for model in emission_model._models.values():
@@ -2330,6 +2333,7 @@ class EmissionModel(Extraction, Generation, Transformation, Combination):
                 )
 
         # Apply any overides we have
+        start_overrides = tic()
         self._apply_overrides(
             emission_model,
             dust_curves,
@@ -2339,6 +2343,7 @@ class EmissionModel(Extraction, Generation, Transformation, Combination):
             mask,
             vel_shift,
         )
+        toc("Applying model overrides", start_overrides)
 
         # Make a spectra dictionary if we haven't got one yet
         if spectra is None:
@@ -2356,6 +2361,7 @@ class EmissionModel(Extraction, Generation, Transformation, Combination):
             )
 
         # Perform all extractions
+        extract_start = tic()
         spectra, particle_spectra = self._extract_spectra(
             emission_model,
             emitters,
@@ -2364,6 +2370,7 @@ class EmissionModel(Extraction, Generation, Transformation, Combination):
             verbose=verbose,
             nthreads=nthreads,
         )
+        toc("Extracting spectra (Operation)", extract_start)
 
         # With all base spectra extracted we can now loop from bottom to top
         # of the tree creating each spectra

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -682,10 +682,13 @@ class Stars(Particles, StarsComponent):
 
         # Get the grid wavelength arrays (and needed for velocity shifts)
         if vel_shift:
-            grid_lam = np.ascontiguousarray(
-                grid._lam[lam_mask],
-                np.float32,
-            )
+            if lam_mask is not None:
+                grid_lam = np.ascontiguousarray(
+                    grid._lam[lam_mask],
+                    np.float32,
+                )
+            else:
+                grid_lam = grid._lam[lam_mask]
         else:
             grid_lam = None
 

--- a/src/synthesizer/sed.py
+++ b/src/synthesizer/sed.py
@@ -143,6 +143,7 @@ class Sed:
             sed (object, Sed)
                 Summed 1D SED.
         """
+        start = tic()
 
         # Check that the lnu array is multidimensional
         if len(self._lnu.shape) > 1:
@@ -162,6 +163,8 @@ class Sed:
                 new_sed.obsnu = self.obsnu
                 new_sed.obslam = self.obslam
                 new_sed.redshift = self.redshift
+
+            toc("Summing Sed", start)
 
             return new_sed
         else:


### PR DESCRIPTION
We had been creating a `lam_mask` if we weren't passed one and then applying this regardless. It turns out this is a huge performance bottleneck. The mask is now only applied if it exists, removing the overhead unless it is actually required. 

In the future, we should move the masks into the C since an explicit skip (i.e. `if (!mask) continue`) will be far more efficient than manipulating masked data to be contiguous and also has the bonus that we can always work on fixed-size arrays.

This also fixes a bug where the user stated grid assignment method could be ignored.

Dependant on #844 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
