### PR TITLE
 Added centre loading from COPs for loading FLARES galaxies

### DIFF
--- a/src/synthesizer/load_data/load_flares.py
+++ b/src/synthesizer/load_data/load_flares.py
@@ -30,7 +30,7 @@ def load_FLARES(master_file, region, tag, read_abundances=False):
     with h5py.File(master_file, "r") as hf:
         slens = hf[f"{region}/{tag}/Galaxy/S_Length"][:]
         glens = hf[f"{region}/{tag}/Galaxy/G_Length"][:]
-        cop=(hf[f"{region}/{tag}/Galaxy/COP"][:]) #loading COP
+        cop = hf[f"{region}/{tag}/Galaxy/COP"][:] #loading COP
 
         ages = hf[f"{region}/{tag}/Particle/S_Age"][:]  # Gyr
         coods = (

--- a/src/synthesizer/load_data/load_flares.py
+++ b/src/synthesizer/load_data/load_flares.py
@@ -30,7 +30,7 @@ def load_FLARES(master_file, region, tag, read_abundances=False):
     with h5py.File(master_file, "r") as hf:
         slens = hf[f"{region}/{tag}/Galaxy/S_Length"][:]
         glens = hf[f"{region}/{tag}/Galaxy/G_Length"][:]
-        cop=(hf["39/005_z010p000/Galaxy/COP"][:]) #loading COP
+        cop=(hf[f"{region}/{tag}/Galaxy/COP"][:]) #loading COP
 
         ages = hf[f"{region}/{tag}/Particle/S_Age"][:]  # Gyr
         coods = (

--- a/src/synthesizer/load_data/load_flares.py
+++ b/src/synthesizer/load_data/load_flares.py
@@ -78,7 +78,6 @@ def load_FLARES(master_file, region, tag, read_abundances=False):
                 coordinates=coods[b:e, :] * Mpc,
                 current_masses=masses[b:e] * Msun,
                 smoothing_lengths=s_hsml[b:e] * Mpc,
-                
             )
         else:
             galaxies[i].load_stars(

--- a/src/synthesizer/load_data/load_flares.py
+++ b/src/synthesizer/load_data/load_flares.py
@@ -30,6 +30,7 @@ def load_FLARES(master_file, region, tag, read_abundances=False):
     with h5py.File(master_file, "r") as hf:
         slens = hf[f"{region}/{tag}/Galaxy/S_Length"][:]
         glens = hf[f"{region}/{tag}/Galaxy/G_Length"][:]
+        cop=(hf["39/005_z010p000/Galaxy/COP"][:]) #loading COP
 
         ages = hf[f"{region}/{tag}/Particle/S_Age"][:]  # Gyr
         coods = (
@@ -66,7 +67,7 @@ def load_FLARES(master_file, region, tag, read_abundances=False):
     for i, (b, e) in enumerate(zip(begin, end)):
         # Create the individual galaxy objects
         galaxies[i] = Galaxy(redshift=zed)
-
+        galaxies[i].centre = np.array([cop[0][i],cop[1][i],cop[2][i]])* scale_factor * Mpc
         if read_abundances:
             galaxies[i].load_stars(
                 imasses[b:e] * Msun,
@@ -77,6 +78,7 @@ def load_FLARES(master_file, region, tag, read_abundances=False):
                 coordinates=coods[b:e, :] * Mpc,
                 current_masses=masses[b:e] * Msun,
                 smoothing_lengths=s_hsml[b:e] * Mpc,
+                
             )
         else:
             galaxies[i].load_stars(
@@ -86,6 +88,7 @@ def load_FLARES(master_file, region, tag, read_abundances=False):
                 coordinates=coods[b:e, :] * Mpc,
                 current_masses=masses[b:e] * Msun,
                 smoothing_lengths=s_hsml[b:e] * Mpc,
+                centre=
             )
 
     # Get the gas particle begin / end indices

--- a/src/synthesizer/load_data/load_flares.py
+++ b/src/synthesizer/load_data/load_flares.py
@@ -88,7 +88,6 @@ def load_FLARES(master_file, region, tag, read_abundances=False):
                 coordinates=coods[b:e, :] * Mpc,
                 current_masses=masses[b:e] * Msun,
                 smoothing_lengths=s_hsml[b:e] * Mpc,
-                centre=
             )
 
     # Get the gas particle begin / end indices


### PR DESCRIPTION


## Issue Type
<!-- delete options below as required -->
- Issue ---> **Added centre loading from COPs for loading FLARES galaxies**. Imaging does not work without the centres being loaded. 
![image_2025-02-24_183607195](https://github.com/user-attachments/assets/dc3ee861-07de-487e-9cf9-8bc2572bbedc)



## Checklist
- [X] I have read the [CONTRIBUTING.md]() --> yes
- [X] I have added docstrings to all methods --> not required for this change
- [X] I have added sufficient comments to all lines --> yes
- [X] I have made corresponding changes to the documentation --> not required for this change
- [X] My changes generate no pep8 errors --> No errors
- [X] I have added tests that prove my fix is effective or that my feature works --> check added image
- [X] New and existing unit tests pass locally with my changes --> yes
