### PR TITLE
Improving scaling of the weights calculation

### DIFF
--- a/src/synthesizer/components/component.py
+++ b/src/synthesizer/components/component.py
@@ -254,6 +254,8 @@ class Component(ABC):
         mask=None,
         vel_shift=None,
         verbose=True,
+        nthreads=1,
+        grid_assignment_method="cic",
         **kwargs,
     ):
         """
@@ -299,6 +301,12 @@ class Component(ABC):
                 Flags whether to apply doppler shift to the spectra.
             verbose (bool)
                 Are we talking?
+            nthreads (int)
+                The number of threads to use for the tree search. If -1, all
+                available threads will be used.
+            grid_assignment_method (str)
+                The method to use for assigning particles to the grid. Options
+                are "cic" (cloud-in-cell) or "ngp" (nearest grid point)."
             kwargs (dict)
                 Any additional keyword arguments to pass to the generator
                 function.
@@ -320,6 +328,8 @@ class Component(ABC):
             mask=mask,
             vel_shift=vel_shift,
             verbose=verbose,
+            nthreads=nthreads,
+            grid_assignment_method=grid_assignment_method,
             **kwargs,
         )
 

--- a/src/synthesizer/emission_models/base_model.py
+++ b/src/synthesizer/emission_models/base_model.py
@@ -2220,6 +2220,7 @@ class EmissionModel(Extraction, Generation, Transformation, Combination):
         particle_spectra=None,
         _is_related=False,
         nthreads=1,
+        grid_assignment_method="cic",
         **fixed_parameters,
     ):
         """
@@ -2303,6 +2304,9 @@ class EmissionModel(Extraction, Generation, Transformation, Combination):
                 this will be done outside the recursive call.
             nthreads (int)
                 The number of threads to use when generating the spectra.
+            grid_assignment_method (str)
+                The method to use when assigning particles to the grid. Options
+                are "cic" (cloud in cell) or "ngp" (nearest grid point).
             fixed_parameters (dict)
                 A dictionary of fixed parameters to apply to the model. Each
                 of these will be applied to the model before generating the
@@ -2318,9 +2322,7 @@ class EmissionModel(Extraction, Generation, Transformation, Combination):
         # modifications made here so we'll make a copy of it (this is a
         # shallow copy so very cheap and doesn't copy any pointed to objects
         # only their reference)
-        copy_start = tic()
         emission_model = copy.copy(self)
-        toc("Copying emission model", copy_start)
 
         # Before we do anything, check that we have the emitters we need
         for model in emission_model._models.values():
@@ -2369,6 +2371,7 @@ class EmissionModel(Extraction, Generation, Transformation, Combination):
             particle_spectra,
             verbose=verbose,
             nthreads=nthreads,
+            grid_assignment_method=grid_assignment_method,
         )
         toc("Extracting spectra (Operation)", extract_start)
 

--- a/src/synthesizer/emission_models/operations.py
+++ b/src/synthesizer/emission_models/operations.py
@@ -66,7 +66,8 @@ class Extraction:
         spectra,
         particle_spectra,
         verbose,
-        **kwargs,
+        nthreads,
+        grid_assignment_method,
     ):
         """
         Extract spectra from the grid.
@@ -82,9 +83,12 @@ class Extraction:
                 The dictionary to store the extracted particle spectra in.
             verbose (bool):
                 Are we talking?
-            kwargs (dict):
-                Any additional keyword arguments to pass to the generator
-                function.
+            nthreads (int):
+                The number of threads to use when generating spectra.
+            grid_assignment_method (str):
+                The method to use when assigning particles to the grid.
+                Options are 'cic' (cloud-in-cell) and 'ngp' (nearest
+                grid point).
 
         Returns:
             dict:
@@ -134,7 +138,8 @@ class Extraction:
                     vel_shift=self.vel_shift,
                     lam_mask=this_model._lam_mask,
                     verbose=verbose,
-                    **kwargs,
+                    nthreads=nthreads,
+                    grid_assignment_method=grid_assignment_method,
                 )
                 * erg
                 / s

--- a/src/synthesizer/extensions/weights.h
+++ b/src/synthesizer/extensions/weights.h
@@ -27,17 +27,76 @@ struct callback_data {
   double *grid_continuum;
 };
 
-/* Define a callback function to be used by the weights functions. Of
- * the form:
- * void Func(double weight, void *indices, void *output)
+/**
+ * @brief Compute an ndimensional index from a flat index.
+ *
+ * @param flat_ind: The flattened index to unravel.
+ * @param ndim: The number of dimensions for the unraveled index.
+ * @param dims: The size of each dimension.
+ * @param indices: The output N-dimensional indices.
  */
-typedef void (*WeightFunc)(double, struct callback_data *, void *);
+static inline void get_indices_from_flat(int flat_ind, int ndim,
+                                         const int *dims, int *indices) {
+
+  /* Loop over indices calculating each one. */
+  for (int i = ndim - 1; i > -1; i--) {
+    indices[i] = flat_ind % dims[i];
+    flat_ind /= dims[i];
+  }
+}
+
+/**
+ * @brief Compute a flat grid index based on the grid dimensions.
+ *
+ * @param multi_index: An array of N-dimensional indices.
+ * @param dims: The length of each dimension.
+ * @param ndim: The number of dimensions.
+ */
+static inline int get_flat_index(const int *multi_index, const int *dims,
+                                 const int ndims) {
+  int index = 0, stride = 1;
+  for (int i = ndims - 1; i >= 0; i--) {
+    index += stride * multi_index[i];
+    stride *= dims[i];
+  }
+
+  return index;
+}
+
+/**
+ * @brief Performs a binary search for the index of an array corresponding to
+ * a value.
+ *
+ * @param low: The initial low index (probably beginning of array).
+ * @param high: The initial high index (probably size of array).
+ * @param arr: The array to search in.
+ * @param val: The value to search for.
+ */
+static inline int binary_search(int low, int high, const double *arr,
+                                const double val) {
+
+  /* While we don't have a pair of adjacent indices. */
+  int diff = high - low;
+  while (diff > 1) {
+
+    /* Define the midpoint. */
+    int mid = low + (int)floor(diff / 2);
+
+    /* Where is the midpoint relative to the value? */
+    if (val >= arr[mid]) {
+      low = mid;
+    } else {
+      high = mid;
+    }
+
+    /* Compute the new range. */
+    diff = high - low;
+  }
+
+  return high;
+}
 
 /* Prototypes */
-void get_indices_from_flat(int flat_ind, int ndim, const int *dims,
-                           int *indices);
-int get_flat_index(const int *multi_index, const int *dims, const int ndims);
-int binary_search(int low, int high, const double *arr, const double val);
 void get_part_ind_frac_cic(int *part_indices, double *axis_fracs, int *dims,
                            int ndim, double **grid_props, double **part_props,
                            int p);


### PR DESCRIPTION
This mildly improves the scaling of the weights calculation, although in real terms this only matters for very high particle counts. Below are plots showing the scaling for 1000 particles (where the weights calculation is ~1% the runtime) and 100000 particles where the weights calculation scales well (but highlights other problems for extreme particle counts).

![weights_cic_integrated_strong_scaling_cic_NStars1000_TotThreahs12](https://github.com/user-attachments/assets/75c18b9e-1ad5-4bc0-b23d-fe3ebbfccb44)

![weights_cic_integrated_strong_scaling_cic_NStars1000000_TotThreahs12](https://github.com/user-attachments/assets/4566559f-cfab-4444-971b-d79d02c75031)

Note that 10^6 particles finished in <0.1 second even without threading.

Depends on #845 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
