### PR TITLE
Adding some initial new unit tests

### DIFF
--- a/tests/test_spectra.py
+++ b/tests/test_spectra.py
@@ -45,3 +45,107 @@ def test_integrated_generation_cic(nebular_emission_model, random_part_stars):
     assert np.allclose(
         integrated_spec._lnu, per_particle_spec._lnu
     ), "The integrated and summed per particle spectra are not the same."
+
+
+def test_threaded_generation_ngp_per_particle(
+    nebular_emission_model,
+    random_part_stars,
+):
+    """Test the generation of spectra with and without threading."""
+    nebular_emission_model.set_per_particle(True)
+
+    # Compute the spectra using both the integrated and per particle machinery
+    serial_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        grid_assignment_method="ngp",
+        nthreads=1,
+    )
+    random_part_stars.clear_all_emissions()
+    threaded_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        grid_assignment_method="ngp",
+        nthreads=4,
+    )
+
+    # Ensure that the integrated spectra are different
+    assert np.allclose(
+        serial_spec._lnu, threaded_spec._lnu
+    ), "The serial and threaded spectra are not the same."
+
+
+def test_threaded_generation_ngp_integrated(
+    nebular_emission_model,
+    random_part_stars,
+):
+    """Test the generation of spectra with and without threading."""
+    nebular_emission_model.set_per_particle(False)
+
+    # Compute the spectra using both the integrated and per particle machinery
+    serial_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        grid_assignment_method="ngp",
+        nthreads=1,
+    )
+    random_part_stars.clear_all_emissions()
+    threaded_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        grid_assignment_method="ngp",
+        nthreads=4,
+    )
+
+    # Ensure that the integrated spectra are different
+    assert np.allclose(
+        serial_spec._lnu, threaded_spec._lnu
+    ), "The serial and threaded spectra are not the same."
+
+
+def test_threaded_generation_cic_per_particle(
+    nebular_emission_model,
+    random_part_stars,
+):
+    """Test the generation of spectra with and without threading."""
+    nebular_emission_model.set_per_particle(True)
+
+    # Compute the spectra using both the integrated and per particle machinery
+    serial_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        grid_assignment_method="cic",
+        nthreads=1,
+    )
+    random_part_stars.clear_all_emissions()
+    threaded_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        grid_assignment_method="cic",
+        nthreads=4,
+    )
+
+    # Ensure that the integrated spectra are different
+    assert np.allclose(
+        serial_spec._lnu, threaded_spec._lnu
+    ), "The serial and threaded spectra are not the same."
+
+
+def test_threaded_generation_cic_integrated(
+    nebular_emission_model,
+    random_part_stars,
+):
+    """Test the generation of spectra with and without threading."""
+    nebular_emission_model.set_per_particle(False)
+
+    # Compute the spectra using both the integrated and per particle machinery
+    serial_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        grid_assignment_method="cic",
+        nthreads=1,
+    )
+    random_part_stars.clear_all_emissions()
+    threaded_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        grid_assignment_method="cic",
+        nthreads=4,
+    )
+
+    # Ensure that the integrated spectra are different
+    assert np.allclose(
+        serial_spec._lnu, threaded_spec._lnu
+    ), "The serial and threaded spectra are not the same."

--- a/tests/test_spectra.py
+++ b/tests/test_spectra.py
@@ -1,0 +1,47 @@
+"""Tests for generating spectra."""
+
+import numpy as np
+
+
+def test_integrated_generation_ngp(nebular_emission_model, random_part_stars):
+    """Test the generation of integrated spectra."""
+    # Compute the spectra using both the integrated and per particle machinery
+    nebular_emission_model.set_per_particle(False)
+    integrated_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        grid_assignment_method="ngp",
+    )
+    random_part_stars.clear_all_emissions()
+    nebular_emission_model.set_per_particle(True)
+    per_particle_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        grid_assignment_method="ngp",
+    )
+    per_particle_spec = per_particle_spec.sum()
+
+    # Ensure that the integrated spectra are different
+    assert np.allclose(
+        integrated_spec._lnu, per_particle_spec._lnu
+    ), "The integrated and summed per particle spectra are not the same."
+
+
+def test_integrated_generation_cic(nebular_emission_model, random_part_stars):
+    """Test the generation of integrated spectra."""
+    # Compute the spectra using both the integrated and per particle machinery
+    nebular_emission_model.set_per_particle(False)
+    integrated_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        grid_assignment_method="cic",
+    )
+    random_part_stars.clear_all_emissions()
+    nebular_emission_model.set_per_particle(True)
+    per_particle_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        grid_assignment_method="cic",
+    )
+    per_particle_spec = per_particle_spec.sum()
+
+    # Ensure that the integrated spectra are different
+    assert np.allclose(
+        integrated_spec._lnu, per_particle_spec._lnu
+    ), "The integrated and summed per particle spectra are not the same."

--- a/tests/test_vel_shift.py
+++ b/tests/test_vel_shift.py
@@ -13,14 +13,12 @@ def test_velocity_shift_applys_cic(random_part_stars, nebular_emission_model):
         vel_shift=True,
         grid_assignment_method="cic",
     )
-    with_shift_spec = random_part_stars.spectra["nebular_line"]
     random_part_stars.clear_all_emissions()
     without_shift_spec = random_part_stars.get_spectra(
         nebular_emission_model,
         vel_shift=False,
         grid_assignment_method="cic",
     )
-    without_shift_spec = random_part_stars.spectra["nebular_line"]
     random_part_stars.clear_all_emissions()
 
     # Get and print a seed for reproducibility
@@ -42,14 +40,12 @@ def test_velocity_shift_conservation_cic(
         vel_shift=True,
         grid_assignment_method="cic",
     )
-    with_shift_spec = random_part_stars.spectra["nebular_line"]
     random_part_stars.clear_all_emissions()
     without_shift_spec = random_part_stars.get_spectra(
         nebular_emission_model,
         vel_shift=False,
         grid_assignment_method="cic",
     )
-    without_shift_spec = random_part_stars.spectra["nebular_line"]
     random_part_stars.clear_all_emissions()
 
     # Get and print a seed for reproducibility

--- a/tests/test_vel_shift.py
+++ b/tests/test_vel_shift.py
@@ -5,16 +5,87 @@ import time
 import numpy as np
 
 
-def test_velocity_shift(random_part_stars, nebular_emission_model):
+def test_velocity_shift_applys_cic(random_part_stars, nebular_emission_model):
     """Test the velocity shift of particle spectra."""
     # Compute the spectra with and without velocity shift
     with_shift_spec = random_part_stars.get_spectra(
         nebular_emission_model,
         vel_shift=True,
+        grid_assignment_method="cic",
+    )
+    with_shift_spec = random_part_stars.spectra["nebular_line"]
+    random_part_stars.clear_all_emissions()
+    without_shift_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        vel_shift=False,
+        grid_assignment_method="cic",
+    )
+    without_shift_spec = random_part_stars.spectra["nebular_line"]
+    random_part_stars.clear_all_emissions()
+
+    # Get and print a seed for reproducibility
+    seed = int(time.time())
+    np.random.seed(seed)
+
+    # Ensure that the spectra are different
+    assert not np.allclose(with_shift_spec._lnu, without_shift_spec._lnu)
+
+
+def test_velocity_shift_conservation_cic(
+    random_part_stars,
+    nebular_emission_model,
+):
+    """Test the velocity shift of particle spectra."""
+    # Compute the spectra with and without velocity shift
+    with_shift_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        vel_shift=True,
+        grid_assignment_method="cic",
+    )
+    with_shift_spec = random_part_stars.spectra["nebular_line"]
+    random_part_stars.clear_all_emissions()
+    without_shift_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        vel_shift=False,
+        grid_assignment_method="cic",
+    )
+    without_shift_spec = random_part_stars.spectra["nebular_line"]
+    random_part_stars.clear_all_emissions()
+
+    # Get and print a seed for reproducibility
+    seed = int(time.time())
+    np.random.seed(seed)
+
+    # Ensure that the overall flux is conserved, since we know it won't
+    # be exactly the same at the edges due to the boundaries of the wavelength
+    # array we can instead compare only the central part of the spectra
+    # where the spectra overlap
+    with_shift_sum = np.sum(with_shift_spec._lnu[100:-100])
+    without_shift_sum = np.sum(without_shift_spec._lnu[100:-100])
+    assert np.isclose(
+        with_shift_sum,
+        without_shift_sum,
+        rtol=1e-6,
+    ), (
+        f"The total flux of the spectra is not conserved (seed: {seed}, "
+        "with-without/without: "
+        f"{(with_shift_sum - without_shift_sum)/without_shift_sum}, "
+        f"with: {with_shift_sum}, without: {without_shift_sum})"
+    )
+
+
+def test_velocity_shift_applys_ngp(random_part_stars, nebular_emission_model):
+    """Test the velocity shift of particle spectra."""
+    # Compute the spectra with and without velocity shift
+    with_shift_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        vel_shift=True,
+        grid_assignment_method="ngp",
     )
     without_shift_spec = random_part_stars.get_spectra(
         nebular_emission_model,
         vel_shift=False,
+        grid_assignment_method="ngp",
     )
 
     # Get and print a seed for reproducibility
@@ -24,12 +95,40 @@ def test_velocity_shift(random_part_stars, nebular_emission_model):
     # Ensure that the spectra are different
     assert not np.allclose(with_shift_spec._lnu, without_shift_spec._lnu)
 
+
+def test_velocity_shift_conservation_ngp(
+    random_part_stars, nebular_emission_model
+):
+    """Test the velocity shift of particle spectra."""
+    # Compute the spectra with and without velocity shift
+    with_shift_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        vel_shift=True,
+        grid_assignment_method="ngp",
+    )
+    without_shift_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        vel_shift=False,
+        grid_assignment_method="ngp",
+    )
+
+    # Get and print a seed for reproducibility
+    seed = int(time.time())
+    np.random.seed(seed)
+
     # Ensure that the overall flux is conserved, since we know it won't
     # be exactly the same at the edges due to the boundaries of the wavelength
     # array we can instead compare only the central part of the spectra
     # where the spectra overlap
-    assert np.allclose(
-        np.sum(with_shift_spec._lnu[100:-100]),
-        np.sum(without_shift_spec._lnu[100:-100]),
+    with_shift_sum = np.sum(with_shift_spec._lnu[100:-100])
+    without_shift_sum = np.sum(without_shift_spec._lnu[100:-100])
+    assert np.isclose(
+        with_shift_sum,
+        without_shift_sum,
         rtol=1e-6,
-    ), f"The total flux of the spectra is not conserved (seed: {seed})"
+    ), (
+        f"The total flux of the spectra is not conserved (seed: {seed}, "
+        "with-without/without: "
+        f"{(with_shift_sum - without_shift_sum)/without_shift_sum}, "
+        f"with: {with_shift_sum}, without: {without_shift_sum})"
+    )


### PR DESCRIPTION
This is the first of many new tests to be introduced. Here we introduce:

- Tests ensuring the integrated spectra and summed per particle spectra are the same.
- A check that spectra generated with and without OpenMP threading give the same result.
- A individual test for velocity shift spectra using `ngp` and `cic` generation separately. 

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [ ] I have read the [CONTRIBUTING.md]() -->
- [ ] I have added docstrings to all methods
- [ ] I have added sufficient comments to all lines
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no pep8 errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
