### PR TITLE
Introduced simple caching of grid weights

### DIFF
--- a/src/synthesizer/base_galaxy.py
+++ b/src/synthesizer/base_galaxy.py
@@ -1389,3 +1389,18 @@ class BaseGalaxy:
 
         # Clear photometry
         self.clear_all_photometry()
+
+    def clear_weights(self):
+        """
+        Clear all cached grid weights.
+
+        This clears all grid weights calculated using different
+        methods from this base galaxy, and resets the
+        `_grid_weights` dictionary.
+        """
+        if self.stars is not None:
+            if hasattr(self.stars, "_grid_weights"):
+                self._grid_weights = {"cic": {}, "ngp": {}}
+        if self.black_holes is not None:
+            if hasattr(self.black_holes, "_grid_weights"):
+                self._grid_weights = {"cic": {}, "ngp": {}}

--- a/src/synthesizer/components/blackhole.py
+++ b/src/synthesizer/components/blackhole.py
@@ -351,7 +351,18 @@ class BlackholesComponent(Component):
         else:
             from ..extensions.integrated_spectra import compute_integrated_sed
 
-            spec = compute_integrated_sed(*args)
+            spec, grid_weights = compute_integrated_sed(*args)
+
+            # If we have no mask then lets store the grid weights in case
+            # we can make use of them later
+            if (
+                mask is None
+                and grid.grid_name
+                not in self._grid_weights[grid_assignment_method.lower()]
+            ):
+                self._grid_weights[grid_assignment_method.lower()][
+                    grid.grid_name
+                ] = grid_weights
 
         # If we had a wavelength mask we need to make sure we return a spectra
         # compatible with the original wavelength array.

--- a/src/synthesizer/components/blackhole.py
+++ b/src/synthesizer/components/blackhole.py
@@ -339,6 +339,7 @@ class BlackholesComponent(Component):
             nthreads=nthreads,
             vel_shift=vel_shift,
             lam_mask=lam_mask,
+            integrated=True,
         )
 
         # Get the integrated spectra in grid units (erg / s / Hz)

--- a/src/synthesizer/components/component.py
+++ b/src/synthesizer/components/component.py
@@ -741,3 +741,14 @@ class Component(ABC):
         self.clear_all_spectra()
         self.clear_all_lines()
         self.clear_all_photometry()
+
+    def clear_weights(self):
+        """
+        Clear all cached grid weights from the component.
+
+        This clears all grid weights calculated using different
+        methods from this component, and resets the `_grid_weights`
+        dictionary.
+        """
+        if hasattr(self, "_grid_weights"):
+            self._grid_weights = {"cic": {}, "ngp": {}}

--- a/src/synthesizer/components/component.py
+++ b/src/synthesizer/components/component.py
@@ -84,6 +84,9 @@ class Component(ABC):
         for key, val in kwargs.items():
             setattr(self, key, val)
 
+        # A container for any grid weights we already computed
+        self._grid_weights = {"cic": {}, "ngp": {}}
+
     @property
     def photo_fluxes(self):
         """

--- a/src/synthesizer/parametric/blackholes.py
+++ b/src/synthesizer/parametric/blackholes.py
@@ -229,6 +229,8 @@ class BlackHole(BlackholesComponent):
             lam_mask (array, bool)
                 A mask to apply to the wavelength array of the grid. This
                 allows for the extraction of specific wavelength ranges.
+            integrated (bool)
+                Whether to return the integrated SED or the SED per particle.
             kwargs (dict)
                 Any other arguments. Mainly unused and here for consistency
                 with particle version of this method which does have extra
@@ -346,6 +348,7 @@ class BlackHole(BlackholesComponent):
             nlam,
             grid_assignment_method,
             nthreads,
+            None,
         )
 
     def _prepare_line_args(

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -723,6 +723,7 @@ class BlackHoles(Particles, BlackholesComponent):
             nthreads=nthreads,
             vel_shift=vel_shift,
             lam_mask=lam_mask,
+            integrated=False,
         )
 
         toc("Preparing C args", start)

--- a/src/synthesizer/particle/blackholes.py
+++ b/src/synthesizer/particle/blackholes.py
@@ -298,6 +298,7 @@ class BlackHoles(Particles, BlackholesComponent):
         lam_mask,
         nthreads,
         vel_shift,
+        integrated,
     ):
         """
         Prepare the arguments for the C extension to compute SEDs.
@@ -322,6 +323,11 @@ class BlackHoles(Particles, BlackholesComponent):
             nthreads (int)
                 The number of threads to use for the computation. If -1 then
                 all available threads are used.
+            vel_shift (bool)
+                Should the spectra be velocity shifted?
+            integrated (bool)
+                Whether to return the integrated spectra or per particle
+                spectra.
 
         Returns:
             tuple
@@ -486,6 +492,23 @@ class BlackHoles(Particles, BlackholesComponent):
                 grid_assignment_method,
                 nthreads,
                 c.to(vel_units).value,
+            )
+        elif integrated:
+            return (
+                grid_spectra,
+                grid_props,
+                props,
+                bol_lum,
+                grid_dims,
+                len(grid_props),
+                npart,
+                nlam,
+                grid_assignment_method,
+                nthreads,
+                self._grid_weights[grid_assignment_method].get(
+                    grid.grid_name,
+                    None,
+                ),
             )
         else:
             return (

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -48,6 +48,11 @@ class Particles:
             The V band optical depth.
         radii (array-like, float)
             The radii of the particles.
+        _grid_weights (dict, array-like, float)
+            Weights for each particle sorted onto a grid. This dictionary takes
+            the form of {<method>: {grid_name: weights}} where weights is an
+            array of the same shape as the grid containg the particles sorted
+            onto the grid.
     """
 
     # Define class level Quantity attributes
@@ -148,6 +153,9 @@ class Particles:
 
         # Attach the name of the particle type
         self.name = name
+
+        # A container for any grid weights we already computed
+        self._grid_weights = {"cic": {}, "ngp": {}}
 
     @property
     def particle_photo_fluxes(self):

--- a/src/synthesizer/particle/particles.py
+++ b/src/synthesizer/particle/particles.py
@@ -154,9 +154,6 @@ class Particles:
         # Attach the name of the particle type
         self.name = name
 
-        # A container for any grid weights we already computed
-        self._grid_weights = {"cic": {}, "ngp": {}}
-
     @property
     def particle_photo_fluxes(self):
         """

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -957,10 +957,6 @@ class Stars(Particles, StarsComponent):
                 and grid.grid_name
                 not in self._grid_weights[grid_assignment_method.lower()]
             ):
-                print(
-                    f"Storing grid weights for {grid.grid_name} "
-                    f"with {grid_assignment_method} method"
-                )
                 self._grid_weights[grid_assignment_method.lower()][
                     grid.grid_name
                 ] = grid_weights

--- a/src/synthesizer/particle/stars.py
+++ b/src/synthesizer/particle/stars.py
@@ -586,6 +586,7 @@ class Stars(Particles, StarsComponent):
         lam_mask,
         nthreads,
         vel_shift,
+        integrated,
     ):
         """
         Prepare the arguments for SED computation with the C functions.
@@ -734,6 +735,23 @@ class Stars(Particles, StarsComponent):
                 grid_assignment_method,
                 nthreads,
                 c.to(vel_units).value,
+            )
+        elif integrated:
+            return (
+                grid_spectra,
+                grid_props,
+                part_props,
+                part_mass,
+                grid_dims,
+                len(grid_props),
+                npart,
+                nlam,
+                grid_assignment_method,
+                nthreads,
+                self._grid_weights[grid_assignment_method].get(
+                    grid.grid_name,
+                    None,
+                ),
             )
         else:
             return (
@@ -884,23 +902,6 @@ class Stars(Particles, StarsComponent):
                     f" have metallicities > {grid.metallicity[-1]}"
                 )
 
-        # Get particle age masks
-        if mask is None:
-            mask = np.ones(self.nparticles, dtype=bool)
-
-        age_mask = self._get_masks(young, old)
-
-        # Ensure and warn that the masking hasn't removed everything
-        if np.sum(mask) == 0:
-            warn("`mask` has filtered out all particles")
-            return np.zeros(len(grid.lam))
-
-        if np.sum(age_mask) == 0:
-            warn("Age mask has filtered out all particles")
-            return np.zeros(len(grid.lam))
-
-        mask = mask & age_mask
-
         if aperture is not None:
             # Get aperture mask
             aperture_mask = self._aperture_mask(aperture_radius=aperture)
@@ -911,17 +912,28 @@ class Stars(Particles, StarsComponent):
 
                 return np.zeros(len(grid.lam))
         else:
-            aperture_mask = np.ones(self.nparticles, dtype=bool)
+            aperture_mask = None
+
+        if mask is not None and aperture_mask is not None:
+            mask = mask & aperture_mask
+        elif aperture_mask is not None:
+            mask = aperture_mask
+
+        # Ensure and warn that the masking hasn't removed everything
+        if mask is not None and np.sum(mask) == 0:
+            warn("`mask` has filtered out all particles")
+            return np.zeros(len(grid.lam))
 
         # Prepare the arguments for the C function.
         args = self._prepare_sed_args(
             grid,
             spectra_type=spectra_name,
-            mask=mask & aperture_mask,
+            mask=mask,
             grid_assignment_method=grid_assignment_method.lower(),
             nthreads=nthreads,
             vel_shift=vel_shift,
             lam_mask=lam_mask,
+            integrated=True,
         )
 
         # Get the integrated spectra in grid units (erg / s / Hz)
@@ -936,7 +948,22 @@ class Stars(Particles, StarsComponent):
                 compute_integrated_sed,
             )
 
-            spec = compute_integrated_sed(*args)
+            spec, grid_weights = compute_integrated_sed(*args)
+
+            # If we have no mask then lets store the grid weights in case
+            # we can make use of them later
+            if (
+                mask is None
+                and grid.grid_name
+                not in self._grid_weights[grid_assignment_method.lower()]
+            ):
+                print(
+                    f"Storing grid weights for {grid.grid_name} "
+                    f"with {grid_assignment_method} method"
+                )
+                self._grid_weights[grid_assignment_method.lower()][
+                    grid.grid_name
+                ] = grid_weights
 
         # If we had a wavelength mask we need to make sure we return a spectra
         # compatible with the original wavelength array.
@@ -1503,6 +1530,7 @@ class Stars(Particles, StarsComponent):
             nthreads=nthreads,
             vel_shift=vel_shift,
             lam_mask=lam_mask,
+            integrated=False,
         )
         toc("Preparing C args", start)
 

--- a/tests/test_spectra.py
+++ b/tests/test_spectra.py
@@ -169,6 +169,7 @@ def test_reusing_weights_ngp(nebular_emission_model, random_part_stars):
     ), "The grid weights are not stored."
 
     # Compute the spectra the second time which will reuse the weights
+    random_part_stars.clear_all_emissions()
     second_spec = random_part_stars.get_spectra(
         nebular_emission_model,
         grid_assignment_method="ngp",
@@ -199,6 +200,7 @@ def test_reusing_weights_cic(nebular_emission_model, random_part_stars):
     ), "The grid weights are not stored."
 
     # Compute the spectra the second time which will reuse the weights
+    random_part_stars.clear_all_emissions()
     second_spec = random_part_stars.get_spectra(
         nebular_emission_model,
         grid_assignment_method="cic",

--- a/tests/test_spectra.py
+++ b/tests/test_spectra.py
@@ -149,3 +149,63 @@ def test_threaded_generation_cic_integrated(
     assert np.allclose(
         serial_spec._lnu, threaded_spec._lnu
     ), "The serial and threaded spectra are not the same."
+
+
+def test_reusing_weights_ngp(nebular_emission_model, random_part_stars):
+    """Test reusing weights to calculate another spectra for the same grid."""
+
+    # Compute the spectra the first time
+    first_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        grid_assignment_method="ngp",
+    )
+
+    # Ensure we have the weights
+    assert hasattr(
+        random_part_stars, "_grid_weights"
+    ), "The grid weights are not stored."
+    assert (
+        "test_grid" in random_part_stars._grid_weights["ngp"]
+    ), "The grid weights are not stored."
+
+    # Compute the spectra the second time which will reuse the weights
+    second_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        grid_assignment_method="ngp",
+    )
+
+    # Ensure that the integrated spectra are different
+    assert np.allclose(
+        first_spec._lnu,
+        second_spec._lnu,
+    ), "The first and second spectra are not the same."
+
+
+def test_reusing_weights_cic(nebular_emission_model, random_part_stars):
+    """Test reusing weights to calculate another spectra for the same grid."""
+
+    # Compute the spectra the first time
+    first_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        grid_assignment_method="cic",
+    )
+
+    # Ensure we have the weights
+    assert hasattr(
+        random_part_stars, "_grid_weights"
+    ), "The grid weights are not stored."
+    assert (
+        "test_grid" in random_part_stars._grid_weights["cic"]
+    ), "The grid weights are not stored."
+
+    # Compute the spectra the second time which will reuse the weights
+    second_spec = random_part_stars.get_spectra(
+        nebular_emission_model,
+        grid_assignment_method="cic",
+    )
+
+    # Ensure that the integrated spectra are different
+    assert np.allclose(
+        first_spec._lnu,
+        second_spec._lnu,
+    ), "The first and second spectra are not the same."


### PR DESCRIPTION
We have previously never held onto the calculated weights grids when extracting spectra for several reasons (memory footprints, complexity with escape fractions and masks etc). However, now we have escape fractions decoupled from extractions this is easier to navigate.

This PR introduces caching of weight grids on a component, however, the weights are only cached and subsequently reused when not in the presence of a mask. This should reduce some overhead in duplicated calculations.

This is the 3rd attempt at this change and is the simplest approach yet (simply returning the grid of weights from the existing integrated spectra and attaching them). It's not clear to me why this works and using a dedicated weights function didn't. Functionally it doesn't matter but the latter would have been cleaner, possibly something to look into in the future should there be any further simplifications to the C extensions.

## Issue Type
<!-- delete options below as required -->
- Enhancement

## Checklist
- [x] I have read the [CONTRIBUTING.md]() -->
- [x] I have added docstrings to all methods
- [x] I have added sufficient comments to all lines
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no pep8 errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
